### PR TITLE
docs: tick op 34 TODO done + NOTORCHLOG entry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,9 +215,8 @@ docstring when you next pass through.
   `notorch_cuda.cu:824`.
 - Fix the `notorch.h:653` alpha-format docstring (raw float bytes, not
   `alpha*1000`).
-- Implement `nt_rrpram_broadcast_attention` (`NT_OP_RRPRAM_BCAST` 34)
-  on the C side — declared in `notorch.h:126,442` but no implementation
-  in `notorch.c`. JS edition currently stops parity at op 33 awaiting
-  this.
+- JS edition: implement op 34 `nt_rrpram_broadcast_attention` for parity —
+  the C reference landed 2026-06-16 (canonical Janus pattern); the JS port
+  currently stops at op 33.
 - Vary RNG seed per cell in `phase7_eval.py` so the first sampled token
   isn't identical across cells with the same prompt.

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,15 @@ Newest entries on top.
 
 ---
 
+## 2026-06-16 — op 34 nt_rrpram_broadcast_attention implemented (closes a standing TODO)
+
+NT_OP_RRPRAM_BCAST (34) was declared in notorch.h with no C implementation —
+the op was unusable from C and the JS port stalled at op 33. Implemented the
+canonical Janus broadcast pattern (mid[h,r] = Σ_t x[t]·Wr_a[h], sc=1/sqrt(D))
+with full forward + backward, plus a 348-line adversarial test. Verified:
+sentinel forward bit-exact (max_diff=0), backward finite-diff (d_wr/d_x/d_v)
+correct, suite 73/73 green. (PR #13.)
+
 ## 2026-06-16 — infer_llama: GGUF-embedded BPE tokenizer (CPU path was byte-level)
 
 examples/infer_llama.c tokenized byte-level — each prompt byte fed as a token


### PR DESCRIPTION
Follow-up to PR #13. Removes the now-false 'nt_rrpram_broadcast_attention has no C impl' TODO (kept a JS-parity follow-up item) and adds the NOTORCHLOG entry. Docs only.