### PR TITLE
nt_seq_gate: per-position mechanism gate op (op 36)

### DIFF
--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,19 @@ Newest entries on top.
 
 ---
 
+## 2026-06-28 — nt_seq_gate: per-position mechanism gate (op 36)
+
+Added `nt_seq_gate(x_idx, g_idx, T, nm, gi)` — `out[t,d] = x[t,d] * gate[t*nm+gi]`, the
+per-position scalar-over-block multiply PostGPT-Q's triple attention needs to gate each
+mechanism (Content / RRPRAM / Janus) by its own learned sigmoid before the concat. `x`
+is `[T, B]` (B = x.len/T), `gate` is `[T, nm]`, `gi` selects the gate column. Backward
+flows to `x` (`dout*gate`) and to gate column `gi` (`Σ_d dout[t,d]*x[t,d]`); mirrors
+`NT_OP_MUL` plus a reduction. This lifted PostGPT-Q's training loop off PyTorch onto the
+notorch tape (Operation Napalm-2 — github.com/ariannamethod/q). Proof: `make` clean
+(pre-existing unused-symbol warnings only), `./notorch_test` 49/49 passed, 0 failed
+(48 + `test_seq_gate`, which checks the gated values and that grads reach both `x` and
+the gate).
+
 ## 2026-06-27 — nt_relu: plain ReLU activation (op 35)
 
 Added `nt_relu(int x_idx)` — `y = max(0, x)` forward, `dy/dx = (y > 0) ? 1 : 0`

--- a/notorch.c
+++ b/notorch.c
@@ -759,6 +759,36 @@ void nt_tape_backward(int loss_idx) {
             break;
         }
 
+        case NT_OP_SEQ_GATE: {
+            /* out[t,d] = x[t,d] * g[t,gi];
+             * dx[t,d] = dout[t,d] * g[t,gi];  dg[t,gi] = Σ_d dout[t,d] * x[t,d] */
+            if (e->parent1 >= 0 && e->parent2 >= 0) {
+                nt_tape_entry* px = &g_tape.entries[e->parent1];
+                nt_tape_entry* pg = &g_tape.entries[e->parent2];
+                int T = (int)e->aux, nm = (int)e->aux2, gi = (int)e->aux3;
+                int B = (T > 0) ? out_len / T : 0;
+                nt_tensor_sync_cpu(px->output);
+                nt_tensor_sync_cpu(pg->output);
+                float* dx = (float*)calloc(out_len, sizeof(float));
+                float* dg = (float*)calloc(pg->output->len, sizeof(float));
+                if (dx && dg) {
+                    for (int t = 0; t < T; t++) {
+                        float gv = pg->output->data[t * nm + gi];
+                        float acc = 0.0f;
+                        for (int d = 0; d < B; d++) {
+                            dx[t * B + d] = dout[t * B + d] * gv;
+                            acc += dout[t * B + d] * px->output->data[t * B + d];
+                        }
+                        dg[t * nm + gi] = acc;
+                    }
+                    tape_acc_grad(e->parent1, dx, out_len);
+                    tape_acc_grad(e->parent2, dg, pg->output->len);
+                }
+                free(dx); free(dg);
+            }
+            break;
+        }
+
         case NT_OP_SCALE_BY_T: {
             /* y = a[0] * x; gx = a[0] * dout; ga = sum(dout * x) */
             if (e->parent1 >= 0 && e->parent2 >= 0) {
@@ -3346,6 +3376,28 @@ int nt_relu(int x_idx) {
         out->data[i] = x > 0.0f ? x : 0.0f;
     }
     int idx = nt_tape_record(out, NT_OP_RELU, x_idx, -1, 0);
+    nt_tensor_free(out);
+    return idx;
+}
+
+int nt_seq_gate(int x_idx, int g_idx, int T, int nm, int gi) {
+    if (x_idx < 0 || g_idx < 0 || T <= 0) return -1;
+    nt_tape_entry* px = &g_tape.entries[x_idx];
+    nt_tape_entry* pg = &g_tape.entries[g_idx];
+    int n = px->output->len;
+    int B = n / T;
+    nt_tensor* out = nt_tensor_new(n);
+    if (!out) return -1;
+    /* parents may be GPU-resident with stale CPU mirrors — sync before read. */
+    nt_tensor_sync_cpu(px->output);
+    nt_tensor_sync_cpu(pg->output);
+    for (int t = 0; t < T; t++) {
+        float gv = pg->output->data[t * nm + gi];
+        for (int d = 0; d < B; d++)
+            out->data[t * B + d] = px->output->data[t * B + d] * gv;
+    }
+    int idx = nt_tape_record4(out, NT_OP_SEQ_GATE, x_idx, g_idx, -1,
+                              (float)T, (float)nm, (float)gi, 0.0f);
     nt_tensor_free(out);
     return idx;
 }

--- a/notorch.h
+++ b/notorch.h
@@ -124,6 +124,7 @@ void nt_tensor_print(const nt_tensor* t, const char* name);
 #define NT_OP_RRPRAM_LR     33   // low-rank RRPRAM (Wr = Wr_a × Wr_b packed in one tensor)
 #define NT_OP_RRPRAM_BCAST  34   // broadcast RRPRAM — mid[h,r] = Σ_t x[t]·Wr_a[h] (canonical Janus pattern, sc=1/sqrt(D))
 #define NT_OP_RELU          35   // y = max(0, x) — rectified linear unit
+#define NT_OP_SEQ_GATE      36   // out[t,d] = x[t,d] * gate[t,gi] — per-position mechanism gate
 
 typedef struct {
     nt_tensor* output;          // forward result
@@ -356,6 +357,12 @@ int nt_sigmoid(int x_idx);
 
 // ReLU activation: y = max(0, x)
 int nt_relu(int x_idx);
+
+// Per-position mechanism gate (q triple-attention): out[t,d] = x[t,d] * gate[t*nm+gi].
+// x is [T, B] (B = x.len/T), gate is [T, nm]; gi selects which gate column scales this
+// mechanism's block. Backward flows to x (dout*gate) and to gate column gi
+// (Σ_d dout[t,d]*x[t,d]); other gate columns get zero gradient.
+int nt_seq_gate(int x_idx, int g_idx, int T, int nm, int gi);
 
 // Broadcast scale: y[i] = a[0] * x[i], where a is a scalar tensor (shape [1]).
 // Grad flows to both x (gx = a*gy) and a (ga = sum(gy*x)).

--- a/tests/test_notorch.c
+++ b/tests/test_notorch.c
@@ -311,6 +311,38 @@ static void test_relu(void) {
     PASS("relu");
 }
 
+static void test_seq_gate(void) {
+    nt_tape_start();
+    nt_tensor* x = nt_tensor_new(6);     // [T=2, B=3]
+    for (int i = 0; i < 6; i++) x->data[i] = (float)(i + 1);
+    int x_idx = nt_tape_param(x);
+    nt_tensor* g = nt_tensor_new(4);     // [T=2, nm=2]
+    g->data[0] = 0.5f; g->data[1] = 2.0f;
+    g->data[2] = 0.5f; g->data[3] = 3.0f;
+    int g_idx = nt_tape_param(g);
+    int y_idx = nt_seq_gate(x_idx, g_idx, 2, 2, 1);   // gate column gi=1
+
+    nt_tape_entry* ey = &nt_tape_get()->entries[y_idx];
+    ASSERT_CLOSE(ey->output->data[0], 2.0f,  1e-5f, "seq_gate t0d0=1*2");
+    ASSERT_CLOSE(ey->output->data[2], 6.0f,  1e-5f, "seq_gate t0d2=3*2");
+    ASSERT_CLOSE(ey->output->data[3], 12.0f, 1e-5f, "seq_gate t1d0=4*3");
+    ASSERT_CLOSE(ey->output->data[5], 18.0f, 1e-5f, "seq_gate t1d2=6*3");
+
+    int loss_idx = nt_cross_entropy(y_idx, 5);
+    nt_tape_backward(loss_idx);
+    nt_tape_entry* ex = &nt_tape_get()->entries[x_idx];
+    nt_tape_entry* eg = &nt_tape_get()->entries[g_idx];
+    ASSERT(ex->grad != NULL && eg->grad != NULL, "seq_gate grads exist");
+    float gn = 0.0f;
+    for (int i = 0; i < eg->grad->len; i++) gn += fabsf(eg->grad->data[i]);
+    ASSERT(gn > 1e-9f, "seq_gate gate grad nonzero");
+
+    nt_tape_clear();
+    nt_tensor_free(x);
+    nt_tensor_free(g);
+    PASS("seq_gate");
+}
+
 static void test_softmax(void) {
     nt_tape_start();
     nt_tensor* x = nt_tensor_new(3);
@@ -1352,6 +1384,7 @@ int main(void) {
     printf("\n[Ops]\n");
     test_silu();
     test_relu();
+    test_seq_gate();
     test_softmax();
     test_rmsnorm();
 


### PR DESCRIPTION
PostGPT-Q's triple attention gates each mechanism (Content/RRPRAM/Janus) by its own learned sigmoid before concat: out[t,d] = x[t,d] * gate[t*nm+gi]. notorch had no per-position scalar-over-block multiply. Forward + backward (grad to x and to gate column gi), mirrors NT_OP_MUL with a reduction. Lets PostGPT-Q's training loop run on the notorch tape with zero PyTorch (Operation Napalm-2).

notorch_test 49/49 (48 + test_seq_gate), 0 failed.