### PR TITLE
train_llama3_bpe: setvbuf stdout unbuffered for Termux/pipe runs

### DIFF
--- a/examples/train_llama3_bpe.c
+++ b/examples/train_llama3_bpe.c
@@ -221,6 +221,7 @@ static float eval_loss(Model* m, int* encoded, int n_tokens) {
 static double now_ms(void) { struct timeval tv; gettimeofday(&tv, NULL); return tv.tv_sec*1000.0+tv.tv_usec/1000.0; }
 
 int main(int argc, char** argv) {
+    setvbuf(stdout, NULL, _IONBF, 0);
     int resume = 0, arg_off = 1;
     if (argc > 1 && strcmp(argv[1], "--resume") == 0) { resume = 1; arg_off = 2; }
     int steps = arg_off < argc ? atoi(argv[arg_off]) : 15000;


### PR DESCRIPTION
## Why
On Termux, and on any pipe/file redirect, stdout defaults to block-buffered (4 KB). During a long \`nt_bpe_encode\` (5.4 MB corpus × 1792 merges takes several minutes on phone-1), the startup banner and \`bpe: ...\` info stay invisible until enough bytes accumulate. The operator can't tell *encoding* from *stuck in an infinite loop*.

## Change
One line at \`main()\` entry: \`setvbuf(stdout, NULL, _IONBF, 0);\`

## Effect
- Banner + \`bpe: 1792 merges, vocab 2048\` appear instantly
- \`corpus: X MB → N tokens\` appears the moment encode finishes
- Per-step lines stream live to \`tee\`/log

Zero behavior change on TTY (already line-buffered).

## Validated
Galaxy A56 8 GB, Termux, phone-1 \`arianna-method\`, \`yent_v11_en_final.txt\` 5.4 MB / 57610 lines:
- 60.0 MB weights, 15735168 params
- step 1 train 7.8092 (≈ log(2048) = 7.624)
- step 5 train 7.5842, val 7.4238
- 0 NaN, 0.29 steps/s

## Test plan
- [x] Builds clean on Termux aarch64 (\`make train_llama3_bpe\`)
- [x] Smoke 5-step run prints banner + bpe info + corpus info before training loop
- [x] Per-step lines stream live (no buffering pause)

— Defender (phone-1)