### PR TITLE
Termux portability: $TMPDIR test fix + AR/openblas Makefile fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 # "fuck torch"
 
 CC = cc
+AR ?= ar
 CFLAGS = -O2 -Wall -Wextra -std=c11 -I.
 
 # Detect platform
@@ -14,8 +15,15 @@ ifeq ($(UNAME), Darwin)
 endif
 
 # ── Linux: OpenBLAS ──
+# Prefer pkg-config when available — handles distros that ship cblas.h in
+# a subdir (Termux: /usr/include/openblas/) and custom $PREFIX layouts.
+# Fallback to bare -lopenblas for minimal environments.
 ifeq ($(UNAME), Linux)
-  BLAS_FLAGS = -DUSE_BLAS -lopenblas
+  ifneq ($(shell command -v pkg-config 2>/dev/null),)
+    BLAS_FLAGS = -DUSE_BLAS $(shell pkg-config --cflags openblas 2>/dev/null) $(shell pkg-config --libs openblas 2>/dev/null || echo -lopenblas)
+  else
+    BLAS_FLAGS = -DUSE_BLAS -lopenblas
+  endif
   BLAS_NAME = OpenBLAS
 endif
 
@@ -52,7 +60,7 @@ lib: libnotorch.a
 libnotorch.a: notorch.c notorch.h gguf.c gguf.h
 	$(CC) $(CFLAGS) $(BLAS_FLAGS) -c notorch.c -o notorch.o
 	$(CC) $(CFLAGS) $(BLAS_FLAGS) -c gguf.c -o gguf.o
-	ar rcs libnotorch.a notorch.o gguf.o
+	$(AR) rcs libnotorch.a notorch.o gguf.o
 	@echo "Built: libnotorch.a (notorch + gguf)"
 
 # ── Install — system-wide baseline at $PREFIX (default /opt/homebrew) ──

--- a/tests/test_notorch.c
+++ b/tests/test_notorch.c
@@ -455,11 +455,18 @@ static void test_save_load(void) {
     for (int i = 0; i < 5; i++) t2->data[i] = (float)(i * 10);
 
     nt_tensor* params[] = {t1, t2};
-    int rc = nt_save("/tmp/notorch_test.bin", params, 2);
+    /* Honor $TMPDIR so the test works on sandboxed environments
+       (Termux/Android, hermetic CI runners) where /tmp is read-only
+       or absent. POSIX-y: TMPDIR > /tmp fallback. */
+    const char* tmpdir = getenv("TMPDIR");
+    if (!tmpdir || !*tmpdir) tmpdir = "/tmp";
+    char tmp_path[512];
+    snprintf(tmp_path, sizeof(tmp_path), "%s/notorch_test.bin", tmpdir);
+    int rc = nt_save(tmp_path, params, 2);
     ASSERT(rc == 0, "save ok");
 
     int n_loaded = 0;
-    nt_tensor** loaded = nt_load("/tmp/notorch_test.bin", &n_loaded);
+    nt_tensor** loaded = nt_load(tmp_path, &n_loaded);
     ASSERT(loaded != NULL, "load ok");
     ASSERT(n_loaded == 2, "loaded count");
     ASSERT(loaded[0]->ndim == 2, "loaded[0] ndim");


### PR DESCRIPTION
## Summary

Two minimal patches that make notorch buildable + testable + trainable end-to-end on Termux/Android out of the box. Verified by training a full 9.5M LLaMA 3 char-level model for 10K steps on a Galaxy phone (8GB RAM, aarch64) — separate PR with the workspace and report in `ariannamethod/ariannamethod`.

## Patches

### 1. `tests/test_notorch.c` — honor `\$TMPDIR` in `test_save_load`
The test hardcoded `/tmp/notorch_test.bin`. Under Termux's sandboxed `/tmp` (and on hermetic CI runners more generally), `nt_save` returns -1 and the test fails despite no actual library bug.

Fix: read `getenv(\"TMPDIR\")` with `/tmp` as fallback. POSIX-y, no behaviour change on Linux/macOS where `TMPDIR` is typically unset and `/tmp` writable.

Verified on Termux: **46/47 → 47/47**.

### 2. `Makefile` — `AR ?= ar` + openblas via pkg-config
Two related portability gaps:

- **`ar`**: Termux GNU binutils ships with a `g` prefix (`gar`, `gnm`, `gobjcopy`) and `ar` itself collides with `arp` from net-tools. `make lib` fails with `ar: No such file or directory`. Solution: `AR ?= ar` so users can override with `make AR=llvm-ar` (or symlink at `\$PREFIX/bin`).
- **openblas headers**: Termux installs `cblas.h` under `/usr/include/openblas/` rather than root, so `#include \"openblas_config.h\"` (chained from cblas.h) doesn't resolve. Same shape on a few other distros that multiplex BLAS implementations. Solution: when pkg-config is available, ask it for `--cflags` + `--libs` of openblas (returns `-I/.../openblas -L.../-lopenblas`); fallback to bare `-lopenblas` for minimal environments.

Verified on Termux: `make lib` → clean `libnotorch.a` (notorch.o + gguf.o).

## What this enables

Together with `pkg install binutils libopenblas` (one-time), the upstream notorch tarball builds, tests, and trains on Termux without a single source-level workaround beyond these two diffs. The workspace + 10K LLaMA-3 training report in `ariannamethod/ariannamethod#device-1/notorch-train` is the headline use case.

## Test plan

- [x] All existing tests still pass on Linux/macOS (no behaviour change unless TMPDIR set / pkg-config invoked)
- [x] Termux: `make`, `make cpu`, `make lib`, `./notorch_test` — all green
- [x] Termux: 10K-step LLaMA-3 char-level run completes without NaN, val 1.15

🤖 Generated with [Claude Code](https://claude.com/claude-code)