### PR TITLE
notorch: land Metal q4k/q6k v3 matvec + DOE parliament kernels

### DIFF
--- a/notorch_metal.h
+++ b/notorch_metal.h
@@ -128,6 +128,18 @@ int nt_metal_attn_decode(int dst_slot, int q_slot, const float *K, const float *
                          uint32_t k_pos_stride, uint32_t k_head_stride,
                          uint32_t v_pos_stride, uint32_t v_head_stride, float scale);
 int nt_metal_copy_to_region(void *dst, int src_slot, uint64_t bytes);
+/* DOE parliament LoRA injection: x_slot += alpha * sum_e gate[e] * A_e @ (B_e @ x).
+ * layer_base = host pointer to this layer's slice of a registered expert arena
+ * laid out [ w_vote ne*D | per-expert (B rank*D, A D*rank) x ne ]. tmp_slot holds
+ * ne*rank scratch, gate_slot holds ne softmax weights (0 = dead/unelected). */
+int nt_metal_parliament_inject(int x_slot, int tmp_slot, int gate_slot,
+                               const float *layer_base, int D, int rank, int ne, float alpha);
+/* DOE parliament election (variable-k vote over experts). votes: vdot[e]=dot(w_vote_e,x);
+ * elect: dense gate[ne] from vdot + res (host 0.1*resonance) with EMA consensus persisted
+ * in cons[layer_idx] and the frozen alive[ne] mask. ne <= 16. */
+int nt_metal_parliament_votes(const float *layer_base, int x_slot, int vdot_slot, int D, int ne);
+int nt_metal_parliament_elect(int vdot_slot, int res_slot, int alive_slot,
+                              int cons_slot, int gate_slot, int ne, int layer_idx, int min_experts);
 
 #ifdef __cplusplus
 }

--- a/notorch_metal.mm
+++ b/notorch_metal.mm
@@ -597,6 +597,154 @@ kernel void copy_f32(
     dst[gid] = src[gid];
 }
 
+/* DOE parliament LoRA injection on the resident stream — two f32 stages over a
+ * registered per-layer arena: [ w_vote ne*D | per-expert (B rank*D, A D*rank) x ne ].
+ * Stage 1 (parliament_btmp): tmp[e*rank+r] = dot(B_e[r], x), one threadgroup per
+ * (e,r), simd-reduced over D. Stage 2 (parliament_apply): one thread per output i,
+ * x[i] += alpha * sum_e gate[e] * sum_r A_e[i][r] * tmp[e*rank+r]. gate[e]=0 (dead
+ * or unelected) is a true no-op. Mirrors the CPU inject (doe.c parliament path);
+ * the GPU reduction order differs, so parity is ~1e-4, not bit-identical. */
+kernel void parliament_btmp(
+    device const float *layer [[buffer(0)]],   /* per-layer arena base */
+    device const float *x     [[buffer(1)]],   /* [D] */
+    device       float *tmp   [[buffer(2)]],   /* [ne*rank] */
+    constant     uint  &D     [[buffer(3)]],
+    constant     uint  &rank  [[buffer(4)]],
+    constant     uint  &ne    [[buffer(5)]],
+    uint gid  [[threadgroup_position_in_grid]],   /* e*rank + r */
+    uint tid  [[thread_position_in_threadgroup]],
+    uint tgsz [[threads_per_threadgroup]],
+    uint sgid [[simdgroup_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]])
+{
+    threadgroup float partials[32];
+    uint e = gid / rank;
+    uint r = gid % rank;
+    uint per_expert = 2u * rank * D;
+    device const float *Brow = layer + ne * D + e * per_expert + r * D;
+    float acc = 0.0f;
+    for (uint j = tid; j < D; j += tgsz) acc += Brow[j] * x[j];
+    float s = simd_sum(acc);
+    if (lane == 0) partials[sgid] = s;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    uint nsg = (tgsz + 31u) / 32u;
+    if (sgid == 0) {
+        float p = (lane < nsg) ? partials[lane] : 0.0f;
+        p = simd_sum(p);
+        if (lane == 0) tmp[gid] = p;
+    }
+}
+
+kernel void parliament_apply(
+    device const float *layer [[buffer(0)]],
+    device const float *tmp   [[buffer(1)]],   /* [ne*rank] */
+    device const float *gate  [[buffer(2)]],   /* [ne] */
+    device       float *x     [[buffer(3)]],   /* [D], in/out */
+    constant     uint  &D     [[buffer(4)]],
+    constant     uint  &rank  [[buffer(5)]],
+    constant     uint  &ne    [[buffer(6)]],
+    constant     float &alpha [[buffer(7)]],
+    uint i [[thread_position_in_grid]])
+{
+    if (i >= D) return;
+    uint per_expert = 2u * rank * D;
+    float acc = 0.0f;
+    for (uint e = 0u; e < ne; e++) {
+        float g = gate[e];
+        if (g == 0.0f) continue;
+        device const float *Arow = layer + ne * D + e * per_expert + rank * D + i * rank;
+        device const float *tg = tmp + e * rank;
+        float s = 0.0f;
+        for (uint r = 0u; r < rank; r++) s += Arow[r] * tg[r];
+        acc += g * s;
+    }
+    x[i] += alpha * acc;
+}
+
+/* DOE parliament election — variable-k vote over the LoRA experts. Two stages.
+ * parliament_votes: vdot[e] = dot(w_vote_e, x) over the ne vote rows at the layer
+ * arena base, one threadgroup per e, simd-reduced. parliament_elect: a single
+ * thread reproduces parliament_elect() (doe.c) bit-for-bit given the same inputs
+ * — votes = vdot + res (host-precomputed 0.1*resonance), mean/var over alive,
+ * EMA consensus persisted in cons[layer], variable k, hard top-k, softmax into a
+ * dense gate[ne] (0 for dead/unelected). alive[e] (1/0) is the frozen liveness
+ * mask; dead vote rows are never counted. cons is the stateful EMA across tokens. */
+kernel void parliament_votes(
+    device const float *layer [[buffer(0)]],   /* w_vote at layer[e*D + j] */
+    device const float *x     [[buffer(1)]],   /* [D] */
+    device       float *vdot  [[buffer(2)]],   /* [ne] */
+    constant     uint  &D     [[buffer(3)]],
+    uint gid  [[threadgroup_position_in_grid]],   /* e */
+    uint tid  [[thread_position_in_threadgroup]],
+    uint tgsz [[threads_per_threadgroup]],
+    uint sgid [[simdgroup_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]])
+{
+    threadgroup float partials[32];
+    device const float *row = layer + (uint)gid * D;
+    float acc = 0.0f;
+    for (uint j = tid; j < D; j += tgsz) acc += row[j] * x[j];
+    float s = simd_sum(acc);
+    if (lane == 0) partials[sgid] = s;
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    uint nsg = (tgsz + 31u) / 32u;
+    if (sgid == 0) {
+        float p = (lane < nsg) ? partials[lane] : 0.0f;
+        p = simd_sum(p);
+        if (lane == 0) vdot[gid] = p;
+    }
+}
+
+kernel void parliament_elect(
+    device const float *vdot  [[buffer(0)]],   /* [ne] */
+    device const float *res   [[buffer(1)]],   /* [ne]  0.1*resonance(freq,hs) */
+    device const float *alive [[buffer(2)]],   /* [ne]  1.0 / 0.0 */
+    device       float *cons  [[buffer(3)]],   /* [n_layers] persistent EMA consensus */
+    device       float *gate  [[buffer(4)]],   /* [ne]  dense output */
+    constant     uint  &ne    [[buffer(5)]],
+    constant     uint  &layer [[buffer(6)]],
+    constant     uint  &min_e [[buffer(7)]],
+    uint tid [[thread_position_in_grid]])
+{
+    if (tid != 0u) return;
+    float votes[16];
+    uint n_alive = 0u;
+    for (uint e = 0u; e < ne; e++) {
+        gate[e] = 0.0f;
+        if (alive[e] != 0.0f) { votes[e] = vdot[e] + res[e]; n_alive++; }
+        else                  { votes[e] = -3.0e38f; }
+    }
+    if (n_alive < min_e) return;                 /* CPU returns 0 -> no injection (gate all 0) */
+    float mean = 0.0f;
+    for (uint e = 0u; e < ne; e++) if (alive[e] != 0.0f) mean += votes[e];
+    mean /= (float)n_alive;
+    float var = 0.0f;
+    for (uint e = 0u; e < ne; e++) if (alive[e] != 0.0f) { float d = votes[e] - mean; var += d*d; }
+    var /= (float)n_alive;
+    float cnew = sqrt(var + 1e-8f) / (fabs(mean) + 1.0f);
+    if (cnew > 1.0f) cnew = 1.0f;
+    float c = 0.9f * cons[layer] + 0.1f * cnew;
+    cons[layer] = c;
+    int k = (int)((float)n_alive * (1.0f - c));
+    if (k < (int)min_e) k = (int)min_e;          /* CPU: if(k<2)k=2; MIN_EXPERTS==2 */
+    if (k > (int)n_alive) k = (int)n_alive;
+    bool used[16];
+    for (uint e = 0u; e < ne; e++) used[e] = false;
+    int   sel[16];
+    float selv[16];
+    for (int ki = 0; ki < k; ki++) {
+        float bv = -3.0e38f; int bi = 0;
+        for (uint e = 0u; e < ne; e++)
+            if (alive[e] != 0.0f && !used[e] && votes[e] > bv) { bv = votes[e]; bi = (int)e; }
+        sel[ki] = bi; selv[ki] = votes[bi]; used[bi] = true;
+    }
+    float mx = selv[0];
+    for (int ki = 1; ki < k; ki++) if (selv[ki] > mx) mx = selv[ki];
+    float sum = 0.0f;
+    for (int ki = 0; ki < k; ki++) { selv[ki] = exp(selv[ki] - mx); sum += selv[ki]; }
+    for (int ki = 0; ki < k; ki++) gate[sel[ki]] = selv[ki] / sum;
+}
+
 )MSL";
 
 /* ── State (ARC-managed) ─────────────────────────────────────────────── */
@@ -618,6 +766,10 @@ static id<MTLComputePipelineState> g_silu_pipe   = nil;
 static id<MTLComputePipelineState> g_add_pipe    = nil;
 static id<MTLComputePipelineState> g_attn_pipe   = nil;
 static id<MTLComputePipelineState> g_copy_pipe   = nil;
+static id<MTLComputePipelineState> g_pbtmp_pipe  = nil;   /* DOE parliament: B@x */
+static id<MTLComputePipelineState> g_papply_pipe = nil;   /* DOE parliament: A@tmp, gated */
+static id<MTLComputePipelineState> g_pvotes_pipe = nil;   /* DOE parliament: w_vote@x */
+static id<MTLComputePipelineState> g_pelect_pipe = nil;   /* DOE parliament: variable-k election */
 
 /* M4 — device-resident activation slots: fixed regions in a persistent
  * GPU arena. Ops read/write slots without host roundtrips, so a whole
@@ -755,6 +907,10 @@ int nt_metal_init(void)
             { @"add_f32",         &g_add_pipe  },
             { @"attn_decode_f32", &g_attn_pipe },
             { @"copy_f32",        &g_copy_pipe },
+            { @"parliament_btmp", &g_pbtmp_pipe },
+            { @"parliament_apply",&g_papply_pipe },
+            { @"parliament_votes",&g_pvotes_pipe },
+            { @"parliament_elect",&g_pelect_pipe },
         };
         for (size_t oi = 0; oi < sizeof(m4ops)/sizeof(m4ops[0]); oi++) {
             id<MTLFunction> f = [lib newFunctionWithName:m4ops[oi].name];
@@ -810,6 +966,8 @@ void nt_metal_shutdown(void)
     g_q6k_sg_pipe = nil;
     g_rms_pipe = nil; g_rope_pipe = nil; g_silu_pipe = nil;
     g_add_pipe = nil; g_attn_pipe = nil; g_copy_pipe = nil;
+    g_pbtmp_pipe = nil; g_papply_pipe = nil;
+    g_pvotes_pipe = nil; g_pelect_pipe = nil;
     g_slot_buf = nil; g_slot_cap = 0; g_slot_used = 0;
     memset(g_slot_tab, 0, sizeof(g_slot_tab));
     g_queue       = nil;
@@ -1391,6 +1549,117 @@ int nt_metal_copy_to_region(void *dst, int src_slot, uint64_t bytes)
         [enc setBytes:&n_u length:4 atIndex:2];
         [enc dispatchThreads:MTLSizeMake((NSUInteger)n_u, 1, 1)
        threadsPerThreadgroup:MTLSizeMake(n_u < 256 ? (NSUInteger)n_u : 256, 1, 1)];
+        return op_fin(cb, enc);
+    }
+}
+
+/* DOE parliament LoRA injection over a registered per-layer arena, x resident.
+ * Two serial dispatches inside the current encoder (batch: serial-dispatch order
+ * makes stage 2 see stage 1's tmp; solo: each commits+waits). layer_base is the
+ * host pointer to this layer's slice of the registered expert arena. gate[ne] in
+ * gate_slot carries the softmax election weights (0 = dead/unelected). Mirrors the
+ * CPU inject; reduction order differs so parity is ~1e-4. */
+int nt_metal_parliament_inject(int x_slot, int tmp_slot, int gate_slot,
+                               const float *layer_base, int D, int rank, int ne, float alpha)
+{
+    if (!g_initialised) { int rc = nt_metal_init(); if (rc) return rc; }
+    if (!slot_ok(x_slot) || !slot_ok(tmp_slot) || !slot_ok(gate_slot)) return 20;
+    if (D <= 0 || rank <= 0 || ne <= 0) return 20;
+    @autoreleasepool {
+        size_t per_expert   = (size_t)2 * rank * D;
+        size_t layer_floats = (size_t)ne * D + (size_t)ne * per_expert;
+        id<MTLBuffer> bL = nil; NSUInteger L_off = 0;
+        if (resolve_region(layer_base, (uint64_t)layer_floats * sizeof(float), &bL, &L_off) != 0) {
+            fprintf(stderr, "nt_metal_parliament_inject: layer arena not registered\n");
+            return 22;
+        }
+        uint32_t Du = (uint32_t)D, ru = (uint32_t)rank, neu = (uint32_t)ne;
+        /* stage 1: tmp[e*rank+r] = dot(B_e[r], x) */
+        {
+            id<MTLCommandBuffer> cb; id<MTLComputeCommandEncoder> enc;
+            int rc = op_enc(&cb, &enc); if (rc) return rc;
+            [enc setComputePipelineState:g_pbtmp_pipe];
+            [enc setBuffer:bL offset:L_off atIndex:0];
+            [enc setBuffer:g_slot_buf offset:g_slot_tab[x_slot].off   atIndex:1];
+            [enc setBuffer:g_slot_buf offset:g_slot_tab[tmp_slot].off atIndex:2];
+            [enc setBytes:&Du  length:4 atIndex:3];
+            [enc setBytes:&ru  length:4 atIndex:4];
+            [enc setBytes:&neu length:4 atIndex:5];
+            [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)ne * (NSUInteger)rank, 1, 1)
+                  threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+            rc = op_fin(cb, enc); if (rc) return rc;
+        }
+        /* stage 2: x[i] += alpha * sum_e gate[e] * sum_r A_e[i][r]*tmp[e][r] */
+        {
+            id<MTLCommandBuffer> cb; id<MTLComputeCommandEncoder> enc;
+            int rc = op_enc(&cb, &enc); if (rc) return rc;
+            [enc setComputePipelineState:g_papply_pipe];
+            [enc setBuffer:bL offset:L_off atIndex:0];
+            [enc setBuffer:g_slot_buf offset:g_slot_tab[tmp_slot].off  atIndex:1];
+            [enc setBuffer:g_slot_buf offset:g_slot_tab[gate_slot].off atIndex:2];
+            [enc setBuffer:g_slot_buf offset:g_slot_tab[x_slot].off    atIndex:3];
+            [enc setBytes:&Du    length:4 atIndex:4];
+            [enc setBytes:&ru    length:4 atIndex:5];
+            [enc setBytes:&neu   length:4 atIndex:6];
+            [enc setBytes:&alpha length:4 atIndex:7];
+            [enc dispatchThreads:MTLSizeMake((NSUInteger)D, 1, 1)
+           threadsPerThreadgroup:MTLSizeMake(D < 256 ? (NSUInteger)D : 256, 1, 1)];
+            rc = op_fin(cb, enc); if (rc) return rc;
+        }
+        return 0;
+    }
+}
+
+/* DOE parliament election stage 1: vdot[e] = dot(w_vote_e, x) over the ne vote
+ * rows at the registered layer arena base, x resident. */
+int nt_metal_parliament_votes(const float *layer_base, int x_slot, int vdot_slot, int D, int ne)
+{
+    if (!g_initialised) { int rc = nt_metal_init(); if (rc) return rc; }
+    if (!slot_ok(x_slot) || !slot_ok(vdot_slot) || D <= 0 || ne <= 0) return 20;
+    @autoreleasepool {
+        id<MTLBuffer> bL = nil; NSUInteger L_off = 0;
+        if (resolve_region(layer_base, (uint64_t)ne * D * sizeof(float), &bL, &L_off) != 0) {
+            fprintf(stderr, "nt_metal_parliament_votes: layer arena not registered\n");
+            return 22;
+        }
+        id<MTLCommandBuffer> cb; id<MTLComputeCommandEncoder> enc;
+        int rc = op_enc(&cb, &enc); if (rc) return rc;
+        uint32_t Du = (uint32_t)D;
+        [enc setComputePipelineState:g_pvotes_pipe];
+        [enc setBuffer:bL offset:L_off atIndex:0];
+        [enc setBuffer:g_slot_buf offset:g_slot_tab[x_slot].off    atIndex:1];
+        [enc setBuffer:g_slot_buf offset:g_slot_tab[vdot_slot].off atIndex:2];
+        [enc setBytes:&Du length:4 atIndex:3];
+        [enc dispatchThreadgroups:MTLSizeMake((NSUInteger)ne, 1, 1)
+              threadsPerThreadgroup:MTLSizeMake(256, 1, 1)];
+        return op_fin(cb, enc);
+    }
+}
+
+/* DOE parliament election stage 2: single-thread variable-k election reproducing
+ * parliament_elect() (doe.c) — votes = vdot + res, EMA consensus in cons[layer_idx],
+ * hard top-k, softmax -> dense gate[ne]. ne <= 16. */
+int nt_metal_parliament_elect(int vdot_slot, int res_slot, int alive_slot,
+                              int cons_slot, int gate_slot, int ne, int layer_idx, int min_experts)
+{
+    if (!g_initialised) { int rc = nt_metal_init(); if (rc) return rc; }
+    if (!slot_ok(vdot_slot) || !slot_ok(res_slot) || !slot_ok(alive_slot) ||
+        !slot_ok(cons_slot) || !slot_ok(gate_slot)) return 20;
+    if (ne <= 0 || ne > 16 || layer_idx < 0 || min_experts < 0) return 20;
+    @autoreleasepool {
+        id<MTLCommandBuffer> cb; id<MTLComputeCommandEncoder> enc;
+        int rc = op_enc(&cb, &enc); if (rc) return rc;
+        uint32_t neu = (uint32_t)ne, lu = (uint32_t)layer_idx, mu = (uint32_t)min_experts;
+        [enc setComputePipelineState:g_pelect_pipe];
+        [enc setBuffer:g_slot_buf offset:g_slot_tab[vdot_slot].off  atIndex:0];
+        [enc setBuffer:g_slot_buf offset:g_slot_tab[res_slot].off   atIndex:1];
+        [enc setBuffer:g_slot_buf offset:g_slot_tab[alive_slot].off atIndex:2];
+        [enc setBuffer:g_slot_buf offset:g_slot_tab[cons_slot].off  atIndex:3];
+        [enc setBuffer:g_slot_buf offset:g_slot_tab[gate_slot].off  atIndex:4];
+        [enc setBytes:&neu length:4 atIndex:5];
+        [enc setBytes:&lu  length:4 atIndex:6];
+        [enc setBytes:&mu  length:4 atIndex:7];
+        [enc dispatchThreadgroups:MTLSizeMake(1, 1, 1) threadsPerThreadgroup:MTLSizeMake(1, 1, 1)];
         return op_fin(cb, enc);
     }
 }

--- a/notorch_metal.mm
+++ b/notorch_metal.mm
@@ -226,6 +226,7 @@ kernel void q4k_matvec_v3(
     const uint row_bytes = nb * 144u;        /* bytes per Q4_K row */
     const uint row_u16   = row_bytes / 2u;   /* row stride in uint16 units */
     const int  first_row = ((int)tgpig.x * NSG + sgitg) * NR0;
+    if (first_row >= (int)m) return;   /* tail threadgroup owns no rows (Codex: OOB W guard) */
 
     device const uchar *x0 = W + (uint)first_row * row_bytes;
     device const float *y4 = x + ix * 256u + 64u * iq + 8u * ir;
@@ -252,6 +253,7 @@ kernel void q4k_matvec_v3(
         device const half     *dh  = (device const half *)blk;
 
         for (short row = 0; row < NR0; ++row) {
+            if (first_row + row >= (int)m) break;   /* tail row: skip OOB W loads (Codex) */
             sc16[0] =  sc[0] & kmask1;
             sc16[1] =  sc[2] & kmask1;
             sc16[2] = ((sc[4] >> 0) & kmask2) | ((sc[0] & kmask3) >> 2);

--- a/notorch_metal.mm
+++ b/notorch_metal.mm
@@ -197,6 +197,102 @@ kernel void q4k_matvec_sg(
     if (lane == 0) out[tpig.y] = total;
 }
 
+/* q4k_matvec_v3 — bandwidth-optimal Q4_K matvec ported from llama.cpp
+ * kernel_mul_mv_q4_K_f32 (240 GB/s class on Apple GPUs). Wins over naive/M3-sg:
+ * multi-row (NR0=2 rows per simdgroup), activation held in registers and reused
+ * across both rows, float4-vectorized nibble unpack, sumy precompute for dmin.
+ * Single-x matvec; our packed Q4_K block is 144 bytes (d/dmin half, scales[12],
+ * qs[128]) — layout-identical to llama's block_q4_K. */
+kernel void q4k_matvec_v3(
+    device const uchar *W   [[buffer(0)]],
+    device const float *x   [[buffer(1)]],
+    device       float *out [[buffer(2)]],
+    constant     uint  &k   [[buffer(3)]],
+    constant     uint  &m   [[buffer(4)]],
+    uint3  tgpig            [[threadgroup_position_in_grid]],
+    ushort tiisg           [[thread_index_in_simdgroup]],
+    ushort sgitg           [[simdgroup_index_in_threadgroup]])
+{
+    const short NSG = 2;     /* simdgroups per threadgroup */
+    const short NR0 = 2;     /* rows per simdgroup */
+    constexpr uint16_t kmask1 = 0x3f3f, kmask2 = 0x0f0f, kmask3 = 0xc0c0;
+
+    const short ix = tiisg / 8;   /* 0..3 */
+    const short it = tiisg % 8;   /* 0..7 */
+    const short iq = it / 4;      /* 0 or 1 */
+    const short ir = it % 4;      /* 0..3 */
+
+    const uint nb        = k / 256u;
+    const uint row_bytes = nb * 144u;        /* bytes per Q4_K row */
+    const uint row_u16   = row_bytes / 2u;   /* row stride in uint16 units */
+    const int  first_row = ((int)tgpig.x * NSG + sgitg) * NR0;
+
+    device const uchar *x0 = W + (uint)first_row * row_bytes;
+    device const float *y4 = x + ix * 256u + 64u * iq + 8u * ir;
+
+    float yl[16];
+    float yh[16];
+    float sumf[NR0] = {0.f, 0.f};
+
+    uint16_t sc16[4];
+    thread const uint8_t *sc8 = (thread const uint8_t *)sc16;
+
+    for (uint ib = ix; ib < nb; ib += 4) {
+        float4 sumy = {0.f, 0.f, 0.f, 0.f};
+        for (short i = 0; i < 8; ++i) {
+            yl[i + 0] = y4[i +   0]; sumy[0] += yl[i + 0];
+            yl[i + 8] = y4[i +  32]; sumy[1] += yl[i + 8];
+            yh[i + 0] = y4[i + 128]; sumy[2] += yh[i + 0];
+            yh[i + 8] = y4[i + 160]; sumy[3] += yh[i + 8];
+        }
+
+        device const uchar    *blk = x0 + ib * 144u;
+        device const uint16_t *sc  = (device const uint16_t *)(blk + 4)  + iq;
+        device const uint16_t *q1  = (device const uint16_t *)(blk + 16) + 16 * iq + 4 * ir;
+        device const half     *dh  = (device const half *)blk;
+
+        for (short row = 0; row < NR0; ++row) {
+            sc16[0] =  sc[0] & kmask1;
+            sc16[1] =  sc[2] & kmask1;
+            sc16[2] = ((sc[4] >> 0) & kmask2) | ((sc[0] & kmask3) >> 2);
+            sc16[3] = ((sc[4] >> 4) & kmask2) | ((sc[2] & kmask3) >> 2);
+
+            device const uint16_t *q2 = q1 + 32;
+
+            float4 acc1 = {0.f, 0.f, 0.f, 0.f};
+            float4 acc2 = {0.f, 0.f, 0.f, 0.f};
+            for (short i = 0; i < 4; ++i) {
+                acc1[0] += yl[2*i + 0] * (q1[i] & 0x000F);
+                acc1[1] += yl[2*i + 1] * (q1[i] & 0x0F00);
+                acc1[2] += yl[2*i + 8] * (q1[i] & 0x00F0);
+                acc1[3] += yl[2*i + 9] * (q1[i] & 0xF000);
+                acc2[0] += yh[2*i + 0] * (q2[i] & 0x000F);
+                acc2[1] += yh[2*i + 1] * (q2[i] & 0x0F00);
+                acc2[2] += yh[2*i + 8] * (q2[i] & 0x00F0);
+                acc2[3] += yh[2*i + 9] * (q2[i] & 0xF000);
+            }
+
+            sumf[row] += (float)dh[0] * ((acc1[0] + 1.f/256.f * acc1[1]) * sc8[0] +
+                                         (acc1[2] + 1.f/256.f * acc1[3]) * sc8[1] * 1.f/16.f +
+                                         (acc2[0] + 1.f/256.f * acc2[1]) * sc8[4] +
+                                         (acc2[2] + 1.f/256.f * acc2[3]) * sc8[5] * 1.f/16.f) -
+                         (float)dh[1] * (sumy[0]*sc8[2] + sumy[1]*sc8[3] + sumy[2]*sc8[6] + sumy[3]*sc8[7]);
+
+            q1 += row_u16;
+            sc += row_u16;
+            dh += row_u16;
+        }
+
+        y4 += 4 * 256;
+    }
+
+    for (short row = 0; row < NR0; ++row) {
+        if (first_row + row >= (int)m) break;
+        float sum_all = simd_sum(sumf[row]);
+        if (tiisg == 0) out[first_row + row] = sum_all;
+    }
+}
+
 kernel void q6k_matvec_sg(
     device const uchar *W   [[buffer(0)]],
     device const float *x   [[buffer(1)]],

--- a/notorch_metal.mm
+++ b/notorch_metal.mm
@@ -522,6 +522,7 @@ static id<MTLCommandQueue>         g_queue       = nil;
 static id<MTLComputePipelineState> g_q4k_pipe    = nil;
 static id<MTLComputePipelineState> g_q6k_pipe    = nil;
 static id<MTLComputePipelineState> g_q4k_sg_pipe = nil;   /* M3 simdgroup path */
+static id<MTLComputePipelineState> g_q4k_v3_pipe = nil;   /* v3 multi-row Q4_K (llama port) */
 static id<MTLComputePipelineState> g_q6k_sg_pipe = nil;
 static int                         g_use_sg      = 0;     /* 0 naive | 1 sg | 2 per-format auto (set in init) */
 static id<MTLComputePipelineState> g_rms_pipe    = nil;   /* M4 layer ops */
@@ -644,6 +645,14 @@ int nt_metal_init(void)
                     err ? err.localizedDescription.UTF8String : "(no error)");
             return 5;
         }
+        /* v3 multi-row Q4_K (optional — falls back to naive/sg if absent) */
+        id<MTLFunction> fn4v = [lib newFunctionWithName:@"q4k_matvec_v3"];
+        if (fn4v) {
+            g_q4k_v3_pipe = [g_device newComputePipelineStateWithFunction:fn4v error:&err];
+            if (!g_q4k_v3_pipe)
+                fprintf(stderr, "nt_metal_init: q4k_v3 pipeline state failed: %s\n",
+                        err ? err.localizedDescription.UTF8String : "(no error)");
+        }
         /* M4 layer-op pipelines */
         struct { NSString *name; id<MTLComputePipelineState> __strong *slot; } m4ops[] = {
             { @"rmsnorm_f32",     &g_rms_pipe  },
@@ -693,6 +702,7 @@ void nt_metal_shutdown(void)
     g_q4k_pipe    = nil;
     g_q6k_pipe    = nil;
     g_q4k_sg_pipe = nil;
+    g_q4k_v3_pipe = nil;
     g_q6k_sg_pipe = nil;
     g_rms_pipe = nil; g_rope_pipe = nil; g_silu_pipe = nil;
     g_add_pipe = nil; g_attn_pipe = nil; g_copy_pipe = nil;

--- a/notorch_metal.mm
+++ b/notorch_metal.mm
@@ -338,6 +338,88 @@ kernel void q6k_matvec_sg(
     if (lane == 0) out[tpig.y] = total;
 }
 
+/* v3 multi-row Q6_K — llama kernel_mul_mv_q6_K port under our single-x ABI.
+ * Same geometry as q4k_matvec_v3 (NSG simdgroups x NR0 rows), but the Q6_K
+ * lane split differs (tid=tiisg/2, ix=tiisg%2 — two block subsets per tid)
+ * and the 6-bit weight is reassembled from ql (4 low bits) + qh (2 high
+ * bits), centred by -32. block_q6_K = ql[128] qh[64] scales[16 int8] d[half]
+ * = 210 bytes. Reductions are fixed simd_sum trees: deterministic. */
+kernel void q6k_matvec_v3(
+    device const uchar *W   [[buffer(0)]],
+    device const float *x   [[buffer(1)]],
+    device       float *out [[buffer(2)]],
+    constant     uint  &k   [[buffer(3)]],
+    constant     uint  &m   [[buffer(4)]],
+    uint3  tgpig            [[threadgroup_position_in_grid]],
+    ushort tiisg           [[thread_index_in_simdgroup]],
+    ushort sgitg           [[simdgroup_index_in_threadgroup]])
+{
+    const short NSG = 2;     /* simdgroups per threadgroup */
+    const short NR0 = 2;     /* rows per simdgroup */
+    constexpr uint8_t kmask1 = 0x03, kmask2 = 0x0C, kmask3 = 0x30, kmask4 = 0xC0;
+
+    const uint nb        = k / 256u;
+    const uint row_bytes = nb * 210u;        /* bytes per Q6_K row */
+    const int  first_row = ((int)tgpig.x * NSG + sgitg) * NR0;
+    if (first_row >= (int)m) return;   /* tail threadgroup owns no rows (Codex: OOB W guard) */
+
+    const short tid = tiisg / 2;     /* 0..15 */
+    const short ix  = tiisg % 2;     /* 0 or 1 — alternating block subsets */
+    const short ip  = tid / 8;       /* 0 or 1 */
+    const short il  = tid % 8;       /* 0..7 */
+    const short l0  = 4 * il;
+    const short is  = 8 * ip + l0 / 16;
+    const short y_offset   = 128 * ip + l0;
+    const short q_offset_l =  64 * ip + l0;
+    const short q_offset_h =  32 * ip + l0;
+
+    device const uchar *x0 = W + (uint)first_row * row_bytes;
+
+    float yl[16];
+    float sumf[NR0] = {0.f, 0.f};
+
+    for (uint i = ix; i < nb; i += 2) {
+        device const float *y = x + i * 256u + y_offset;
+        for (short l = 0; l < 4; ++l) {
+            yl[4*l + 0] = y[l +  0];
+            yl[4*l + 1] = y[l + 32];
+            yl[4*l + 2] = y[l + 64];
+            yl[4*l + 3] = y[l + 96];
+        }
+
+        device const uchar  *blk = x0 + i * 210u;
+        device const uint8_t *q1 = (device const uint8_t *)(blk +   0) + q_offset_l;
+        device const uint8_t *q2 = q1 + 32;
+        device const uint8_t *qh = (device const uint8_t *)(blk + 128) + q_offset_h;
+        device const int8_t  *sc = (device const int8_t  *)(blk + 192) + is;
+        device const half    *dh = (device const half    *)(blk + 208);
+
+        for (short row = 0; row < NR0; ++row) {
+            if (first_row + row >= (int)m) break;   /* tail row: skip OOB W loads (Codex) */
+            float4 sums = {0.f, 0.f, 0.f, 0.f};
+            for (short l = 0; l < 4; ++l) {
+                sums[0] += yl[4*l + 0] * ((int8_t)((q1[l] & 0xF) | ((qh[l] & kmask1) << 4)) - 32);
+                sums[1] += yl[4*l + 1] * ((int8_t)((q2[l] & 0xF) | ((qh[l] & kmask2) << 2)) - 32);
+                sums[2] += yl[4*l + 2] * ((int8_t)((q1[l]  >> 4) | ((qh[l] & kmask3) << 0)) - 32);
+                sums[3] += yl[4*l + 3] * ((int8_t)((q2[l]  >> 4) | ((qh[l] & kmask4) >> 2)) - 32);
+            }
+            sumf[row] += (float)dh[0] * (sums[0]*sc[0] + sums[1]*sc[2] + sums[2]*sc[4] + sums[3]*sc[6]);
+
+            q1 += row_bytes;
+            q2 += row_bytes;
+            qh += row_bytes;
+            sc += row_bytes;
+            dh += row_bytes / 2u;   /* half units */
+        }
+    }
+
+    for (short row = 0; row < NR0; ++row) {
+        if (first_row + row >= (int)m) break;
+        float sum_all = simd_sum(sumf[row]);
+        if (tiisg == 0) out[first_row + row] = sum_all;
+    }
+}
+
 /* ── M4 — layer ops: the CPU fence-posts move onto the GPU ──────────────
  * rmsnorm / rope / silu·mul / residual add / single-token attention over
  * the KV cache. With these plus the matvecs, a whole decode layer encodes
@@ -525,6 +607,7 @@ static id<MTLComputePipelineState> g_q4k_pipe    = nil;
 static id<MTLComputePipelineState> g_q6k_pipe    = nil;
 static id<MTLComputePipelineState> g_q4k_sg_pipe = nil;   /* M3 simdgroup path */
 static id<MTLComputePipelineState> g_q4k_v3_pipe = nil;   /* v3 multi-row Q4_K (llama port) */
+static id<MTLComputePipelineState> g_q6k_v3_pipe = nil;   /* v3 multi-row Q6_K (llama port) */
 static id<MTLComputePipelineState> g_q6k_sg_pipe = nil;
 static int                         g_use_sg      = 0;     /* 0 naive | 1 sg | 2 per-format auto (set in init) */
 static int                         g_use_v3      = 0;     /* 1 = v3 multi-row Q4_K (NT_METAL_V3) */
@@ -656,6 +739,13 @@ int nt_metal_init(void)
                 fprintf(stderr, "nt_metal_init: q4k_v3 pipeline state failed: %s\n",
                         err ? err.localizedDescription.UTF8String : "(no error)");
         }
+        id<MTLFunction> fn6v = [lib newFunctionWithName:@"q6k_matvec_v3"];
+        if (fn6v) {
+            g_q6k_v3_pipe = [g_device newComputePipelineStateWithFunction:fn6v error:&err];
+            if (!g_q6k_v3_pipe)
+                fprintf(stderr, "nt_metal_init: q6k_v3 pipeline state failed: %s\n",
+                        err ? err.localizedDescription.UTF8String : "(no error)");
+        }
         /* M4 layer-op pipelines */
         struct { NSString *name; id<MTLComputePipelineState> __strong *slot; } m4ops[] = {
             { @"rmsnorm_f32",     &g_rms_pipe  },
@@ -707,6 +797,7 @@ void nt_metal_shutdown(void)
     g_q6k_pipe    = nil;
     g_q4k_sg_pipe = nil;
     g_q4k_v3_pipe = nil;
+    g_q6k_v3_pipe = nil;
     g_q6k_sg_pipe = nil;
     g_rms_pipe = nil; g_rope_pipe = nil; g_silu_pipe = nil;
     g_add_pipe = nil; g_attn_pipe = nil; g_copy_pipe = nil;
@@ -874,17 +965,20 @@ static int encode_matvec(id<MTLComputePipelineState> pipe, NSUInteger block_byte
      * Q6_K only; see nt_metal_init for the per-format A/B. */
     id<MTLComputePipelineState> sg_pipe =
         (block_bytes == 144u) ? g_q4k_sg_pipe : g_q6k_sg_pipe;
+    id<MTLComputePipelineState> v3_pipe =
+        (block_bytes == 144u) ? g_q4k_v3_pipe :
+        (block_bytes == 210u) ? g_q6k_v3_pipe : nil;
     uint32_t k_u32 = (uint32_t)k;
     int sg_on = sg_pipe && (g_use_sg == 1 || (g_use_sg == 2 && block_bytes == 210u));
-    int v3_on = g_use_v3 && g_q4k_v3_pipe && block_bytes == 144u;
+    int v3_on = g_use_v3 && v3_pipe;
     if (v3_on) {
-        /* v3 multi-row Q4_K: NSG simdgroups x NR0 rows each. Kernel uses
-         * threadgroup_position_in_grid, so dispatchThreadgroups (not Threads).
-         * setBytes m at index 4 for row bounds (tail threadgroup). */
+        /* v3 multi-row (Q4_K and Q6_K): NSG simdgroups x NR0 rows each. Kernel
+         * uses threadgroup_position_in_grid, so dispatchThreadgroups (not
+         * Threads). setBytes m at index 4 for row bounds (tail threadgroup). */
         uint32_t m_u32 = (uint32_t)m;
         const NSUInteger NSG = 2u, NR0 = 2u;
         NSUInteger ntg = ((NSUInteger)m + (NSG*NR0) - 1u) / (NSG*NR0);
-        [enc setComputePipelineState:g_q4k_v3_pipe];
+        [enc setComputePipelineState:v3_pipe];
         [enc setBuffer:bW          offset:W_off atIndex:0];
         [enc setBuffer:g_arena_in  offset:x_off atIndex:1];
         [enc setBuffer:g_arena_out offset:o_off atIndex:2];
@@ -1313,13 +1407,16 @@ static int matvec_slot(id<MTLComputePipelineState> naive_pipe,
         id<MTLCommandBuffer> cb; id<MTLComputeCommandEncoder> enc;
         int rc = op_enc(&cb, &enc); if (rc) return rc;
         uint32_t k_u32 = (uint32_t)k;
+        id<MTLComputePipelineState> v3_pipe =
+            (block_bytes == 144u) ? g_q4k_v3_pipe :
+            (block_bytes == 210u) ? g_q6k_v3_pipe : nil;
         int sg_on = sg_pipe && (g_use_sg == 1 || (g_use_sg == 2 && block_bytes == 210u));
-        int v3_on = g_use_v3 && g_q4k_v3_pipe && block_bytes == 144u;
+        int v3_on = g_use_v3 && v3_pipe;
         if (v3_on) {
             uint32_t m_u32 = (uint32_t)m;
             const NSUInteger NSG = 2u, NR0 = 2u;
             NSUInteger ntg = ((NSUInteger)m + (NSG*NR0) - 1u) / (NSG*NR0);
-            [enc setComputePipelineState:g_q4k_v3_pipe];
+            [enc setComputePipelineState:v3_pipe];
             [enc setBuffer:bW offset:W_off atIndex:0];
             [enc setBuffer:g_slot_buf offset:g_slot_tab[src_slot].off atIndex:1];
             [enc setBuffer:g_slot_buf offset:g_slot_tab[dst_slot].off atIndex:2];

--- a/notorch_metal.mm
+++ b/notorch_metal.mm
@@ -611,6 +611,7 @@ static id<MTLComputePipelineState> g_q6k_v3_pipe = nil;   /* v3 multi-row Q6_K (
 static id<MTLComputePipelineState> g_q6k_sg_pipe = nil;
 static int                         g_use_sg      = 0;     /* 0 naive | 1 sg | 2 per-format auto (set in init) */
 static int                         g_use_v3      = 0;     /* 1 = v3 multi-row Q4_K (NT_METAL_V3) */
+static int                         g_use_v3_q6   = 0;     /* 1 = v3 multi-row Q6_K (NT_METAL_V3, unless NT_METAL_V3_NOQ6) */
 static id<MTLComputePipelineState> g_rms_pipe    = nil;   /* M4 layer ops */
 static id<MTLComputePipelineState> g_rope_pipe   = nil;
 static id<MTLComputePipelineState> g_silu_pipe   = nil;
@@ -775,7 +776,15 @@ int nt_metal_init(void)
         g_use_sg = getenv("NT_METAL_SG") ? 1 : 0;
         if (getenv("NT_METAL_AUTO")) g_use_sg = 2;         /* per-format: sg on Q6_K only */
         if (getenv("NT_METAL_NAIVE")) g_use_sg = 0;
-        g_use_v3 = getenv("NT_METAL_V3") ? 1 : 0;          /* v3 multi-row Q4_K (M4 Pro tuning) */
+        g_use_v3 = getenv("NT_METAL_V3") ? 1 : 0;          /* v3 multi-row Q4_K — WINS on M4 Pro (gate+up +20%) */
+        /* q6k v3 is a SEPARATE opt-in (NT_METAL_V3_Q6=1), default OFF. A clean
+         * same-binary A/B on M4 Pro (tool b80lte1bv): naive 4.21 < q4k-v3-only
+         * 5.18, but q4k+q6k-v3 drops to 3.81 — the multi-row q6k geometry LOSES
+         * to naive for the Q6_K forms (ffn_down m=5120, byte-wise 6-bit unpack,
+         * not vectorised like q4k). Same lesson as the sg path: A18 multi-row
+         * wins do not transfer to M4 Pro. Kept correct + opt-in for A18/future
+         * geometry work; NT_METAL_V3=1 alone keeps the clean q4k-only win. */
+        g_use_v3_q6 = getenv("NT_METAL_V3_Q6") ? 1 : 0;
     }
 
     g_initialised = 1;
@@ -970,7 +979,7 @@ static int encode_matvec(id<MTLComputePipelineState> pipe, NSUInteger block_byte
         (block_bytes == 210u) ? g_q6k_v3_pipe : nil;
     uint32_t k_u32 = (uint32_t)k;
     int sg_on = sg_pipe && (g_use_sg == 1 || (g_use_sg == 2 && block_bytes == 210u));
-    int v3_on = g_use_v3 && v3_pipe;
+    int v3_on = v3_pipe && ((block_bytes == 144u) ? g_use_v3 : g_use_v3_q6);
     if (v3_on) {
         /* v3 multi-row (Q4_K and Q6_K): NSG simdgroups x NR0 rows each. Kernel
          * uses threadgroup_position_in_grid, so dispatchThreadgroups (not
@@ -1411,7 +1420,7 @@ static int matvec_slot(id<MTLComputePipelineState> naive_pipe,
             (block_bytes == 144u) ? g_q4k_v3_pipe :
             (block_bytes == 210u) ? g_q6k_v3_pipe : nil;
         int sg_on = sg_pipe && (g_use_sg == 1 || (g_use_sg == 2 && block_bytes == 210u));
-        int v3_on = g_use_v3 && v3_pipe;
+        int v3_on = v3_pipe && ((block_bytes == 144u) ? g_use_v3 : g_use_v3_q6);
         if (v3_on) {
             uint32_t m_u32 = (uint32_t)m;
             const NSUInteger NSG = 2u, NR0 = 2u;

--- a/notorch_metal.mm
+++ b/notorch_metal.mm
@@ -525,6 +525,7 @@ static id<MTLComputePipelineState> g_q4k_sg_pipe = nil;   /* M3 simdgroup path *
 static id<MTLComputePipelineState> g_q4k_v3_pipe = nil;   /* v3 multi-row Q4_K (llama port) */
 static id<MTLComputePipelineState> g_q6k_sg_pipe = nil;
 static int                         g_use_sg      = 0;     /* 0 naive | 1 sg | 2 per-format auto (set in init) */
+static int                         g_use_v3      = 0;     /* 1 = v3 multi-row Q4_K (NT_METAL_V3) */
 static id<MTLComputePipelineState> g_rms_pipe    = nil;   /* M4 layer ops */
 static id<MTLComputePipelineState> g_rope_pipe   = nil;
 static id<MTLComputePipelineState> g_silu_pipe   = nil;
@@ -682,6 +683,7 @@ int nt_metal_init(void)
         g_use_sg = getenv("NT_METAL_SG") ? 1 : 0;
         if (getenv("NT_METAL_AUTO")) g_use_sg = 2;         /* per-format: sg on Q6_K only */
         if (getenv("NT_METAL_NAIVE")) g_use_sg = 0;
+        g_use_v3 = getenv("NT_METAL_V3") ? 1 : 0;          /* v3 multi-row Q4_K (M4 Pro tuning) */
     }
 
     g_initialised = 1;
@@ -872,7 +874,23 @@ static int encode_matvec(id<MTLComputePipelineState> pipe, NSUInteger block_byte
         (block_bytes == 144u) ? g_q4k_sg_pipe : g_q6k_sg_pipe;
     uint32_t k_u32 = (uint32_t)k;
     int sg_on = sg_pipe && (g_use_sg == 1 || (g_use_sg == 2 && block_bytes == 210u));
-    if (sg_on) {
+    int v3_on = g_use_v3 && g_q4k_v3_pipe && block_bytes == 144u;
+    if (v3_on) {
+        /* v3 multi-row Q4_K: NSG simdgroups x NR0 rows each. Kernel uses
+         * threadgroup_position_in_grid, so dispatchThreadgroups (not Threads).
+         * setBytes m at index 4 for row bounds (tail threadgroup). */
+        uint32_t m_u32 = (uint32_t)m;
+        const NSUInteger NSG = 2u, NR0 = 2u;
+        NSUInteger ntg = ((NSUInteger)m + (NSG*NR0) - 1u) / (NSG*NR0);
+        [enc setComputePipelineState:g_q4k_v3_pipe];
+        [enc setBuffer:bW          offset:W_off atIndex:0];
+        [enc setBuffer:g_arena_in  offset:x_off atIndex:1];
+        [enc setBuffer:g_arena_out offset:o_off atIndex:2];
+        [enc setBytes:&k_u32 length:sizeof(uint32_t) atIndex:3];
+        [enc setBytes:&m_u32 length:sizeof(uint32_t) atIndex:4];
+        [enc dispatchThreadgroups:MTLSizeMake(ntg, 1, 1)
+              threadsPerThreadgroup:MTLSizeMake(32u*NSG, 1, 1)];
+    } else if (sg_on) {
         [enc setComputePipelineState:sg_pipe];
         [enc setBuffer:bW          offset:W_off atIndex:0];
         [enc setBuffer:g_arena_in  offset:x_off atIndex:1];

--- a/notorch_metal.mm
+++ b/notorch_metal.mm
@@ -1312,7 +1312,20 @@ static int matvec_slot(id<MTLComputePipelineState> naive_pipe,
         int rc = op_enc(&cb, &enc); if (rc) return rc;
         uint32_t k_u32 = (uint32_t)k;
         int sg_on = sg_pipe && (g_use_sg == 1 || (g_use_sg == 2 && block_bytes == 210u));
-        if (sg_on) {
+        int v3_on = g_use_v3 && g_q4k_v3_pipe && block_bytes == 144u;
+        if (v3_on) {
+            uint32_t m_u32 = (uint32_t)m;
+            const NSUInteger NSG = 2u, NR0 = 2u;
+            NSUInteger ntg = ((NSUInteger)m + (NSG*NR0) - 1u) / (NSG*NR0);
+            [enc setComputePipelineState:g_q4k_v3_pipe];
+            [enc setBuffer:bW offset:W_off atIndex:0];
+            [enc setBuffer:g_slot_buf offset:g_slot_tab[src_slot].off atIndex:1];
+            [enc setBuffer:g_slot_buf offset:g_slot_tab[dst_slot].off atIndex:2];
+            [enc setBytes:&k_u32 length:4 atIndex:3];
+            [enc setBytes:&m_u32 length:4 atIndex:4];
+            [enc dispatchThreadgroups:MTLSizeMake(ntg, 1, 1)
+                  threadsPerThreadgroup:MTLSizeMake(32u*NSG, 1, 1)];
+        } else if (sg_on) {
             [enc setComputePipelineState:sg_pipe];
             [enc setBuffer:bW offset:W_off atIndex:0];
             [enc setBuffer:g_slot_buf offset:g_slot_tab[src_slot].off atIndex:1];

--- a/tests/test_parliament_elect.c
+++ b/tests/test_parliament_elect.c
@@ -1,0 +1,92 @@
+/* test_parliament_elect.c — isolated gate for the GPU parliament election.
+ *  A) parliament_votes: vdot[e]=dot(w_vote_e,x) vs CPU dot, bar 1e-3.
+ *  B) parliament_elect fed the CPU vdot (isolates the election logic from the
+ *     dot reduction-order noise): EMA consensus, variable k, hard top-k, softmax
+ *     must match parliament_elect() (doe.c) — same selected SET (exact), same k,
+ *     consensus and gate weights within 1e-5.
+ *
+ * build (neo): cc -DUSE_METAL -O2 tests/test_parliament_elect.c notorch_metal.o \
+ *   -framework Metal -framework Foundation -lc++ -lm -o test_parliament_elect
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <unistd.h>
+#include "../notorch_metal.h"
+
+#define NE   8
+#define D    256
+#define MINE 2
+
+static float wval(int e, int j) { return 0.02f * sinf(0.011f*(float)(e*9173 + j*53)); }
+
+int main(void) {
+    if (!nt_metal_available()) { fprintf(stderr, "metal unavailable\n"); return 2; }
+
+    size_t pg = (size_t)getpagesize();
+    size_t wbytes = (size_t)NE * D * sizeof(float);
+    size_t bytes  = (wbytes + pg - 1) / pg * pg;
+    float *arena = NULL;
+    if (posix_memalign((void**)&arena, pg, bytes) != 0) { perror("posix_memalign"); return 2; }
+    memset(arena, 0, bytes);
+    for (int e = 0; e < NE; e++) for (int j = 0; j < D; j++) arena[(size_t)e*D + j] = wval(e, j);
+
+    float x[D];      for (int j = 0; j < D; j++) x[j] = 0.1f * cosf(0.07f*(float)j);
+    float alive[NE] = {1,1,1,0,1,1,0,1};                 /* 6 alive, experts 3 & 6 dead */
+    float res[NE];   for (int e = 0; e < NE; e++) res[e] = 0.1f * (0.3f*sinf(0.9f*(float)e));
+    float cons0 = 0.5f;
+
+    /* ---- CPU reference: dot, then parliament_elect() math verbatim ---- */
+    float vdot_cpu[NE];
+    for (int e = 0; e < NE; e++) { float s=0; for (int j=0;j<D;j++) s += arena[(size_t)e*D+j]*x[j]; vdot_cpu[e]=s; }
+    float votes[NE]; int n_alive = 0;
+    for (int e = 0; e < NE; e++) { if (alive[e]!=0.0f){ votes[e]=vdot_cpu[e]+res[e]; n_alive++; } else votes[e]=-1e30f; }
+    float mean=0; for (int e=0;e<NE;e++) if (alive[e]!=0.0f) mean+=votes[e]; mean/=n_alive;
+    float var=0;  for (int e=0;e<NE;e++) if (alive[e]!=0.0f){ float d=votes[e]-mean; var+=d*d; } var/=n_alive;
+    float cnew=sqrtf(var+1e-8f)/(fabsf(mean)+1.0f); if (cnew>1.0f) cnew=1.0f;
+    float c_cpu=0.9f*cons0+0.1f*cnew;
+    int k_cpu=(int)(n_alive*(1.0f-c_cpu)); if (k_cpu<MINE) k_cpu=MINE; if (k_cpu>n_alive) k_cpu=n_alive;
+    int used[NE]={0}; int sel[NE]; float selv[NE];
+    for (int ki=0;ki<k_cpu;ki++){ float bv=-1e30f;int bi=0; for(int e=0;e<NE;e++) if(alive[e]!=0.0f&&!used[e]&&votes[e]>bv){bv=votes[e];bi=e;} sel[ki]=bi;selv[ki]=votes[bi];used[bi]=1; }
+    float mx=selv[0]; for(int ki=1;ki<k_cpu;ki++) if(selv[ki]>mx)mx=selv[ki];
+    float sum=0; for(int ki=0;ki<k_cpu;ki++){ selv[ki]=expf(selv[ki]-mx); sum+=selv[ki]; }
+    float gate_cpu[NE]={0}; for(int ki=0;ki<k_cpu;ki++) gate_cpu[sel[ki]]=selv[ki]/sum;
+
+    /* ---- GPU ---- */
+    if (nt_metal_register_region(arena, bytes) != 0) { fprintf(stderr, "register failed\n"); return 2; }
+    enum { S_X=0, S_VDOT=1, S_RES=2, S_ALIVE=3, S_CONS=4, S_GATE=5 };
+    if (nt_metal_slot_alloc(S_X,(uint64_t)D*4)||nt_metal_slot_alloc(S_VDOT,(uint64_t)NE*4)||
+        nt_metal_slot_alloc(S_RES,(uint64_t)NE*4)||nt_metal_slot_alloc(S_ALIVE,(uint64_t)NE*4)||
+        nt_metal_slot_alloc(S_CONS,(uint64_t)4*4)||nt_metal_slot_alloc(S_GATE,(uint64_t)NE*4)) { fprintf(stderr,"alloc failed\n"); return 2; }
+    nt_metal_slot_upload(S_X, x, (uint64_t)D*4);
+    nt_metal_slot_upload(S_RES, res, (uint64_t)NE*4);
+    nt_metal_slot_upload(S_ALIVE, alive, (uint64_t)NE*4);
+
+    /* A) votes kernel vs CPU dot */
+    int rc = nt_metal_parliament_votes(arena, S_X, S_VDOT, D, NE);
+    if (rc) { fprintf(stderr,"votes rc=%d\n", rc); return 2; }
+    float vdot_gpu[NE]; nt_metal_slot_download(S_VDOT, vdot_gpu, (uint64_t)NE*4);
+    double vmax=0; for(int e=0;e<NE;e++){ double d=fabs((double)vdot_gpu[e]-(double)vdot_cpu[e]); if(d>vmax)vmax=d; }
+    printf("[votes] max|vdot_gpu - vdot_cpu| = %.3e\n", vmax);
+
+    /* B) elect fed the CPU vdot — isolate election logic */
+    float cons4[4]={cons0,0,0,0};
+    nt_metal_slot_upload(S_VDOT, vdot_cpu, (uint64_t)NE*4);
+    nt_metal_slot_upload(S_CONS, cons4, (uint64_t)4*4);
+    rc = nt_metal_parliament_elect(S_VDOT, S_RES, S_ALIVE, S_CONS, S_GATE, NE, 0, MINE);
+    if (rc) { fprintf(stderr,"elect rc=%d\n", rc); return 2; }
+    float gate_gpu[NE]; nt_metal_slot_download(S_GATE, gate_gpu, (uint64_t)NE*4);
+    float cons_gpu[4]; nt_metal_slot_download(S_CONS, cons_gpu, (uint64_t)4*4);
+
+    int k_gpu=0; for(int e=0;e<NE;e++) if(gate_gpu[e]!=0.0f) k_gpu++;
+    int set_match=1; for(int e=0;e<NE;e++) if((gate_cpu[e]!=0.0f)!=(gate_gpu[e]!=0.0f)) set_match=0;
+    double gmax=0; for(int e=0;e<NE;e++){ double d=fabs((double)gate_gpu[e]-(double)gate_cpu[e]); if(d>gmax)gmax=d; }
+    double cdiff=fabs((double)cons_gpu[0]-(double)c_cpu);
+    printf("[elect] k_cpu=%d k_gpu=%d  set_match=%d  max|gate|diff=%.3e  cons diff=%.3e (c_cpu=%.6f)\n",
+           k_cpu, k_gpu, set_match, gmax, cdiff, c_cpu);
+
+    int pass = (vmax<1e-3) && (k_gpu==k_cpu) && set_match && (gmax<1e-5) && (cdiff<1e-5);
+    printf("%s\n", pass ? "PASS" : "FAIL");
+    return pass ? 0 : 1;
+}

--- a/tests/test_parliament_inject.c
+++ b/tests/test_parliament_inject.c
@@ -1,0 +1,96 @@
+/* test_parliament_inject.c — isolated gate for nt_metal_parliament_inject.
+ * Builds a tiny registered expert arena (ne=4, D=512, rank=16), known x/gate,
+ * runs the GPU inject and compares to the CPU reference (the doe parliament
+ * inject math). The GPU reduction order differs from the CPU sequential sum,
+ * so the bar is max|Δ| < 1e-3, not bit-identical. Also checks the all-gate-0
+ * no-op (dead/unelected experts must contribute exactly nothing).
+ *
+ * build (neo / Apple Silicon):
+ *   clang++ -DUSE_METAL -fobjc-arc -c notorch_metal.mm -o notorch_metal.o
+ *   cc -DUSE_METAL -O2 tests/test_parliament_inject.c notorch_metal.o \
+ *      -framework Metal -framework Foundation -lc++ -lm -o test_parliament_inject
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <unistd.h>
+#include "../notorch_metal.h"
+
+#define NE   4
+#define D    512
+#define RANK 16
+
+/* deterministic LoRA-scale weights so CPU and GPU read identical bytes */
+static float bval(int e, int r, int j) { return 0.01f * sinf(0.013f*(float)(e*7919 + r*131 + j)); }
+static float aval(int e, int i, int r) { return 0.01f * cosf(0.017f*(float)(e*5003 + i*97 + r)); }
+
+int main(void) {
+    if (!nt_metal_available()) { fprintf(stderr, "metal unavailable\n"); return 2; }
+
+    size_t per_expert   = (size_t)2 * RANK * D;            /* B rank*D + A D*rank */
+    size_t layer_floats = (size_t)NE * D + (size_t)NE * per_expert;
+    size_t pg    = (size_t)getpagesize();
+    size_t bytes = (layer_floats * sizeof(float) + pg - 1) / pg * pg;
+
+    float *arena = NULL;
+    if (posix_memalign((void**)&arena, pg, bytes) != 0 || !arena) { perror("posix_memalign"); return 2; }
+    memset(arena, 0, bytes);
+
+    /* layout: [ w_vote NE*D | per-expert (B rank*D, A D*rank) x NE ] */
+    float *experts = arena + (size_t)NE * D;
+    for (int e = 0; e < NE; e++) {
+        float *Bb = experts + (size_t)e * per_expert;          /* [rank, D] */
+        float *Ab = Bb + (size_t)RANK * D;                     /* [D, rank] */
+        for (int r = 0; r < RANK; r++) for (int j = 0; j < D; j++) Bb[(size_t)r*D + j] = bval(e,r,j);
+        for (int i = 0; i < D; i++) for (int r = 0; r < RANK; r++) Ab[(size_t)i*RANK + r] = aval(e,i,r);
+    }
+
+    float x[D], gate[NE] = { 0.5f, 0.0f, 0.3f, 0.2f };         /* expert 1 unelected */
+    for (int j = 0; j < D; j++) x[j] = 0.1f * cosf(0.05f * (float)j);
+    float alpha = 0.1f;
+
+    /* CPU reference — exactly the doe parliament inject math */
+    float xref[D]; memcpy(xref, x, sizeof(x));
+    for (int e = 0; e < NE; e++) {
+        if (gate[e] == 0.0f) continue;
+        float *Bb = experts + (size_t)e * per_expert;
+        float *Ab = Bb + (size_t)RANK * D;
+        float tmp[RANK];
+        for (int r = 0; r < RANK; r++) { float s = 0.0f; for (int j = 0; j < D; j++) s += Bb[(size_t)r*D+j]*x[j]; tmp[r] = s; }
+        for (int i = 0; i < D; i++) {
+            float s = 0.0f; for (int r = 0; r < RANK; r++) s += Ab[(size_t)i*RANK+r]*tmp[r];
+            xref[i] += alpha * gate[e] * s;
+        }
+    }
+
+    /* GPU path */
+    if (nt_metal_register_region(arena, bytes) != 0) { fprintf(stderr, "register_region failed\n"); return 2; }
+    enum { SLOT_X = 0, SLOT_TMP = 1, SLOT_GATE = 2 };
+    if (nt_metal_slot_alloc(SLOT_X,   (uint64_t)D*4)        ||
+        nt_metal_slot_alloc(SLOT_TMP, (uint64_t)NE*RANK*4)  ||
+        nt_metal_slot_alloc(SLOT_GATE,(uint64_t)NE*4)) { fprintf(stderr, "slot_alloc failed\n"); return 2; }
+    nt_metal_slot_upload(SLOT_X,    x,    (uint64_t)D*4);
+    nt_metal_slot_upload(SLOT_GATE, gate, (uint64_t)NE*4);
+    int rc = nt_metal_parliament_inject(SLOT_X, SLOT_TMP, SLOT_GATE, arena, D, RANK, NE, alpha);
+    if (rc) { fprintf(stderr, "parliament_inject rc=%d\n", rc); return 2; }
+    float xg[D]; nt_metal_slot_download(SLOT_X, xg, (uint64_t)D*4);
+
+    double maxd = 0.0; int argi = 0;
+    for (int i = 0; i < D; i++) { double d = fabs((double)xg[i] - (double)xref[i]); if (d > maxd) { maxd = d; argi = i; } }
+    printf("[inject] max|x_gpu - x_cpu| = %.3e at i=%d (xg=%.6f xref=%.6f)\n", maxd, argi, xg[argi], xref[argi]);
+
+    /* all-gate-0 no-op: dead/unelected experts contribute exactly nothing */
+    float zgate[NE] = {0,0,0,0};
+    nt_metal_slot_upload(SLOT_X,    x,     (uint64_t)D*4);
+    nt_metal_slot_upload(SLOT_GATE, zgate, (uint64_t)NE*4);
+    rc = nt_metal_parliament_inject(SLOT_X, SLOT_TMP, SLOT_GATE, arena, D, RANK, NE, alpha);
+    if (rc) { fprintf(stderr, "parliament_inject(zero) rc=%d\n", rc); return 2; }
+    float xz[D]; nt_metal_slot_download(SLOT_X, xz, (uint64_t)D*4);
+    double maxz = 0.0; for (int i = 0; i < D; i++) { double d = fabs((double)xz[i]-(double)x[i]); if (d > maxz) maxz = d; }
+    printf("[inject] all-gate-0 max|x_out - x_in| = %.3e (must be 0)\n", maxz);
+
+    int pass = (maxd < 1e-3) && (maxz == 0.0);
+    printf("%s\n", pass ? "PASS" : "FAIL");
+    return pass ? 0 : 1;
+}


### PR DESCRIPTION
Brings the active Metal speed work into main: q4k_matvec_v3 + q6k_matvec_v3 (opt-in NT_METAL_V3 / NT_METAL_V3_Q6, naive stays default) and the DOE parliament GPU kernels (election + LoRA inject) + tests. notorch_metal.{h,mm} + tests only — CPU/BLAS build unaffected. This is the canonical home of the kernels doe already vendors (doe's notorch_metal.mm is byte-identical to this branch). Developed and tested on feat/q4k-v3 (q4k-v3 + parliament-GPU milestones); merges clean to main. Using --merge (not squash) to preserve commit history and keep feat/q4k-v3 mergeable for ongoing work.