### PR TITLE
notorch: implement nt_rrpram_broadcast_attention (op 34) — closes open TODO

### DIFF
--- a/notorch.c
+++ b/notorch.c
@@ -103,6 +103,17 @@ static void nt_tensor_mark_cpu_dirty(nt_tensor* t) {
 }
 #endif
 
+/* Public sync wrapper for external callers (e.g. nanoarianna LoRA trainer that
+ * needs to read a parameter's CPU data after Chuck step). On non-USE_CUDA build
+ * this is a no-op since CPU is always authoritative. */
+void nt_tensor_sync_cpu(nt_tensor* t) {
+#ifdef USE_CUDA
+    nt_tensor_ensure_cpu(t);
+#else
+    (void)t;
+#endif
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // RNG
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/notorch.c
+++ b/notorch.c
@@ -2929,6 +2929,10 @@ int nt_seq_linear(int w_idx, int x_idx, int T) {
     }
 #endif
     if (!done_gpu) {
+#ifdef USE_CUDA
+        nt_tensor_ensure_cpu(pw->output);
+        nt_tensor_ensure_cpu(px->output);
+#endif
         float* W = pw->output->data;
         float* X = px->output->data;
         float* Y = out->data;

--- a/notorch.c
+++ b/notorch.c
@@ -2988,6 +2988,10 @@ int nt_seq_linear_t(int w_idx, int x_idx, int T) {
     }
 #endif
     if (!done_gpu) {
+#ifdef USE_CUDA
+        nt_tensor_ensure_cpu(pw->output);
+        nt_tensor_ensure_cpu(px->output);
+#endif
         float* W = pw->output->data;
         float* X = px->output->data;
         float* Y = out->data;
@@ -3067,6 +3071,13 @@ int nt_seq_rmsnorm(int x_idx, int gamma_idx, int T, int D) {
     }
 #endif
     if (!done_gpu) {
+#ifdef USE_CUDA
+        nt_tensor_ensure_cpu(px->output);
+        if (gamma_idx >= 0 && gamma_idx < g_tape.count) {
+            nt_tape_entry* pg = &g_tape.entries[gamma_idx];
+            nt_tensor_ensure_cpu(pg->output);
+        }
+#endif
         for (int t = 0; t < T; t++) {
             float* x_t = px->output->data + t * D;
             float* o_t = out->data + t * D;
@@ -3264,6 +3275,11 @@ int nt_mh_causal_attention(int q_idx, int k_idx, int v_idx, int T, int head_dim)
     }
 #endif
 
+#ifdef USE_CUDA
+    nt_tensor_ensure_cpu(pq->output);
+    nt_tensor_ensure_cpu(pk->output);
+    nt_tensor_ensure_cpu(pv->output);
+#endif
     float* scores_buf = (float*)malloc(T * sizeof(float));
     for (int h = 0; h < n_heads; h++) {
         int ho = h * head_dim;
@@ -3905,6 +3921,10 @@ int nt_seq_cross_entropy(int logits_idx, int targets_idx, int T, int V) {
     }
 #endif
     if (!done_gpu) {
+#ifdef USE_CUDA
+        nt_tensor_ensure_cpu(pl->output);
+        nt_tensor_ensure_cpu(pt->output);
+#endif
         float total_loss = 0;
         for (int t = 0; t < T; t++) {
             float* logits_t = pl->output->data + t * V;

--- a/notorch.c
+++ b/notorch.c
@@ -1402,6 +1402,143 @@ void nt_tape_backward(int loss_idx) {
             break;
         }
 
+        case NT_OP_RRPRAM_BCAST: {
+            /* Broadcast RRPRAM backward.
+             * Forward: mid = Σ_t x·Wr_a (broadcast); score = mid·Wr_b (per layer);
+             *          attn[i,:] = softmax_causal(score)[0..i]; out[i] = Σ attn·v.
+             * d_v[j,h,d] += Σ_i attn[i,j] · dout[i,h,d]
+             * d_attn[i,j] = Σ_d dout[i,h,d] · v[j,h,d]
+             * d_score[j] = Σ_i softmax_bwd(attn[i],d_attn[i])[j]   (only j ≤ i)
+             * d_mid[r] = Σ_j d_score[j] · Wr_b[h,r,j]
+             * d_Wr_b[h,r,j] = mid[r] · d_score[j]
+             * d_x[t,e] += Σ_r d_mid[r] · Wr_a[h,e,r]   (broadcast — same dxe added to every t)
+             * d_Wr_a[h,e,r] += Σ_t x[t,e] · d_mid[r]
+             */
+            if (e->parent1 >= 0 && e->parent2 >= 0 && e->parent3 >= 0) {
+                nt_tape_entry* pwr = &g_tape.entries[e->parent1];
+                nt_tape_entry* px  = &g_tape.entries[e->parent2];
+                nt_tape_entry* pv  = &g_tape.entries[e->parent3];
+                int T = (int)e->aux; int n_embd = (int)e->aux2;
+                int nr = (int)e->aux3; int hd = (int)e->aux4;
+                int out_dim = nr * hd;
+                int T_r = T;
+                long combined_len = pwr->output->len;
+                int rank = (int)(combined_len / ((long)nr * (n_embd + T_r)));
+                long wra_total = (long)nr * n_embd * rank;
+
+#ifdef USE_CUDA
+                nt_tensor_ensure_cpu(pwr->output);
+                nt_tensor_ensure_cpu(px->output);
+                nt_tensor_ensure_cpu(pv->output);
+                nt_tensor_ensure_cpu(e->grad);
+#endif
+
+                float* dwr = (float*)calloc(combined_len, sizeof(float));
+                float* dx  = (float*)calloc((long)T * n_embd, sizeof(float));
+                float* dv  = (float*)calloc((long)T * out_dim, sizeof(float));
+
+                float* mid_buf       = (float*)malloc(rank * sizeof(float));
+                float* d_mid_buf     = (float*)malloc(rank * sizeof(float));
+                float* all_scores    = (float*)malloc(T_r  * sizeof(float));
+                float* attn_buf      = (float*)malloc(T_r  * sizeof(float));
+                float* d_attn_buf    = (float*)malloc(T_r  * sizeof(float));
+                float* d_score_global= (float*)calloc(T_r,   sizeof(float));
+
+                float* dout = e->grad ? e->grad->data : NULL;
+
+                if (dwr && dx && dv && mid_buf && d_mid_buf && all_scores &&
+                    attn_buf && d_attn_buf && d_score_global && dout) {
+                    for (int h = 0; h < nr; h++) {
+                        long wr_a_base = (long)h * n_embd * rank;
+                        long wr_b_base = wra_total + (long)h * rank * T_r;
+                        int  v_off     = h * hd;
+
+                        for (int r = 0; r < rank; r++) mid_buf[r] = 0.0f;
+                        for (int t = 0; t < T; t++) {
+                            const float* xt = px->output->data + (long)t * n_embd;
+                            for (int e2 = 0; e2 < n_embd; e2++) {
+                                float xe = xt[e2];
+                                const float* wa_row = pwr->output->data + wr_a_base + (long)e2 * rank;
+                                for (int r = 0; r < rank; r++) mid_buf[r] += xe * wa_row[r];
+                            }
+                        }
+
+                        for (int j = 0; j < T; j++) {
+                            float s = 0.0f;
+                            for (int r = 0; r < rank; r++) {
+                                s += mid_buf[r] * pwr->output->data[wr_b_base + (long)r * T_r + j];
+                            }
+                            all_scores[j] = s;
+                        }
+
+                        for (int j = 0; j < T_r; j++) d_score_global[j] = 0.0f;
+
+                        for (int i = 0; i < T; i++) {
+                            float mx = -1e30f;
+                            for (int j = 0; j <= i; j++) {
+                                attn_buf[j] = all_scores[j];
+                                if (attn_buf[j] > mx) mx = attn_buf[j];
+                            }
+                            float sm = 0.0f;
+                            for (int j = 0; j <= i; j++) { attn_buf[j] = expf(attn_buf[j] - mx); sm += attn_buf[j]; }
+                            if (sm > 0.0f) for (int j = 0; j <= i; j++) attn_buf[j] /= sm;
+
+                            const float* dout_i = dout + (long)i * out_dim + v_off;
+
+                            for (int j = 0; j <= i; j++) d_attn_buf[j] = 0.0f;
+                            for (int j = 0; j <= i; j++) {
+                                const float* vj = pv->output->data + (long)j * out_dim + v_off;
+                                float* dvj      = dv + (long)j * out_dim + v_off;
+                                for (int d = 0; d < hd; d++) {
+                                    d_attn_buf[j] += dout_i[d] * vj[d];
+                                    dvj[d]        += attn_buf[j] * dout_i[d];
+                                }
+                            }
+
+                            float dot_da = 0.0f;
+                            for (int j = 0; j <= i; j++) dot_da += d_attn_buf[j] * attn_buf[j];
+                            for (int j = 0; j <= i; j++) {
+                                d_score_global[j] += attn_buf[j] * (d_attn_buf[j] - dot_da);
+                            }
+                        }
+
+                        for (int r = 0; r < rank; r++) d_mid_buf[r] = 0.0f;
+                        for (int j = 0; j < T; j++) {
+                            float ds = d_score_global[j];
+                            if (ds == 0.0f) continue;
+                            for (int r = 0; r < rank; r++) {
+                                d_mid_buf[r] += ds * pwr->output->data[wr_b_base + (long)r * T_r + j];
+                                dwr[wr_b_base + (long)r * T_r + j] += ds * mid_buf[r];
+                            }
+                        }
+
+                        for (int t = 0; t < T; t++) {
+                            const float* xt = px->output->data + (long)t * n_embd;
+                            float* dxt = dx + (long)t * n_embd;
+                            for (int e2 = 0; e2 < n_embd; e2++) {
+                                const float* wa_row = pwr->output->data + wr_a_base + (long)e2 * rank;
+                                float* dwa_row     = dwr + wr_a_base + (long)e2 * rank;
+                                float dxe = 0.0f;
+                                float xe  = xt[e2];
+                                for (int r = 0; r < rank; r++) {
+                                    dxe         += d_mid_buf[r] * wa_row[r];
+                                    dwa_row[r]  += d_mid_buf[r] * xe;
+                                }
+                                dxt[e2] += dxe;
+                            }
+                        }
+                    }
+                    tape_acc_grad(e->parent1, dwr, combined_len);
+                    tape_acc_grad(e->parent2, dx,  (long)T * n_embd);
+                    tape_acc_grad(e->parent3, dv,  (long)T * out_dim);
+                }
+                free(dwr); free(dx); free(dv);
+                free(mid_buf); free(d_mid_buf); free(all_scores);
+                free(attn_buf); free(d_attn_buf); free(d_score_global);
+            }
+            break;
+        }
+
         case NT_OP_RRPRAM_ATTN: {
             if (e->parent1 >= 0 && e->parent2 >= 0 && e->parent3 >= 0) {
                 nt_tape_entry* pwr = &g_tape.entries[e->parent1];
@@ -3341,6 +3478,98 @@ int nt_rrpram_lowrank_attention(int wr_combined_idx, int x_idx, int v_idx,
     free(u_buf); free(scores_buf);
 
     int idx = nt_tape_record4(out, NT_OP_RRPRAM_LR, wr_combined_idx, x_idx, v_idx,
+                              (float)T, (float)n_embd, (float)nr_heads, (float)head_dim);
+    nt_tensor_free(out);
+    return idx;
+}
+
+/* ════════════════════════════════════════════════════════════════════════
+ * nt_rrpram_broadcast_attention
+ *
+ * Canonical Janus broadcast pattern (per dario/infer_v4.c:218-249).
+ *
+ *   mid[h, r]   = Σ_t Σ_e x[t, e] · Wr_a[h, e, r]                  (one mid per head, layer-broadcast)
+ *   score[h, j] = Σ_r mid[h, r] · Wr_b[h, r, j]                    (one set of scores, broadcast across i)
+ *   attn[h,i,j] = softmax(scores[h])[0..i] for j ≤ i               (causal softmax per i)
+ *   out[i, h_off+d] = Σ_{j≤i} attn[h, i, j] · v[j, h_off+d]
+ * ════════════════════════════════════════════════════════════════════════ */
+int nt_rrpram_broadcast_attention(int wr_combined_idx, int x_idx, int v_idx,
+                                   int T, int n_embd, int nr_heads, int head_dim) {
+    if (wr_combined_idx < 0 || x_idx < 0 || v_idx < 0) return -1;
+    int out_dim = nr_heads * head_dim;
+    nt_tensor* out = nt_tensor_new(T * out_dim);
+    if (!out) return -1;
+    nt_tape_entry* pwr = &g_tape.entries[wr_combined_idx];
+    nt_tape_entry* px  = &g_tape.entries[x_idx];
+    nt_tape_entry* pv  = &g_tape.entries[v_idx];
+
+    int T_r = T;
+    long combined_len = pwr->output->len;
+    int rank = (int)(combined_len / ((long)nr_heads * (n_embd + T_r)));
+    if (rank < 1) { nt_tensor_free(out); return -1; }
+    long wra_total = (long)nr_heads * n_embd * rank;
+
+#ifdef USE_CUDA
+    nt_tensor_ensure_cpu(pwr->output);
+    nt_tensor_ensure_cpu(px->output);
+    nt_tensor_ensure_cpu(pv->output);
+#endif
+
+    float* mid_buf    = (float*)malloc(rank * sizeof(float));
+    float* all_scores = (float*)malloc(T_r  * sizeof(float));
+    float* attn_buf   = (float*)malloc(T_r  * sizeof(float));
+    if (!mid_buf || !all_scores || !attn_buf) {
+        free(mid_buf); free(all_scores); free(attn_buf); nt_tensor_free(out); return -1;
+    }
+
+    for (int h = 0; h < nr_heads; h++) {
+        long wr_a_base = (long)h * n_embd * rank;
+        long wr_b_base = wra_total + (long)h * rank * T_r;
+        int  v_off     = h * head_dim;
+
+        for (int r = 0; r < rank; r++) mid_buf[r] = 0.0f;
+        for (int t = 0; t < T; t++) {
+            const float* xt = px->output->data + (long)t * n_embd;
+            for (int e = 0; e < n_embd; e++) {
+                float xe = xt[e];
+                const float* wa_row = pwr->output->data + wr_a_base + (long)e * rank;
+                for (int r = 0; r < rank; r++) mid_buf[r] += xe * wa_row[r];
+            }
+        }
+
+        for (int j = 0; j < T; j++) {
+            float s = 0.0f;
+            for (int r = 0; r < rank; r++) {
+                s += mid_buf[r] * pwr->output->data[wr_b_base + (long)r * T_r + j];
+            }
+            all_scores[j] = s;
+        }
+
+        for (int i = 0; i < T; i++) {
+            float mx = -1e30f;
+            for (int j = 0; j <= i; j++) {
+                attn_buf[j] = all_scores[j];
+                if (attn_buf[j] > mx) mx = attn_buf[j];
+            }
+            float sm = 0.0f;
+            for (int j = 0; j <= i; j++) {
+                attn_buf[j] = expf(attn_buf[j] - mx);
+                sm += attn_buf[j];
+            }
+            if (sm > 0.0f) for (int j = 0; j <= i; j++) attn_buf[j] /= sm;
+
+            float* oi = out->data + (long)i * out_dim + v_off;
+            for (int d = 0; d < head_dim; d++) oi[d] = 0.0f;
+            for (int j = 0; j <= i; j++) {
+                const float* vj = pv->output->data + (long)j * out_dim + v_off;
+                for (int d = 0; d < head_dim; d++) oi[d] += attn_buf[j] * vj[d];
+            }
+        }
+    }
+
+    free(mid_buf); free(all_scores); free(attn_buf);
+
+    int idx = nt_tape_record4(out, NT_OP_RRPRAM_BCAST, wr_combined_idx, x_idx, v_idx,
                               (float)T, (float)n_embd, (float)nr_heads, (float)head_dim);
     nt_tensor_free(out);
     return idx;

--- a/notorch.c
+++ b/notorch.c
@@ -2988,10 +2988,6 @@ int nt_seq_linear_t(int w_idx, int x_idx, int T) {
     }
 #endif
     if (!done_gpu) {
-#ifdef USE_CUDA
-        nt_tensor_ensure_cpu(pw->output);
-        nt_tensor_ensure_cpu(px->output);
-#endif
         float* W = pw->output->data;
         float* X = px->output->data;
         float* Y = out->data;
@@ -3071,13 +3067,6 @@ int nt_seq_rmsnorm(int x_idx, int gamma_idx, int T, int D) {
     }
 #endif
     if (!done_gpu) {
-#ifdef USE_CUDA
-        nt_tensor_ensure_cpu(px->output);
-        if (gamma_idx >= 0 && gamma_idx < g_tape.count) {
-            nt_tape_entry* pg = &g_tape.entries[gamma_idx];
-            nt_tensor_ensure_cpu(pg->output);
-        }
-#endif
         for (int t = 0; t < T; t++) {
             float* x_t = px->output->data + t * D;
             float* o_t = out->data + t * D;
@@ -3275,11 +3264,6 @@ int nt_mh_causal_attention(int q_idx, int k_idx, int v_idx, int T, int head_dim)
     }
 #endif
 
-#ifdef USE_CUDA
-    nt_tensor_ensure_cpu(pq->output);
-    nt_tensor_ensure_cpu(pk->output);
-    nt_tensor_ensure_cpu(pv->output);
-#endif
     float* scores_buf = (float*)malloc(T * sizeof(float));
     for (int h = 0; h < n_heads; h++) {
         int ho = h * head_dim;
@@ -3921,10 +3905,6 @@ int nt_seq_cross_entropy(int logits_idx, int targets_idx, int T, int V) {
     }
 #endif
     if (!done_gpu) {
-#ifdef USE_CUDA
-        nt_tensor_ensure_cpu(pl->output);
-        nt_tensor_ensure_cpu(pt->output);
-#endif
         float total_loss = 0;
         for (int t = 0; t < T; t++) {
             float* logits_t = pl->output->data + t * V;

--- a/notorch.c
+++ b/notorch.c
@@ -366,6 +366,7 @@ int nt_tape_record4(nt_tensor* output, int op, int p1, int p2, int p3, float aux
     e->aux4 = aux4;
     e->is_param = 0;
     e->no_decay = 0;
+    e->frozen = 0;  /* clear leftover from prior tape session sharing this slot */
     g_tape.count++;
     return idx;
 }
@@ -384,6 +385,7 @@ int nt_tape_param(nt_tensor* param) {
     e->aux = 0;
     e->aux2 = 0;
     e->is_param = 1;
+    e->frozen = 0;  /* clear leftover from prior tape session sharing this slot */
     e->no_decay = 0;
 
     if (g_tape.n_params < NT_TAPE_MAX_PARAMS) {
@@ -1432,11 +1434,12 @@ void nt_tape_backward(int loss_idx) {
                 nt_tape_entry* px  = &g_tape.entries[e->parent2];
                 nt_tape_entry* pv  = &g_tape.entries[e->parent3];
                 int T = (int)e->aux; int n_embd = (int)e->aux2;
-                int nr = (int)e->aux3; int hd = (int)e->aux4;
+                int nr = (int)e->aux3;
+                int rank = (int)e->aux4;  /* aux4 = rank, head_dim = E/H */
+                int hd = n_embd / nr;
                 int out_dim = nr * hd;
-                int T_r = T;
                 long combined_len = pwr->output->len;
-                int rank = (int)(combined_len / ((long)nr * (n_embd + T_r)));
+                int ctx_T = (int)(combined_len / ((long)nr * rank) - n_embd);
                 long wra_total = (long)nr * n_embd * rank;
                 float sc = 1.0f / sqrtf((float)hd);
 
@@ -1453,10 +1456,10 @@ void nt_tape_backward(int loss_idx) {
 
                 float* mid_buf       = (float*)malloc(rank * sizeof(float));
                 float* d_mid_buf     = (float*)malloc(rank * sizeof(float));
-                float* all_scores    = (float*)malloc(T_r  * sizeof(float));
-                float* attn_buf      = (float*)malloc(T_r  * sizeof(float));
-                float* d_attn_buf    = (float*)malloc(T_r  * sizeof(float));
-                float* d_score_global= (float*)calloc(T_r,   sizeof(float));
+                float* all_scores    = (float*)malloc(T  * sizeof(float));
+                float* attn_buf      = (float*)malloc(T  * sizeof(float));
+                float* d_attn_buf    = (float*)malloc(T  * sizeof(float));
+                float* d_score_global= (float*)calloc(T,   sizeof(float));
 
                 float* dout = e->grad ? e->grad->data : NULL;
 
@@ -1464,7 +1467,7 @@ void nt_tape_backward(int loss_idx) {
                     attn_buf && d_attn_buf && d_score_global && dout) {
                     for (int h = 0; h < nr; h++) {
                         long wr_a_base = (long)h * n_embd * rank;
-                        long wr_b_base = wra_total + (long)h * rank * T_r;
+                        long wr_b_base = wra_total + (long)h * rank * ctx_T;
                         int  v_off     = h * hd;
 
                         for (int r = 0; r < rank; r++) mid_buf[r] = 0.0f;
@@ -1480,12 +1483,12 @@ void nt_tape_backward(int loss_idx) {
                         for (int j = 0; j < T; j++) {
                             float s = 0.0f;
                             for (int r = 0; r < rank; r++) {
-                                s += mid_buf[r] * pwr->output->data[wr_b_base + (long)r * T_r + j];
+                                s += mid_buf[r] * pwr->output->data[wr_b_base + (long)r * ctx_T + j];
                             }
                             all_scores[j] = s * sc;
                         }
 
-                        for (int j = 0; j < T_r; j++) d_score_global[j] = 0.0f;
+                        for (int j = 0; j < T; j++) d_score_global[j] = 0.0f;
 
                         for (int i = 0; i < T; i++) {
                             float mx = -1e30f;
@@ -1522,8 +1525,8 @@ void nt_tape_backward(int loss_idx) {
                             float ds = d_score_global[j] * sc;
                             if (ds == 0.0f) continue;
                             for (int r = 0; r < rank; r++) {
-                                d_mid_buf[r] += ds * pwr->output->data[wr_b_base + (long)r * T_r + j];
-                                dwr[wr_b_base + (long)r * T_r + j] += ds * mid_buf[r];
+                                d_mid_buf[r] += ds * pwr->output->data[wr_b_base + (long)r * ctx_T + j];
+                                dwr[wr_b_base + (long)r * ctx_T + j] += ds * mid_buf[r];
                             }
                         }
 
@@ -3509,8 +3512,10 @@ int nt_rrpram_lowrank_attention(int wr_combined_idx, int x_idx, int v_idx,
  *   out[i, h_off+d] = Σ_{j≤i} attn[h, i, j] · v[j, h_off+d]
  * ════════════════════════════════════════════════════════════════════════ */
 int nt_rrpram_broadcast_attention(int wr_combined_idx, int x_idx, int v_idx,
-                                   int T, int n_embd, int nr_heads, int head_dim) {
+                                   int T, int n_embd, int nr_heads, int head_dim, int rank) {
     if (wr_combined_idx < 0 || x_idx < 0 || v_idx < 0) return -1;
+    if (rank < 1 || nr_heads < 1 || head_dim < 1 || n_embd < 1) return -1;
+    if (nr_heads * head_dim != n_embd) return -1;  /* invariant: H*D=E */
     int out_dim = nr_heads * head_dim;
     nt_tensor* out = nt_tensor_new(T * out_dim);
     if (!out) return -1;
@@ -3518,10 +3523,16 @@ int nt_rrpram_broadcast_attention(int wr_combined_idx, int x_idx, int v_idx,
     nt_tape_entry* px  = &g_tape.entries[x_idx];
     nt_tape_entry* pv  = &g_tape.entries[v_idx];
 
-    int T_r = T;
+    /* Packed weight shape: H*E*R + H*R*ctx_T = H*R*(E+ctx_T).
+     * Derive ctx_T from combined_len / (H*R) - E (rank passed by caller). */
     long combined_len = pwr->output->len;
-    int rank = (int)(combined_len / ((long)nr_heads * (n_embd + T_r)));
-    if (rank < 1) { nt_tensor_free(out); return -1; }
+    long expected_per_head = (long)rank * (n_embd + 0);
+    int ctx_T = (int)(combined_len / ((long)nr_heads * rank) - n_embd);
+    if (ctx_T < T) { nt_tensor_free(out); return -1; }  /* runtime T must fit ctx */
+    if ((long)nr_heads * rank * ((long)n_embd + ctx_T) != combined_len) {
+        nt_tensor_free(out); return -1;  /* shape mismatch */
+    }
+    (void)expected_per_head;
     long wra_total = (long)nr_heads * n_embd * rank;
     /* Canonical Janus attention scale: 1/sqrt(D) per dario/infer_v4.c:239-244 */
     float sc = 1.0f / sqrtf((float)head_dim);
@@ -3533,15 +3544,15 @@ int nt_rrpram_broadcast_attention(int wr_combined_idx, int x_idx, int v_idx,
 #endif
 
     float* mid_buf    = (float*)malloc(rank * sizeof(float));
-    float* all_scores = (float*)malloc(T_r  * sizeof(float));
-    float* attn_buf   = (float*)malloc(T_r  * sizeof(float));
+    float* all_scores = (float*)malloc(T  * sizeof(float));
+    float* attn_buf   = (float*)malloc(T  * sizeof(float));
     if (!mid_buf || !all_scores || !attn_buf) {
         free(mid_buf); free(all_scores); free(attn_buf); nt_tensor_free(out); return -1;
     }
 
     for (int h = 0; h < nr_heads; h++) {
         long wr_a_base = (long)h * n_embd * rank;
-        long wr_b_base = wra_total + (long)h * rank * T_r;
+        long wr_b_base = wra_total + (long)h * rank * ctx_T;
         int  v_off     = h * head_dim;
 
         for (int r = 0; r < rank; r++) mid_buf[r] = 0.0f;
@@ -3557,7 +3568,7 @@ int nt_rrpram_broadcast_attention(int wr_combined_idx, int x_idx, int v_idx,
         for (int j = 0; j < T; j++) {
             float s = 0.0f;
             for (int r = 0; r < rank; r++) {
-                s += mid_buf[r] * pwr->output->data[wr_b_base + (long)r * T_r + j];
+                s += mid_buf[r] * pwr->output->data[wr_b_base + (long)r * ctx_T + j];
             }
             all_scores[j] = s * sc;
         }
@@ -3586,8 +3597,10 @@ int nt_rrpram_broadcast_attention(int wr_combined_idx, int x_idx, int v_idx,
 
     free(mid_buf); free(all_scores); free(attn_buf);
 
+    /* aux4 stores RANK (not head_dim) — head_dim derivable at backward as E/H.
+     * ctx_T is derivable from combined_len / (H*rank) - n_embd. */
     int idx = nt_tape_record4(out, NT_OP_RRPRAM_BCAST, wr_combined_idx, x_idx, v_idx,
-                              (float)T, (float)n_embd, (float)nr_heads, (float)head_dim);
+                              (float)T, (float)n_embd, (float)nr_heads, (float)rank);
     nt_tensor_free(out);
     return idx;
 }

--- a/notorch.c
+++ b/notorch.c
@@ -2929,10 +2929,6 @@ int nt_seq_linear(int w_idx, int x_idx, int T) {
     }
 #endif
     if (!done_gpu) {
-#ifdef USE_CUDA
-        nt_tensor_ensure_cpu(pw->output);
-        nt_tensor_ensure_cpu(px->output);
-#endif
         float* W = pw->output->data;
         float* X = px->output->data;
         float* Y = out->data;

--- a/notorch.c
+++ b/notorch.c
@@ -282,6 +282,9 @@ void nt_tape_clear(void) {
             nt_tensor_free(g_tape.entries[i].grad);
             g_tape.entries[i].grad = NULL;
         }
+        /* Reset frozen flag — defense-in-depth so reused slots can't leak
+         * frozen=1 from prior session into ops that don't init it explicitly. */
+        g_tape.entries[i].frozen = 0;
     }
     g_tape.count = 0;
     g_tape.active = 0;
@@ -326,6 +329,7 @@ int nt_tape_record(nt_tensor* output, int op, int p1, int p2, float aux) {
     e->aux2 = 0;
     e->is_param = 0;
     e->no_decay = 0;
+    e->frozen = 0;  /* clear leftover from prior tape session sharing this slot */
     g_tape.count++;
     return idx;
 }
@@ -345,6 +349,7 @@ int nt_tape_record3(nt_tensor* output, int op, int p1, int p2, int p3, float aux
     e->aux2 = aux2;
     e->is_param = 0;
     e->no_decay = 0;
+    e->frozen = 0;  /* clear leftover from prior tape session sharing this slot */
     g_tape.count++;
     return idx;
 }

--- a/notorch.c
+++ b/notorch.c
@@ -2415,12 +2415,26 @@ void nt_tape_chuck_step(float lr, float loss_val) {
 
     // ── Level 2: Per-param gradient norm + Adam update ──
     int param_idx = 0;
+    int g_dbg = getenv("NT_CHUCK_DBG") ? atoi(getenv("NT_CHUCK_DBG")) : 0;
+    int dbg_count = 0;
     for (int i = 0; i < g_tape.count && param_idx < g_tape.n_params; i++) {
         nt_tape_entry* e = &g_tape.entries[i];
-        if (!e->is_param || !e->grad) continue;
+        if (!e->is_param) {
+            if (g_dbg && dbg_count < 5) { fprintf(stderr, "  [chuck-skip] tape_i=%d not_param\n", i); dbg_count++; }
+            continue;
+        }
+        if (!e->grad) {
+            if (g_dbg && dbg_count < 5 && param_idx >= 320 && param_idx <= 330) { fprintf(stderr, "  [chuck-skip] tape_i=%d param_i=%d no_grad\n", i, param_idx); dbg_count++; }
+            param_idx++;
+            continue;
+        }
         nt_adam_state* as = &g_tape.adam[param_idx];
         nt_chuck_param_state* cp = &g_tape.chuck_params[param_idx];
         if (cp->dampen == 0.0f) cp->dampen = 1.0f;
+        if (g_dbg && param_idx >= 325 && param_idx <= 330) {
+            fprintf(stderr, "  [chuck-DBG] tape_i=%d param_i=%d frozen=%d m=%p v=%p len_out=%d len_m=%d\n",
+                    i, param_idx, cp->frozen, (void*)as->m, (void*)as->v, e->output->len, as->m ? as->m->len : -1);
+        }
         if (cp->frozen) { param_idx++; continue; }
         if (!as->m || !as->v) { param_idx++; continue; }
 

--- a/notorch.c
+++ b/notorch.c
@@ -2415,26 +2415,12 @@ void nt_tape_chuck_step(float lr, float loss_val) {
 
     // ── Level 2: Per-param gradient norm + Adam update ──
     int param_idx = 0;
-    int g_dbg = getenv("NT_CHUCK_DBG") ? atoi(getenv("NT_CHUCK_DBG")) : 0;
-    int dbg_count = 0;
     for (int i = 0; i < g_tape.count && param_idx < g_tape.n_params; i++) {
         nt_tape_entry* e = &g_tape.entries[i];
-        if (!e->is_param) {
-            if (g_dbg && dbg_count < 5) { fprintf(stderr, "  [chuck-skip] tape_i=%d not_param\n", i); dbg_count++; }
-            continue;
-        }
-        if (!e->grad) {
-            if (g_dbg && dbg_count < 5 && param_idx >= 320 && param_idx <= 330) { fprintf(stderr, "  [chuck-skip] tape_i=%d param_i=%d no_grad\n", i, param_idx); dbg_count++; }
-            param_idx++;
-            continue;
-        }
+        if (!e->is_param || !e->grad) continue;
         nt_adam_state* as = &g_tape.adam[param_idx];
         nt_chuck_param_state* cp = &g_tape.chuck_params[param_idx];
         if (cp->dampen == 0.0f) cp->dampen = 1.0f;
-        if (g_dbg && param_idx >= 325 && param_idx <= 330) {
-            fprintf(stderr, "  [chuck-DBG] tape_i=%d param_i=%d frozen=%d m=%p v=%p len_out=%d len_m=%d\n",
-                    i, param_idx, cp->frozen, (void*)as->m, (void*)as->v, e->output->len, as->m ? as->m->len : -1);
-        }
         if (cp->frozen) { param_idx++; continue; }
         if (!as->m || !as->v) { param_idx++; continue; }
 

--- a/notorch.c
+++ b/notorch.c
@@ -1403,14 +1403,16 @@ void nt_tape_backward(int loss_idx) {
         }
 
         case NT_OP_RRPRAM_BCAST: {
-            /* Broadcast RRPRAM backward.
-             * Forward: mid = Σ_t x·Wr_a (broadcast); score = mid·Wr_b (per layer);
+            /* Broadcast RRPRAM backward (canonical Janus scale included).
+             * Forward: mid = Σ_t x·Wr_a (broadcast); raw_s = mid·Wr_b (per layer);
+             *          score = raw_s * sc, sc = 1/sqrt(D);
              *          attn[i,:] = softmax_causal(score)[0..i]; out[i] = Σ attn·v.
              * d_v[j,h,d] += Σ_i attn[i,j] · dout[i,h,d]
              * d_attn[i,j] = Σ_d dout[i,h,d] · v[j,h,d]
              * d_score[j] = Σ_i softmax_bwd(attn[i],d_attn[i])[j]   (only j ≤ i)
-             * d_mid[r] = Σ_j d_score[j] · Wr_b[h,r,j]
-             * d_Wr_b[h,r,j] = mid[r] · d_score[j]
+             * d_raw_s[j] = d_score[j] * sc                          (chain rule through scale)
+             * d_mid[r] = Σ_j d_raw_s[j] · Wr_b[h,r,j]
+             * d_Wr_b[h,r,j] = mid[r] · d_raw_s[j]
              * d_x[t,e] += Σ_r d_mid[r] · Wr_a[h,e,r]   (broadcast — same dxe added to every t)
              * d_Wr_a[h,e,r] += Σ_t x[t,e] · d_mid[r]
              */
@@ -1425,6 +1427,7 @@ void nt_tape_backward(int loss_idx) {
                 long combined_len = pwr->output->len;
                 int rank = (int)(combined_len / ((long)nr * (n_embd + T_r)));
                 long wra_total = (long)nr * n_embd * rank;
+                float sc = 1.0f / sqrtf((float)hd);
 
 #ifdef USE_CUDA
                 nt_tensor_ensure_cpu(pwr->output);
@@ -1468,7 +1471,7 @@ void nt_tape_backward(int loss_idx) {
                             for (int r = 0; r < rank; r++) {
                                 s += mid_buf[r] * pwr->output->data[wr_b_base + (long)r * T_r + j];
                             }
-                            all_scores[j] = s;
+                            all_scores[j] = s * sc;
                         }
 
                         for (int j = 0; j < T_r; j++) d_score_global[j] = 0.0f;
@@ -1504,7 +1507,8 @@ void nt_tape_backward(int loss_idx) {
 
                         for (int r = 0; r < rank; r++) d_mid_buf[r] = 0.0f;
                         for (int j = 0; j < T; j++) {
-                            float ds = d_score_global[j];
+                            /* Chain rule through forward scale: d_raw_s[j] = d_score[j] * sc. */
+                            float ds = d_score_global[j] * sc;
                             if (ds == 0.0f) continue;
                             for (int r = 0; r < rank; r++) {
                                 d_mid_buf[r] += ds * pwr->output->data[wr_b_base + (long)r * T_r + j];
@@ -3508,6 +3512,8 @@ int nt_rrpram_broadcast_attention(int wr_combined_idx, int x_idx, int v_idx,
     int rank = (int)(combined_len / ((long)nr_heads * (n_embd + T_r)));
     if (rank < 1) { nt_tensor_free(out); return -1; }
     long wra_total = (long)nr_heads * n_embd * rank;
+    /* Canonical Janus attention scale: 1/sqrt(D) per dario/infer_v4.c:239-244 */
+    float sc = 1.0f / sqrtf((float)head_dim);
 
 #ifdef USE_CUDA
     nt_tensor_ensure_cpu(pwr->output);
@@ -3542,7 +3548,7 @@ int nt_rrpram_broadcast_attention(int wr_combined_idx, int x_idx, int v_idx,
             for (int r = 0; r < rank; r++) {
                 s += mid_buf[r] * pwr->output->data[wr_b_base + (long)r * T_r + j];
             }
-            all_scores[j] = s;
+            all_scores[j] = s * sc;
         }
 
         for (int i = 0; i < T; i++) {

--- a/notorch.h
+++ b/notorch.h
@@ -114,6 +114,7 @@ void nt_tensor_print(const nt_tensor* t, const char* name);
 #define NT_OP_BIT_SEQ_LINEAR 31  // Y[t] = bitquant(W) @ X[t] for T positions (BitNet seq)
 #define NT_OP_SEQ_CROSSENT_MASKED 32  // masked sequence cross-entropy (parent3 = mask)
 #define NT_OP_RRPRAM_LR     33   // low-rank RRPRAM (Wr = Wr_a × Wr_b packed in one tensor)
+#define NT_OP_RRPRAM_BCAST  34   // broadcast RRPRAM — mid[h,r] = Σ_t x[t]·Wr_a[h] (canonical Janus pattern)
 
 typedef struct {
     nt_tensor* output;          // forward result
@@ -412,6 +413,23 @@ int nt_rrpram_attention(int wr_idx, int x_idx, int v_idx, int T, int n_embd, int
 // H·R·(E+T_r) — a 5× reduction at this configuration.
 int nt_rrpram_lowrank_attention(int wr_combined_idx, int x_idx, int v_idx,
                                  int T, int n_embd, int nr_heads, int head_dim);
+
+// Broadcast RRPRAM low-rank attention — canonical Janus pattern (per dario/infer_v4.c:218-249).
+// Differs from nt_rrpram_lowrank_attention in that mid[h, r] is computed ONCE per head per
+// layer by summing over ALL positions, not recomputed per-position. This matches the
+// PyTorch / canonical-Janus semantics where the low-rank intermediate is layer-broadcast,
+// not position-local.
+//
+//   mid[h, r]    = Σ_t Σ_e x[t, e] · Wr_a[h, e, r]                  (one mid per head, broadcast)
+//   score[h, j]  = Σ_r mid[h, r] · Wr_b[h, r, j]                    (same scores for all i, only causal mask varies)
+//   attn[h,i,j]  = softmax_causal(scores[h])[i, j]                  (per i, j ≤ i)
+//   out[i, h_off+d] = Σ_{j≤i} attn[h, i, j] · v[j, h_off+d]
+//
+// Use this when training/inferring against weights produced by canonical Janus models —
+// nt_rrpram_lowrank_attention's per-position pattern is a function-class-different op
+// and DoE LoRA training against it plateaus near uniform-distribution loss.
+int nt_rrpram_broadcast_attention(int wr_combined_idx, int x_idx, int v_idx,
+                                   int T, int n_embd, int nr_heads, int head_dim);
 
 // Concatenate per-position: out[t] = [a[t], b[t]]. a: [T, D_a], b: [T, D_b] → out: [T, D_a+D_b]
 int nt_concat(int a_idx, int b_idx, int T);

--- a/notorch.h
+++ b/notorch.h
@@ -427,8 +427,11 @@ int nt_rrpram_lowrank_attention(int wr_combined_idx, int x_idx, int v_idx,
 // Use this when training/inferring against weights produced by canonical Janus models —
 // nt_rrpram_lowrank_attention's per-position pattern is a function-class-different op
 // and DoE LoRA training against it plateaus near uniform-distribution loss.
+// rank is REQUIRED — packed weight is H*R*(E + ctx_T), and ctx_T is derived from
+// combined_len / (H*rank) - n_embd. Caller passes the model's rank from JANU header.
+// head_dim must satisfy nr_heads*head_dim == n_embd (Janus invariant).
 int nt_rrpram_broadcast_attention(int wr_combined_idx, int x_idx, int v_idx,
-                                   int T, int n_embd, int nr_heads, int head_dim);
+                                   int T, int n_embd, int nr_heads, int head_dim, int rank);
 
 // Concatenate per-position: out[t] = [a[t], b[t]]. a: [T, D_a], b: [T, D_b] → out: [T, D_a+D_b]
 int nt_concat(int a_idx, int b_idx, int T);

--- a/notorch.h
+++ b/notorch.h
@@ -69,6 +69,10 @@ void nt_tensor_xavier(nt_tensor* t, int fan_in, int fan_out);
 // Reshape in-place (total elements must match). Returns 0 on success.
 int nt_tensor_reshape(nt_tensor* t, const int* new_shape, int new_ndim);
 
+// Sync GPU mirror to CPU. No-op on non-USE_CUDA builds. Use before reading
+// param->data after a Chuck/Adam step on GPU (e.g. saving LoRA adapter).
+void nt_tensor_sync_cpu(nt_tensor* t);
+
 // Print tensor info (shape, first/last few values)
 void nt_tensor_print(const nt_tensor* t, const char* name);
 

--- a/tests/test_rrpram_broadcast.c
+++ b/tests/test_rrpram_broadcast.c
@@ -1,0 +1,220 @@
+/*
+ * test_rrpram_broadcast.c — synthetic gradient check for nt_rrpram_broadcast_attention.
+ *
+ * Tiny dims (T=4, E=8, R=2, H=2, hd=4) keep ε-sweep cheap.
+ * For every element of Wr_combined / x / v we compute analytic gradient
+ * (one backward pass with grad-of-loss = ones into out) and finite-difference
+ * gradient ((L(x+ε) - L(x-ε)) / 2ε), where L = Σ out. They must match
+ * within 1e-3 absolute error, else the broadcast op is wrong.
+ *
+ * Build (CPU only):
+ *   cc -O2 -I. tests/test_rrpram_broadcast.c notorch.c -o /tmp/test_rrpram_bcast -lm
+ *
+ * Run:
+ *   /tmp/test_rrpram_bcast
+ *   exits 0 if all gates pass, 1 otherwise.
+ */
+
+#include "notorch.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#define T_LEN   4
+#define E_LEN   8
+#define R_LEN   2
+#define H_LEN   2
+#define HD_LEN  4
+#define OUT_DIM (H_LEN * HD_LEN)
+
+#define EPS_FD     1e-3f
+#define TOL_ABS    1e-3f
+#define TOL_REL    5e-3f
+
+static float frand_unit(void) {
+    return ((float)rand() / (float)RAND_MAX) * 2.0f - 1.0f;
+}
+
+static float forward_only(const float* wr_data, long wr_len,
+                          const float* x_data,  int t_len, int e_len,
+                          const float* v_data,  int out_dim) {
+    nt_tape_start();
+
+    nt_tensor* tw = nt_tensor_new(wr_len);
+    memcpy(tw->data, wr_data, (size_t)wr_len * sizeof(float));
+    int wr_idx = nt_tape_param(tw);
+    nt_tape_freeze_param(wr_idx);
+
+    nt_tensor* tx = nt_tensor_new(t_len * e_len);
+    memcpy(tx->data, x_data, (size_t)t_len * e_len * sizeof(float));
+    int x_idx = nt_tape_param(tx);
+    nt_tape_freeze_param(x_idx);
+
+    nt_tensor* tv = nt_tensor_new(t_len * out_dim);
+    memcpy(tv->data, v_data, (size_t)t_len * out_dim * sizeof(float));
+    int v_idx = nt_tape_param(tv);
+    nt_tape_freeze_param(v_idx);
+
+    int out_idx = nt_rrpram_broadcast_attention(wr_idx, x_idx, v_idx,
+                                                 t_len, e_len, H_LEN, HD_LEN);
+    if (out_idx < 0) { nt_tape_clear(); return NAN; }
+
+    nt_tape_entry* po = &nt_tape_get()->entries[out_idx];
+    float loss = 0.0f;
+    for (long i = 0; i < po->output->len; i++) loss += po->output->data[i];
+
+    nt_tape_clear();
+    return loss;
+}
+
+static int analytic_grads(const float* wr_data, long wr_len,
+                          const float* x_data,  int t_len, int e_len,
+                          const float* v_data,  int out_dim,
+                          float** out_dwr, float** out_dx, float** out_dv) {
+    nt_tape_start();
+
+    nt_tensor* tw = nt_tensor_new(wr_len);
+    memcpy(tw->data, wr_data, (size_t)wr_len * sizeof(float));
+    int wr_idx = nt_tape_param(tw);
+    nt_tape_no_decay(wr_idx);
+
+    nt_tensor* tx = nt_tensor_new(t_len * e_len);
+    memcpy(tx->data, x_data, (size_t)t_len * e_len * sizeof(float));
+    int x_idx = nt_tape_param(tx);
+    nt_tape_no_decay(x_idx);
+
+    nt_tensor* tv = nt_tensor_new(t_len * out_dim);
+    memcpy(tv->data, v_data, (size_t)t_len * out_dim * sizeof(float));
+    int v_idx = nt_tape_param(tv);
+    nt_tape_no_decay(v_idx);
+
+    int out_idx = nt_rrpram_broadcast_attention(wr_idx, x_idx, v_idx,
+                                                 t_len, e_len, H_LEN, HD_LEN);
+    if (out_idx < 0) { nt_tape_clear(); return -1; }
+
+    nt_tape_entry* po = &nt_tape_get()->entries[out_idx];
+    if (!po->grad) {
+        po->grad = nt_tensor_new(po->output->len);
+    }
+    for (long i = 0; i < po->grad->len; i++) po->grad->data[i] = 1.0f;
+
+    nt_tape_backward(out_idx);
+
+    nt_tape_entry* ew = &nt_tape_get()->entries[wr_idx];
+    nt_tape_entry* ex = &nt_tape_get()->entries[x_idx];
+    nt_tape_entry* ev = &nt_tape_get()->entries[v_idx];
+
+    *out_dwr = (float*)malloc(wr_len * sizeof(float));
+    *out_dx  = (float*)malloc(t_len * e_len * sizeof(float));
+    *out_dv  = (float*)malloc(t_len * out_dim * sizeof(float));
+
+    if (ew->grad) memcpy(*out_dwr, ew->grad->data, wr_len * sizeof(float));
+    else memset(*out_dwr, 0, wr_len * sizeof(float));
+    if (ex->grad) memcpy(*out_dx,  ex->grad->data,  t_len * e_len * sizeof(float));
+    else memset(*out_dx,  0, t_len * e_len * sizeof(float));
+    if (ev->grad) memcpy(*out_dv,  ev->grad->data,  t_len * out_dim * sizeof(float));
+    else memset(*out_dv,  0, t_len * out_dim * sizeof(float));
+
+    nt_tape_clear();
+    return 0;
+}
+
+static int compare_grads(const char* name, const float* analytic,
+                         float* x_data, long n_elem,
+                         const float* wr_data, long wr_len,
+                         const float* x_full,  int t_len, int e_len,
+                         const float* v_data,  int out_dim,
+                         int which) {
+    int n_fail = 0;
+    float max_abs_err = 0.0f, max_rel_err = 0.0f;
+    int max_idx = -1;
+
+    for (long k = 0; k < n_elem; k++) {
+        float orig = x_data[k];
+        x_data[k] = orig + EPS_FD;
+        float l_plus = forward_only(
+            (which == 0) ? x_data : wr_data, wr_len,
+            (which == 1) ? x_data : x_full, t_len, e_len,
+            (which == 2) ? x_data : v_data, out_dim);
+        x_data[k] = orig - EPS_FD;
+        float l_minus = forward_only(
+            (which == 0) ? x_data : wr_data, wr_len,
+            (which == 1) ? x_data : x_full, t_len, e_len,
+            (which == 2) ? x_data : v_data, out_dim);
+        x_data[k] = orig;
+
+        float fd  = (l_plus - l_minus) / (2.0f * EPS_FD);
+        float ana = analytic[k];
+        float abs_err = fabsf(fd - ana);
+        float denom = fmaxf(fabsf(fd), fabsf(ana));
+        float rel_err = (denom > 1e-9f) ? abs_err / denom : 0.0f;
+
+        if (abs_err > max_abs_err) { max_abs_err = abs_err; max_idx = (int)k; }
+        if (rel_err > max_rel_err) max_rel_err = rel_err;
+
+        if (abs_err > TOL_ABS && rel_err > TOL_REL) {
+            if (n_fail < 5)
+                printf("  [%s] FAIL k=%ld fd=%.6e ana=%.6e abs=%.6e rel=%.6e\n",
+                       name, k, fd, ana, abs_err, rel_err);
+            n_fail++;
+        }
+    }
+
+    printf("  [%s] n=%ld max_abs=%.4e (idx %d) max_rel=%.4e fails=%d\n",
+           name, n_elem, max_abs_err, max_idx, max_rel_err, n_fail);
+    return n_fail;
+}
+
+int main(void) {
+    srand(42);
+    nt_seed(42);
+
+    long wr_len = (long)H_LEN * E_LEN * R_LEN + (long)H_LEN * R_LEN * T_LEN;
+    float* wr   = (float*)malloc(wr_len * sizeof(float));
+    float* x    = (float*)malloc(T_LEN * E_LEN * sizeof(float));
+    float* v    = (float*)malloc(T_LEN * OUT_DIM * sizeof(float));
+
+    for (long i = 0; i < wr_len; i++) wr[i] = 0.1f * frand_unit();
+    for (long i = 0; i < T_LEN * E_LEN; i++) x[i] = 0.5f * frand_unit();
+    for (long i = 0; i < T_LEN * OUT_DIM; i++) v[i] = 0.5f * frand_unit();
+
+    printf("=== nt_rrpram_broadcast_attention gradient check ===\n");
+    printf("dims: T=%d E=%d R=%d H=%d hd=%d  wr_len=%ld\n",
+           T_LEN, E_LEN, R_LEN, H_LEN, HD_LEN, wr_len);
+
+    float *dwr = NULL, *dx = NULL, *dv = NULL;
+    if (analytic_grads(wr, wr_len, x, T_LEN, E_LEN, v, OUT_DIM,
+                       &dwr, &dx, &dv) < 0) {
+        printf("FAIL: analytic forward returned error\n");
+        return 1;
+    }
+
+    float L0 = forward_only(wr, wr_len, x, T_LEN, E_LEN, v, OUT_DIM);
+    printf("L0 = %.6f (loss = sum(out))\n", L0);
+
+    int n_fail = 0;
+
+    float* wr_copy = (float*)malloc(wr_len * sizeof(float));
+    memcpy(wr_copy, wr, wr_len * sizeof(float));
+    n_fail += compare_grads("d_wr", dwr, wr_copy, wr_len,
+                             wr_copy, wr_len, x, T_LEN, E_LEN, v, OUT_DIM, 0);
+
+    float* x_copy = (float*)malloc(T_LEN * E_LEN * sizeof(float));
+    memcpy(x_copy, x, T_LEN * E_LEN * sizeof(float));
+    n_fail += compare_grads("d_x", dx, x_copy, T_LEN * E_LEN,
+                             wr, wr_len, x_copy, T_LEN, E_LEN, v, OUT_DIM, 1);
+
+    float* v_copy = (float*)malloc(T_LEN * OUT_DIM * sizeof(float));
+    memcpy(v_copy, v, T_LEN * OUT_DIM * sizeof(float));
+    n_fail += compare_grads("d_v", dv, v_copy, T_LEN * OUT_DIM,
+                             wr, wr_len, x, T_LEN, E_LEN, v_copy, OUT_DIM, 2);
+
+    free(dwr); free(dx); free(dv);
+    free(wr_copy); free(x_copy); free(v_copy);
+    free(wr); free(x); free(v);
+
+    printf("\n=== %s — total fails: %d ===\n",
+           n_fail == 0 ? "PASS" : "FAIL", n_fail);
+    return n_fail == 0 ? 0 : 1;
+}

--- a/tests/test_rrpram_broadcast.c
+++ b/tests/test_rrpram_broadcast.c
@@ -199,15 +199,25 @@ static int sentinel_layout_check(void) {
     for (int t = 0; t < T_LEN; t++)
         for (int e = 0; e < E_LEN; e++)
             x[t*E_LEN+e] = 1.0f;
-    /* v[t,h_off+d] = 1 for all (so attention weighted sum = sum of weights = 1). */
-    for (long i = 0; i < T_LEN * OUT_DIM; i++) v[i] = 1.0f;
+    /* v[j, h*hd+d] = 10*j + h + 0.01*d — position-coded so wrong attn weights
+     * (from wrong stride read) yield distinct output values, NOT just 1. */
+    for (int j = 0; j < T_LEN; j++)
+        for (int h = 0; h < H_LEN; h++)
+            for (int d = 0; d < HD_LEN; d++)
+                v[j*OUT_DIM + h*HD_LEN + d] = 10.0f*j + (float)h + 0.01f*(float)d;
 
-    /* Expected: mid[h,r=0] = T_LEN*E_LEN = 24. mid[h,r=1] = 0.
-     * score[h,j] = mid[h,0] * Wr_b[h,0,j] + 0 = 24 * ((j+1)*100 + h*10).
-     * scaled by sc=1/sqrt(hd)=0.5. Then softmax over j ≤ i across positions [0..T_LEN-1].
-     * Output[i] = Σ_{j<=i} attn[i,j]*v[j] = Σ_{j<=i} attn[i,j]*1 = 1 (since v=1, attn sums to 1).
-     * So out[i, h_off+d] = 1 for all (i,h,d) when v all ones.
-     * Check op output matches this; mismatch implies wrong stride/rank read. */
+    /* Expected (correct ctx_T stride):
+     *   mid[h, r=0] = Σ_t,e x[t,e] * Wr_a[h,e,r=0] = T*E*1 = 24 (all r=0 weights = 1).
+     *   mid[h, r=1] = 0 (all r=1 weights = 0).
+     *   score[h, j] = mid[h,0] * Wr_b[h,0,j] = 24 * ((j+1)*100 + h*10).
+     *   scaled = score * sc = score / sqrt(4) = score / 2.
+     *   With T=3 positions, score values are large → softmax peaks at j=last visible.
+     *   For i=0: j∈{0}; attn[0,0]=1; out[0,h*hd+d] = v[0,h*hd+d] = 0+h+0.01d
+     *   For i=1: j∈{0,1}; softmax dominated by j=1 (larger score); out ≈ v[1,h,d] = 10+h+0.01d
+     *   For i=2: j∈{0,1,2}; softmax dominated by j=2; out ≈ v[2,h,d] = 20+h+0.01d
+     * Wrong stride (T_input=3 vs ctx_T=7) reads from wrong Wr_b columns →
+     * different score values → different attn dist → different output values
+     * → max_diff != 0. */
     nt_tape_start();
     nt_tensor* tw = nt_tensor_new(wr_len);
     memcpy(tw->data, wr, (size_t)wr_len * sizeof(float));
@@ -230,12 +240,46 @@ static int sentinel_layout_check(void) {
     nt_tape_entry* po = &nt_tape_get()->entries[out_idx];
     int n_fail = 0;
     float max_diff = 0.0f;
+    /* Compute analytic expected output via direct ctx_T stride formula.
+     * (wra_total declared at line 186 above.) */
+    float sc = 1.0f / sqrtf((float)HD_LEN);
+    float* expected = (float*)calloc(T_LEN * OUT_DIM, sizeof(float));
+    for (int h = 0; h < H_LEN; h++) {
+        float mid[R_LEN];
+        for (int r = 0; r < R_LEN; r++) mid[r] = 0.0f;
+        for (int t = 0; t < T_LEN; t++)
+            for (int e = 0; e < E_LEN; e++)
+                for (int r = 0; r < R_LEN; r++)
+                    mid[r] += x[t*E_LEN+e] * wr[(long)h*E_LEN*R_LEN + (long)e*R_LEN + r];
+        float scores[T_LEN];
+        for (int j = 0; j < T_LEN; j++) {
+            float s = 0.0f;
+            for (int r = 0; r < R_LEN; r++)
+                s += mid[r] * wr[wra_total + (long)h*R_LEN*CTX_T + (long)r*CTX_T + j];
+            scores[j] = s * sc;
+        }
+        for (int i = 0; i < T_LEN; i++) {
+            float mx = -1e30f;
+            for (int j = 0; j <= i; j++) if (scores[j] > mx) mx = scores[j];
+            float sm = 0.0f;
+            float att[T_LEN] = {0};
+            for (int j = 0; j <= i; j++) { att[j] = expf(scores[j] - mx); sm += att[j]; }
+            if (sm > 0) for (int j = 0; j <= i; j++) att[j] /= sm;
+            for (int d = 0; d < HD_LEN; d++) {
+                float o = 0.0f;
+                for (int j = 0; j <= i; j++)
+                    o += att[j] * v[j*OUT_DIM + h*HD_LEN + d];
+                expected[i*OUT_DIM + h*HD_LEN + d] = o;
+            }
+        }
+    }
     for (long i = 0; i < po->output->len; i++) {
-        float diff = fabsf(po->output->data[i] - 1.0f);
+        float diff = fabsf(po->output->data[i] - expected[i]);
         if (diff > max_diff) max_diff = diff;
         if (diff > 1e-3f) n_fail++;
     }
-    printf("  [sentinel] expected out[i]=1.0 (v=1, attn=1), max_diff=%.4e fails=%d\n",
+    free(expected);
+    printf("  [sentinel] expected vs op output (position-coded v), max_diff=%.4e fails=%d\n",
            max_diff, n_fail);
 
     nt_tape_clear();

--- a/tests/test_rrpram_broadcast.c
+++ b/tests/test_rrpram_broadcast.c
@@ -1,18 +1,22 @@
 /*
- * test_rrpram_broadcast.c — synthetic gradient check for nt_rrpram_broadcast_attention.
+ * test_rrpram_broadcast.c — gradient check for nt_rrpram_broadcast_attention.
  *
- * Tiny dims (T=4, E=8, R=2, H=2, hd=4) keep ε-sweep cheap.
- * For every element of Wr_combined / x / v we compute analytic gradient
- * (one backward pass with grad-of-loss = ones into out) and finite-difference
- * gradient ((L(x+ε) - L(x-ε)) / 2ε), where L = Σ out. They must match
- * within 1e-3 absolute error, else the broadcast op is wrong.
+ * Adversarial config: T_input=3 < ctx_T=7 (packed weight size > runtime sequence).
+ * This is the regression case that the original test missed (T_packed == T_input
+ * synthetic shape coincidentally produced the right answer with the old buggy
+ * rank/stride inference).
+ *
+ * Layout: Wr_combined = [H,E,R] concat [H,R,ctx_T] — packed at full ctx, sliced
+ * at runtime to T_input columns of Wr_b. New API takes `rank` explicitly,
+ * derives `ctx_T` from combined_len / (H*rank) - n_embd.
  *
  * Build (CPU only):
  *   cc -O2 -I. tests/test_rrpram_broadcast.c notorch.c -o /tmp/test_rrpram_bcast -lm
+ * Run:  /tmp/test_rrpram_bcast  ; exits 0 if all gates pass, 1 otherwise.
  *
- * Run:
- *   /tmp/test_rrpram_bcast
- *   exits 0 if all gates pass, 1 otherwise.
+ * Negative control: revert notorch broadcast op fix, rebuild, run — must FAIL.
+ * Re-apply fix, rebuild, run — must PASS. If both PASS, test has no diagnostic
+ * power (the original failure mode).
  */
 
 #include "notorch.h"
@@ -21,12 +25,14 @@
 #include <string.h>
 #include <math.h>
 
-#define T_LEN   4
-#define E_LEN   8
-#define R_LEN   2
-#define H_LEN   2
-#define HD_LEN  4
-#define OUT_DIM (H_LEN * HD_LEN)
+/* Adversarial: T_input < CTX_T (packed > runtime), H*HD=E invariant. */
+#define T_LEN    3
+#define CTX_T    7
+#define E_LEN    8
+#define R_LEN    2
+#define H_LEN    2
+#define HD_LEN   4
+#define OUT_DIM  (H_LEN * HD_LEN)
 
 #define EPS_FD     1e-3f
 #define TOL_ABS    1e-3f
@@ -57,7 +63,7 @@ static float forward_only(const float* wr_data, long wr_len,
     nt_tape_freeze_param(v_idx);
 
     int out_idx = nt_rrpram_broadcast_attention(wr_idx, x_idx, v_idx,
-                                                 t_len, e_len, H_LEN, HD_LEN);
+                                                 t_len, e_len, H_LEN, HD_LEN, R_LEN);
     if (out_idx < 0) { nt_tape_clear(); return NAN; }
 
     nt_tape_entry* po = &nt_tape_get()->entries[out_idx];
@@ -90,7 +96,7 @@ static int analytic_grads(const float* wr_data, long wr_len,
     nt_tape_no_decay(v_idx);
 
     int out_idx = nt_rrpram_broadcast_attention(wr_idx, x_idx, v_idx,
-                                                 t_len, e_len, H_LEN, HD_LEN);
+                                                 t_len, e_len, H_LEN, HD_LEN, R_LEN);
     if (out_idx < 0) { nt_tape_clear(); return -1; }
 
     nt_tape_entry* po = &nt_tape_get()->entries[out_idx];
@@ -166,11 +172,82 @@ static int compare_grads(const char* name, const float* analytic,
     return n_fail;
 }
 
+/* Sentinel-coded check: pack Wr_b with position-tag values so that wrong stride
+ * (T_input vs ctx_T) produces dramatically different output. Independently
+ * compute expected output via direct formula, compare to op output. */
+static int sentinel_layout_check(void) {
+    long wr_len = (long)H_LEN * E_LEN * R_LEN + (long)H_LEN * R_LEN * CTX_T;
+    float* wr = (float*)calloc(wr_len, sizeof(float));
+    float* x  = (float*)calloc(T_LEN * E_LEN, sizeof(float));
+    float* v  = (float*)calloc(T_LEN * OUT_DIM, sizeof(float));
+    if (!wr || !x || !v) { free(wr); free(x); free(v); return -1; }
+
+    /* Wr_a[h,e,r] = 1 only for r==0, else 0. So mid[h,r=0] = Σ_t,e x[t,e]. */
+    long wra_total = (long)H_LEN * E_LEN * R_LEN;
+    for (int h = 0; h < H_LEN; h++)
+        for (int e = 0; e < E_LEN; e++)
+            wr[(long)h*E_LEN*R_LEN + (long)e*R_LEN + 0] = 1.0f;
+
+    /* Wr_b[h,r=0,j] = (j+1) * 100 + h*10. Sentinel = position-coded.
+     * Wrong stride (T_input=3 vs ctx_T=7) reads from wr_a region or earlier
+     * positions, producing distinct output values. */
+    for (int h = 0; h < H_LEN; h++)
+        for (int j = 0; j < CTX_T; j++)
+            wr[wra_total + (long)h*R_LEN*CTX_T + (long)0*CTX_T + j] = (j+1)*100.0f + h*10.0f;
+
+    /* x[t,e] = 1 for all (so mid[h,0] = T_LEN * E_LEN regardless of h). */
+    for (int t = 0; t < T_LEN; t++)
+        for (int e = 0; e < E_LEN; e++)
+            x[t*E_LEN+e] = 1.0f;
+    /* v[t,h_off+d] = 1 for all (so attention weighted sum = sum of weights = 1). */
+    for (long i = 0; i < T_LEN * OUT_DIM; i++) v[i] = 1.0f;
+
+    /* Expected: mid[h,r=0] = T_LEN*E_LEN = 24. mid[h,r=1] = 0.
+     * score[h,j] = mid[h,0] * Wr_b[h,0,j] + 0 = 24 * ((j+1)*100 + h*10).
+     * scaled by sc=1/sqrt(hd)=0.5. Then softmax over j ≤ i across positions [0..T_LEN-1].
+     * Output[i] = Σ_{j<=i} attn[i,j]*v[j] = Σ_{j<=i} attn[i,j]*1 = 1 (since v=1, attn sums to 1).
+     * So out[i, h_off+d] = 1 for all (i,h,d) when v all ones.
+     * Check op output matches this; mismatch implies wrong stride/rank read. */
+    nt_tape_start();
+    nt_tensor* tw = nt_tensor_new(wr_len);
+    memcpy(tw->data, wr, (size_t)wr_len * sizeof(float));
+    int wr_idx = nt_tape_param(tw); nt_tape_freeze_param(wr_idx);
+    nt_tensor* tx = nt_tensor_new(T_LEN * E_LEN);
+    memcpy(tx->data, x, (size_t)T_LEN * E_LEN * sizeof(float));
+    int x_idx = nt_tape_param(tx); nt_tape_freeze_param(x_idx);
+    nt_tensor* tv = nt_tensor_new(T_LEN * OUT_DIM);
+    memcpy(tv->data, v, (size_t)T_LEN * OUT_DIM * sizeof(float));
+    int v_idx = nt_tape_param(tv); nt_tape_freeze_param(v_idx);
+
+    int out_idx = nt_rrpram_broadcast_attention(wr_idx, x_idx, v_idx,
+                                                 T_LEN, E_LEN, H_LEN, HD_LEN, R_LEN);
+    if (out_idx < 0) {
+        printf("  [sentinel] op returned -1 (likely shape mismatch reject — investigate)\n");
+        nt_tape_clear(); free(wr); free(x); free(v);
+        return -1;
+    }
+
+    nt_tape_entry* po = &nt_tape_get()->entries[out_idx];
+    int n_fail = 0;
+    float max_diff = 0.0f;
+    for (long i = 0; i < po->output->len; i++) {
+        float diff = fabsf(po->output->data[i] - 1.0f);
+        if (diff > max_diff) max_diff = diff;
+        if (diff > 1e-3f) n_fail++;
+    }
+    printf("  [sentinel] expected out[i]=1.0 (v=1, attn=1), max_diff=%.4e fails=%d\n",
+           max_diff, n_fail);
+
+    nt_tape_clear();
+    free(wr); free(x); free(v);
+    return n_fail;
+}
+
 int main(void) {
     srand(42);
     nt_seed(42);
 
-    long wr_len = (long)H_LEN * E_LEN * R_LEN + (long)H_LEN * R_LEN * T_LEN;
+    long wr_len = (long)H_LEN * E_LEN * R_LEN + (long)H_LEN * R_LEN * CTX_T;
     float* wr   = (float*)malloc(wr_len * sizeof(float));
     float* x    = (float*)malloc(T_LEN * E_LEN * sizeof(float));
     float* v    = (float*)malloc(T_LEN * OUT_DIM * sizeof(float));
@@ -179,21 +256,28 @@ int main(void) {
     for (long i = 0; i < T_LEN * E_LEN; i++) x[i] = 0.5f * frand_unit();
     for (long i = 0; i < T_LEN * OUT_DIM; i++) v[i] = 0.5f * frand_unit();
 
-    printf("=== nt_rrpram_broadcast_attention gradient check ===\n");
-    printf("dims: T=%d E=%d R=%d H=%d hd=%d  wr_len=%ld\n",
-           T_LEN, E_LEN, R_LEN, H_LEN, HD_LEN, wr_len);
+    printf("=== nt_rrpram_broadcast_attention gradient check (adversarial) ===\n");
+    printf("dims: T_input=%d ctx_T=%d E=%d R=%d H=%d hd=%d  wr_len=%ld\n",
+           T_LEN, CTX_T, E_LEN, R_LEN, H_LEN, HD_LEN, wr_len);
+    printf("(T_input != ctx_T — exposes rank/stride layout bugs)\n");
 
+    int n_fail = 0;
+
+    printf("\n--- sentinel layout check ---\n");
+    int sentinel = sentinel_layout_check();
+    n_fail += (sentinel < 0) ? 1 : sentinel;
+
+    printf("\n--- finite-diff gradient check ---\n");
     float *dwr = NULL, *dx = NULL, *dv = NULL;
     if (analytic_grads(wr, wr_len, x, T_LEN, E_LEN, v, OUT_DIM,
                        &dwr, &dx, &dv) < 0) {
         printf("FAIL: analytic forward returned error\n");
+        free(wr); free(x); free(v);
         return 1;
     }
 
     float L0 = forward_only(wr, wr_len, x, T_LEN, E_LEN, v, OUT_DIM);
     printf("L0 = %.6f (loss = sum(out))\n", L0);
-
-    int n_fail = 0;
 
     float* wr_copy = (float*)malloc(wr_len * sizeof(float));
     memcpy(wr_copy, wr, wr_len * sizeof(float));


### PR DESCRIPTION
Implements the declared-but-missing NT_OP_RRPRAM_BCAST (op 34): main had only the decl (notorch.h:125,446) + a CLAUDE.md TODO; notorch.c had no impl. This branch (canonical Janus broadcast pattern, sc=1/sqrt(D)) adds it + a 348-line adversarial test.

Verified against current main (test-merged in a worktree):
- merges clean; make test 73/73 (no regression)
- test_rrpram_broadcast PASS, 0 fails: sentinel forward bit-exact (max_diff=0), backward finite-diff d_wr/d_x/d_v correct
Branch dated 2026-05-10 (behind main) but merges + builds + op-test green. Squash collapses its revert/merge/debug history.