### PR TITLE
infer_llama: use GGUF-embedded BPE tokenizer (fixes garbage on real-vocab GGUF)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,9 +119,9 @@ gemma: examples/infer_gemma.c gguf.c gguf.h notorch.c notorch.h
 	$(CC) $(CFLAGS) $(BLAS_FLAGS) -o infer_gemma examples/infer_gemma.c gguf.c notorch.c -lm $(BLAS_LIBS)
 	@echo "Compiled: infer_gemma (Gemma-3 GGUF, $(BLAS_NAME))"
 
-llama: examples/infer_llama.c gguf.c gguf.h notorch.c notorch.h
-	$(CC) $(CFLAGS) $(BLAS_FLAGS) -o infer_llama examples/infer_llama.c gguf.c notorch.c -lm $(BLAS_LIBS)
-	@echo "Compiled: infer_llama (LLaMA/Qwen GGUF, $(BLAS_NAME))"
+llama: examples/infer_llama.c examples/bpe.c examples/bpe.h gguf.c gguf.h notorch.c notorch.h
+	$(CC) $(CFLAGS) $(BLAS_FLAGS) -o infer_llama examples/infer_llama.c examples/bpe.c gguf.c notorch.c -lm $(BLAS_LIBS)
+	@echo "Compiled: infer_llama (LLaMA/Qwen GGUF + GGUF-BPE tokenizer, $(BLAS_NAME))"
 
 # ── Training ──
 

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,21 @@ Newest entries on top.
 
 ---
 
+## 2026-06-16 — infer_llama: GGUF-embedded BPE tokenizer (CPU path was byte-level)
+
+examples/infer_llama.c tokenized byte-level — each prompt byte fed as a token
+id (infer_llama.c:327) and decoded as raw ASCII — so any real BPE-vocab GGUF
+(SmolLM2, Qwen2.5, Mistral) got scrambled input and emitted token-number
+garbage (`[9234][512]…`). The fix wires the gguf-native BPE that already
+shipped in examples/bpe.c (bpe_load reads tokenizer.ggml.tokens/.merges
+straight from the file; bpe_encode/bpe_decode_token) — the same tokenizer the
+Metal inferer infer_gguf_metal.c already used; the CPU path simply never got
+it. eos comes from tokenizer.ggml.eos_token_id; byte-level is kept as a guarded
+fallback for char/byte-level models (nanollama) where bpe_load returns NULL.
+Makefile `llama` target now links examples/bpe.c. Verified: BPE roundtrip
+BPE_OK on the SmolLM2 vocab; SmolLM2-135M produces coherent English (was
+`[9234][512]` garbage); notorch test suite 73/73 green.
+
 ## 2026-06-13 — Metal: naive matvec is the default; sg goes opt-in (NT_METAL_SG=1)
 
 The authoritative A/B — live oyent-24B decode through doe on M4 Pro, one

--- a/examples/infer_llama.c
+++ b/examples/infer_llama.c
@@ -331,6 +331,11 @@ int main(int argc, char **argv) {
     float temp = argc > 4 ? (float)atof(argv[4]) : 0.8f;
 
     int max_seq = 256;
+    // tokens[] below is sized to max_seq; clamp max_tokens (from argv[3]) so the
+    // encode cap (max_seq - max_tokens - 1) and the byte-loop bound stay inside
+    // the buffer — a negative or oversized max_tokens would otherwise overflow it.
+    if (max_tokens < 1) max_tokens = 1;
+    if (max_tokens > max_seq - 1) max_tokens = max_seq - 1;
     kv_cache* kv = kv_new(model->n_layers, max_seq, model->kv_dim);
     float *logits = (float*)calloc(model->vocab, sizeof(float));
 

--- a/examples/infer_llama.c
+++ b/examples/infer_llama.c
@@ -10,6 +10,7 @@
 
 #include "gguf.h"
 #include "notorch.h"
+#include "examples/bpe.h"
 #include <stdio.h>
 #include <string.h>
 #include <sys/time.h>
@@ -313,6 +314,18 @@ int main(int argc, char **argv) {
     if (!model) { gguf_close(gf); return 1; }
     printf("loaded in %.0f ms\n", now_ms() - t0);
 
+    // GGUF-embedded BPE tokenizer (tokenizer.ggml.tokens/.merges). NULL for
+    // char/byte-level models (e.g. nanollama) → byte-level fallback below.
+    bpe_tokenizer* tok = bpe_load(argv[1]);
+    int eos = -1;
+    if (tok) {
+        const gguf_kv* e = gguf_get_kv(gf, "tokenizer.ggml.eos_token_id");
+        if (e) eos = (int)e->val.u32;
+        printf("tokenizer: GGUF BPE (vocab=%d eos=%d)\n", bpe_n_vocab(tok), eos);
+    } else {
+        printf("tokenizer: byte-level fallback (no GGUF BPE vocab)\n");
+    }
+
     const char* prompt = argc > 2 ? argv[2] : "Hello";
     int max_tokens = argc > 3 ? atoi(argv[3]) : 50;
     float temp = argc > 4 ? (float)atof(argv[4]) : 0.8f;
@@ -321,11 +334,15 @@ int main(int argc, char **argv) {
     kv_cache* kv = kv_new(model->n_layers, max_seq, model->kv_dim);
     float *logits = (float*)calloc(model->vocab, sizeof(float));
 
-    // Simple byte-level tokenization (BOS=1 for llama, BOS=2 for others)
     int tokens[256]; int n_tok = 0;
-    tokens[n_tok++] = 1; // BOS
-    for (int i = 0; prompt[i] && n_tok < max_seq - max_tokens; i++)
-        tokens[n_tok++] = (unsigned char)prompt[i];
+    if (tok) {
+        n_tok = bpe_encode(tok, prompt, tokens, max_seq - max_tokens - 1);
+    } else {
+        // byte-level fallback (BOS=1) for char/byte-level models without a GGUF vocab
+        tokens[n_tok++] = 1; // BOS
+        for (int i = 0; prompt[i] && n_tok < max_seq - max_tokens; i++)
+            tokens[n_tok++] = (unsigned char)prompt[i];
+    }
 
     printf("\nprompt: \"%s\" (%d tokens, temp=%.2f)\n", prompt, n_tok, temp);
 
@@ -339,15 +356,19 @@ int main(int argc, char **argv) {
     fflush(stdout);
 
     // Decode
-    int gen = 0;
+    int gen = 0; char piece[256];
     for (int step = 0; step < max_tokens; step++) {
         int next = sample(logits, model->vocab, temp);
-        if (next <= 2) break; // EOS/BOS/PAD
-
-        // Print: if printable ASCII or newline
-        if (next >= 32 && next < 127) printf("%c", (char)next);
-        else if (next == 10) printf("\n");
-        else printf("[%d]", next);
+        if (tok) {
+            if (next == eos) break;
+            bpe_decode_token(tok, next, piece, sizeof(piece));
+            printf("%s", piece);
+        } else {
+            if (next <= 2) break; // EOS/BOS/PAD (byte-level)
+            if (next >= 32 && next < 127) printf("%c", (char)next);
+            else if (next == 10) printf("\n");
+            else printf("[%d]", next);
+        }
         fflush(stdout);
         gen++;
 
@@ -361,6 +382,7 @@ int main(int argc, char **argv) {
            n_tok, prefill_ms, n_tok * 1000.0 / prefill_ms,
            gen, total_ms - prefill_ms, gen > 0 ? gen * 1000.0 / (total_ms - prefill_ms) : 0);
 
+    if (tok) bpe_free(tok);
     free(logits); kv_free(kv); llama_free(model); gguf_close(gf);
     return 0;
 }


### PR DESCRIPTION
## Корень
`examples/infer_llama.c` токенизировал **byte-level**: каждый байт промпта = id токена (`:327`), декод = сырой ASCII (`:348-350`). На любой реальной BPE-vocab GGUF (SmolLM2/Qwen2.5/Mistral) → абракадабра на входе, `[9234][512]` мусор на выходе. Математика инференса при этом верна — дыра только в слое токенайзера.

## Фикс
notorch УЖЕ имел gguf-native BPE — `examples/bpe.c` (`bpe_load` читает `tokenizer.ggml.tokens`/`.merges` прямо из файла, `bpe_encode`/`bpe_decode_token`), его уже использует `infer_gguf_metal.c`. CPU-путь `infer_llama` просто не был на него подключён. Подключил: `bpe_load` + `eos` из `tokenizer.ggml.eos_token_id`; byte-level оставлен **guarded fallback** для char-level моделей (nanollama), где `bpe_load` возвращает NULL. Makefile `llama`-таргет линкует `examples/bpe.c`. Это проводка готового кода, не переделка.

## Проверка
- BPE roundtrip `BPE_OK` на словаре SmolLM2 ("The capital of France is Paris." → 7 токенов → декод бит-в-бит).
- SmolLM2-135M (temp 0.8) даёт связный английский (было `[9234][512]`).
- `make test` notorch: **73 passed, 0 failed** — регрессии нет.

Малый фикс → запись в NOTORCHLOG. Никаких изменений в несущем notorch.c/gguf.c.