### PR TITLE
tri-version op parity + hygiene → v4.2.0 (JS op 34/36, Termux, gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,22 @@ test_vision
 *.log
 infer_janus_sonar_chain
 nanodurov.html
+
+# compiled test / example binaries (sources kept; binaries are build output)
+tests/test_*
+tests/bench_*
+!tests/*.c
+!tests/*.h
+!tests/*.sh
+examples/infer_*
+examples/train_*
+!examples/*.c
+!examples/*.h
+!examples/*.sh
+!examples/*.txt
+
+# local tooling / editor state
+.claude/
+
+# stepped checkpoints (e.g. model.bin.step100)
+*.bin.*

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,37 @@ Newest entries on top.
 
 ---
 
+## 2026-07-15 — JS edition: op 34 RRPRAM_BCAST + op 36 SEQ_GATE ported (tri-version parity)
+
+The JS edition (`js-edition/notorch.js`) had stalled at op 33 while the C canon advanced
+to op 36 (RRPRAM_BCAST 2026-06-16, RELU 2026-06-27, SEQ_GATE 2026-06-28). RELU was already
+present under JS-local opcode 105; the two genuinely-missing ops are now ported, closing
+C↔JS op parity at the full 0–36 set.
+
+Ported (forward + backward, 1:1 with C semantics):
+- `seqGate(x, g, T, nm, gi)` — op 36 SEQ_GATE, per-position mechanism gate
+  `out[t,d] = x[t,d]·g[t,gi]`. Mirrors C `nt_seq_gate` (notorch.c:3383 fwd / :762 bwd).
+- `rrpramBroadcastAttention(wr, x, v, T, E, nH, hD, rank)` — op 34 RRPRAM_BCAST, canonical
+  Janus broadcast pattern: `mid[h,r] = Σ_t Σ_e x·Wr_a` (one mid per head, broadcast across
+  queries), causal-softmax scores scaled `1/√hD`. Mirrors C `nt_rrpram_broadcast_attention`
+  (notorch.c:3796 fwd / :1578 bwd). `rank` is passed explicitly (ctx ≥ T ⇒ not derivable
+  from `Wr.len`). OP table gains `RRPRAM_BCAST:34`, `SEQ_GATE:36`.
+
+Proof (neo, node v25.9.0): a C emitter (`parity_emit.c`, built against canonical
+`notorch.c`) and a JS runner ran both ops fwd+bwd on identical hardcoded inputs
+(dout = all-ones, loss = Σ out) and diffed —
+- op 36 SEQ_GATE — bit-identical to C: `SG_OUT/DX/DG` maxAbs = 0.0.
+- op 34 RRPRAM_BCAST — within float32 rounding: `RB_OUT` 1.5e-8, `RB_DWR` 2.3e-10,
+  `RB_DX` 1.5e-11, `RB_DV` 6.0e-8 (float32-vs-float64 intermediate accumulation).
+- Independent JS finite-difference grad-check (ε=1e-3): both ops, all groups `fails=0`.
+
+`notorch_test` full suite 49/49 on neo (Accelerate). The Termux edition (a platform
+recipe + demo that builds `../../notorch.c` directly — no core fork) was rebuilt and
+generated against the current canon: parity by construction. README parity table
+(`js-edition/README.md`) and main-README op-count synced (37 ops, IDs 0–36); js caveats
+corrected (op parity through 36). Tree hygiene: `.gitignore` hardened so compiled
+test/example binaries and editor state stay out of `git status`.
+
 ## 2026-07-07 — gguf.c: harden parser error-paths (F-1 NULL-deref + latent data_size wrap)
 
 An error-path hardening pass on the GGUF parser (untrusted-binary surface). One real

--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ each is a single self-contained C file under `examples/` (~550–610 LOC) with i
 
 ## autograd
 
-the backward pass supports **34 operation types** (op IDs 0–34, each with a `NT_OP_*` constant; op 34 RRPRAM-broadcast is declared, implementation pending). the tape records operations during forward, then backward walks it in reverse computing local gradients via the chain rule. standard reverse-mode AD.
+the backward pass supports **37 operation types** (op IDs 0–36, each with a `NT_OP_*` constant). the tape records operations during forward, then backward walks it in reverse computing local gradients via the chain rule. standard reverse-mode AD.
 
 **gradient checking**: every op is verified against finite differences (`(f(x+h) - f(x-h)) / 2h`). relative error tolerances from 0.01 to 0.3 depending on op complexity. all pass. including the annoying ones — GEGLU, SwiGLU, multi-head attention with multi-path gradients through Q/K/V, BitLinear with STE identity passthrough.
 
@@ -864,7 +864,7 @@ if you trained something on notorch and it's not here, open a PR.
 > *"the logic of memory without the weight of framework"*
 > — `js-edition/notorch.js`, line 1
 
-a single-file pure-JavaScript port of notorch for the browser. WebGPU when available, V8-optimised CPU fallback (Math.fround f32 hint) when not. zero npm dependencies. live at `js-edition/notorch.js` (~3580 LOC).
+a single-file pure-JavaScript port of notorch for the browser. WebGPU when available, V8-optimised CPU fallback (Math.fround f32 hint) when not. zero npm dependencies. live at `js-edition/notorch.js` (~3900 LOC).
 
 ### what it ships (feature parity with the C lib at small scale)
 
@@ -899,7 +899,7 @@ autograd works, Chuck works, sampler works, everything works.
 ### caveats
 
 - WebGPU paths are code-correct but were not runtime-verified in node (no headless WebGPU). real validation needs a browser. CPU path passes everywhere `node` runs.
-- GQA, BitLinear/BitNet, low-rank RRPRAM, GEGLU, scale-by-t and friends are now ported (op parity through op 33); op 34 RRPRAM-broadcast awaits the C-side implementation. `loadGGUF` (GGUF v3, F16+F32) and `loadSafetensors` are wired.
+- GQA, BitLinear/BitNet, low-rank RRPRAM, GEGLU, scale-by-t and friends are ported (op parity through op 36 — the full C op set); op 34 RRPRAM-broadcast and op 36 SEQ_GATE landed 2026-07-15, C-parity + finite-diff verified. `loadGGUF` (GGUF v3, F16+F32) and `loadSafetensors` are wired.
 - generic transpose backward covers 2D and 3D `(1, 2)` swap (sufficient for attention; not fully general).
 - async batching of multiple GPU ops into one submit is partially achieved through the buffer pool, but no explicit op queue. impact only matters once multiple GPU ops chain.
 

--- a/js-edition/README.md
+++ b/js-edition/README.md
@@ -137,8 +137,8 @@ Tokenizers: `CharTokenizer`, `BPETokenizer`.
 
 ## Op parity table
 
-35 op codes (matching C `notorch.h:92-126` numbering) + 8 JS-specific
-extensions.
+37 C op codes (0–36, matching C `notorch.h:91-127` numbering) + 8 JS-specific
+extension codes (100+). RELU (C op 35) runs under JS-local opcode 105.
 
 | OP | # | Forward method | Notes |
 |----|---|----------------|-------|
@@ -176,7 +176,9 @@ extensions.
 | BIT_SEQ_LINEAR      | 31 | `bitSeqLinear(W, x, T)`                        | BitNet 1.58 sequence |
 | SEQ_CROSSENT_MASKED | 32 | `seqCrossEntropyLossMasked(l, t, m, T, V)`     | assistant-only SFT |
 | RRPRAM_LR           | 33 | `rrpramLowrankAttention(wr, x, v, T, E, nH, hD)` | low-rank Wr_a × Wr_b |
-| **RRPRAM_BCAST**    | 34 | _not yet implemented (parity with C — declared in `notorch.h` but unimplemented in `notorch.c`)_ | |
+| RRPRAM_BCAST        | 34 | `rrpramBroadcastAttention(wr, x, v, T, E, nH, hD, rank)` | broadcast RRPRAM — canonical Janus, sc=1/√hd |
+| RELU                | 35 | `relu(x)`                                       | C op 35; forward via JS-local opcode 105 (see extensions) |
+| SEQ_GATE            | 36 | `seqGate(x, g, T, nm, gi)`                      | per-position mechanism gate |
 
 ### JS-specific extensions (op codes 100+)
 

--- a/js-edition/notorch.js
+++ b/js-edition/notorch.js
@@ -128,7 +128,9 @@ export const OP = Object.freeze({
   BIT_SEQ_LINEAR: 31,
   SEQ_CROSSENT_MASKED: 32,
   RRPRAM_LR: 33,
-  // JS-specific extensions
+  RRPRAM_BCAST: 34,      // broadcast RRPRAM — canonical Janus pattern (C op 34)
+  SEQ_GATE: 36,          // per-position mechanism gate (C op 36)
+  // JS-specific extensions (RELU below mirrors C op 35 under a JS-local code)
   SUB: 100,
   DIV: 101,
   NEG: 102,
@@ -982,6 +984,31 @@ export class Tape {
         return;
       }
 
+      case OP.SEQ_GATE: {
+        // out[t,d] = x[t,d]·g[t,gi]; dx[t,d] = dout[t,d]·g[t,gi];
+        // dg[t,gi] = Σ_d dout[t,d]·x[t,d]. Mirrors C notorch.c:762.
+        if (e.parent1 >= 0 && e.parent2 >= 0) {
+          const x = this.entries[e.parent1].output;
+          const g = this.entries[e.parent2].output;
+          const T = e.aux | 0, nm = e.aux2 | 0, gi = e.aux3 | 0;
+          const B = (T > 0) ? (outLen / T) | 0 : 0;
+          const dx = new Float32Array(outLen);
+          const dg = new Float32Array(g.len);
+          for (let t = 0; t < T; t++) {
+            const gv = g.data[t * nm + gi];
+            let acc = 0;
+            for (let d = 0; d < B; d++) {
+              dx[t * B + d] = dout[t * B + d] * gv;
+              acc += dout[t * B + d] * x.data[t * B + d];
+            }
+            dg[t * nm + gi] = acc;
+          }
+          this.accGrad(e.parent1, dx);
+          this.accGrad(e.parent2, dg);
+        }
+        return;
+      }
+
       case OP.SEQ_MATVEC_T: {
         // Y[t] = W^T @ X[t] ; W:[W_rows, W_cols] ; X[t]:[W_rows] ; Y[t]:[W_cols]
         // dX[t][i] = Σ_j W[i,j] * dout[t][j]   → dX[t] = W @ dout[t]
@@ -1205,6 +1232,105 @@ export class Tape {
                   dWr[waRow + r] += duBuf[r] * xd;
                 }
                 dx[xiOff + d] += dxd;
+              }
+            }
+          }
+          this.accGrad(e.parent1, dWr);
+          this.accGrad(e.parent2, dx);
+          this.accGrad(e.parent3, dv);
+        }
+        return;
+      }
+
+      case OP.RRPRAM_BCAST: {
+        // Broadcast RRPRAM backward. mid = Σ_t x·Wr_a (broadcast); raw_s = mid·Wr_b;
+        // score = raw_s·sc, sc = 1/√headDim; attn[i] = softmax_causal(score)[0..i];
+        // out[i] = Σ attn·v. Mirrors C notorch.c:1578.
+        if (e.parent1 >= 0 && e.parent2 >= 0 && e.parent3 >= 0) {
+          const Wr = this.entries[e.parent1].output;
+          const x = this.entries[e.parent2].output;
+          const v = this.entries[e.parent3].output;
+          const T = e.aux | 0;
+          const nEmbd = e.aux2 | 0;
+          const nr = e.aux3 | 0;
+          const rank = e.aux4 | 0;          // aux4 = rank; headDim = E/H
+          const hd = (nEmbd / nr) | 0;
+          const outDim = nr * hd;
+          const combinedLen = Wr.len;
+          const ctxT = ((combinedLen / (nr * rank)) | 0) - nEmbd;
+          const wraTotal = nr * nEmbd * rank;
+          const sc = 1 / Math.sqrt(hd);
+          const dWr = new Float32Array(combinedLen);
+          const dx = new Float32Array(T * nEmbd);
+          const dv = new Float32Array(T * outDim);
+          const midBuf = new Float32Array(rank);
+          const dMidBuf = new Float32Array(rank);
+          const allScores = new Float32Array(T);
+          const attnBuf = new Float32Array(T);
+          const dAttnBuf = new Float32Array(T);
+          const dScoreGlobal = new Float32Array(T);
+          for (let h = 0; h < nr; h++) {
+            const wrABase = h * nEmbd * rank;
+            const wrBBase = wraTotal + h * rank * ctxT;
+            const vOff = h * hd;
+            // recompute mid (broadcast) and scores
+            for (let r = 0; r < rank; r++) midBuf[r] = 0;
+            for (let t = 0; t < T; t++) {
+              const xtOff = t * nEmbd;
+              for (let e2 = 0; e2 < nEmbd; e2++) {
+                const xe = x.data[xtOff + e2];
+                const waRow = wrABase + e2 * rank;
+                for (let r = 0; r < rank; r++) midBuf[r] += xe * Wr.data[waRow + r];
+              }
+            }
+            for (let j = 0; j < T; j++) {
+              let s = 0;
+              for (let r = 0; r < rank; r++) s += midBuf[r] * Wr.data[wrBBase + r * ctxT + j];
+              allScores[j] = s * sc;
+            }
+            for (let j = 0; j < T; j++) dScoreGlobal[j] = 0;
+            // accumulate d_score across all query positions i, plus d_v
+            for (let i = 0; i < T; i++) {
+              let mx = -Infinity;
+              for (let j = 0; j <= i; j++) { attnBuf[j] = allScores[j]; if (attnBuf[j] > mx) mx = attnBuf[j]; }
+              let sm = 0;
+              for (let j = 0; j <= i; j++) { attnBuf[j] = Math.exp(attnBuf[j] - mx); sm += attnBuf[j]; }
+              if (sm > 0) for (let j = 0; j <= i; j++) attnBuf[j] /= sm;
+              const doutiOff = i * outDim + vOff;
+              for (let j = 0; j <= i; j++) dAttnBuf[j] = 0;
+              for (let j = 0; j <= i; j++) {
+                const vjOff = j * outDim + vOff;
+                for (let d = 0; d < hd; d++) {
+                  dAttnBuf[j] += dout[doutiOff + d] * v.data[vjOff + d];
+                  dv[vjOff + d] += attnBuf[j] * dout[doutiOff + d];
+                }
+              }
+              let dotDa = 0;
+              for (let j = 0; j <= i; j++) dotDa += dAttnBuf[j] * attnBuf[j];
+              for (let j = 0; j <= i; j++) dScoreGlobal[j] += attnBuf[j] * (dAttnBuf[j] - dotDa);
+            }
+            // d_raw_s[j] = d_score[j]·sc → d_mid, dWr_b
+            for (let r = 0; r < rank; r++) dMidBuf[r] = 0;
+            for (let j = 0; j < T; j++) {
+              const ds = dScoreGlobal[j] * sc;
+              if (ds === 0) continue;
+              for (let r = 0; r < rank; r++) {
+                dMidBuf[r] += ds * Wr.data[wrBBase + r * ctxT + j];
+                dWr[wrBBase + r * ctxT + j] += ds * midBuf[r];
+              }
+            }
+            // d_x[t,e] += Σ_r d_mid[r]·Wr_a[h,e,r] (broadcast); dWr_a += Σ_t x·d_mid
+            for (let t = 0; t < T; t++) {
+              const xtOff = t * nEmbd;
+              for (let e2 = 0; e2 < nEmbd; e2++) {
+                const waRow = wrABase + e2 * rank;
+                const xe = x.data[xtOff + e2];
+                let dxe = 0;
+                for (let r = 0; r < rank; r++) {
+                  dxe += dMidBuf[r] * Wr.data[waRow + r];
+                  dWr[waRow + r] += dMidBuf[r] * xe;
+                }
+                dx[xtOff + e2] += dxe;
               }
             }
           }
@@ -1846,6 +1972,23 @@ export class Notorch {
     return this.tape.record(out, OP.SCALE_BY_T, xIdx, aIdx);
   }
 
+  /**
+   * Per-position mechanism gate: out[t,d] = x[t,d] · gate[t,gi].
+   * x:[T, B] flat (B = x.len/T); gate:[T, nm] flat, column gi selects the scalar
+   * applied to every channel of position t. Mirrors C nt_seq_gate (notorch.c:3383).
+   */
+  seqGate(xIdx, gIdx, T, nm, gi) {
+    const x = this.tape.entries[xIdx].output;
+    const g = this.tape.entries[gIdx].output;
+    const B = (x.len / T) | 0;
+    const out = Tensor.zeros(x.shape);
+    for (let t = 0; t < T; t++) {
+      const gv = g.data[t * nm + gi];
+      for (let d = 0; d < B; d++) out.data[t * B + d] = x.data[t * B + d] * gv;
+    }
+    return this.tape.record(out, OP.SEQ_GATE, xIdx, gIdx, -1, T, nm, gi);
+  }
+
   // ═════════════════════════════════════════════════════════════════════════
   // ACTIVATIONS
   // ═════════════════════════════════════════════════════════════════════════
@@ -2351,6 +2494,79 @@ export class Notorch {
       }
     }
     return this.tape.record(out, OP.RRPRAM_LR, wrCombinedIdx, xIdx, vIdx, T, nEmbd, nrHeads, headDim);
+  }
+
+  /**
+   * Broadcast RRPRAM attention (canonical Janus pattern). wr_combined packed as
+   * [Wr_a | Wr_b]:
+   *   Wr_a (H·E·R)   — [h,e,r] = h·E·R + e·R + r
+   *   Wr_b (H·R·ctx) — [h,r,j] = wraTotal + h·R·ctx + r·ctx + j
+   * mid[h,r]   = Σ_t Σ_e x[t,e]·Wr_a[h,e,r]          (broadcast — one mid per head)
+   * score[h,j] = (Σ_r mid[r]·Wr_b[h,r,j]) · sc,      sc = 1/√headDim
+   * attn[h,i,:] = softmax_causal(score)[0..i];  out[i,vOff+d] = Σ_{j≤i} attn[j]·v[j,vOff+d]
+   * `rank` is passed explicitly (ctx ≥ T, so it can't be derived from Wr.len alone).
+   * Mirrors C nt_rrpram_broadcast_attention (notorch.c:3796).
+   */
+  rrpramBroadcastAttention(wrCombinedIdx, xIdx, vIdx, T, nEmbd, nrHeads, headDim, rank) {
+    const Wr = this.tape.entries[wrCombinedIdx].output;
+    const x = this.tape.entries[xIdx].output;
+    const v = this.tape.entries[vIdx].output;
+    if (nrHeads * headDim !== nEmbd) {
+      throw new Error(`rrpramBroadcastAttention: H*D=${nrHeads * headDim} != E=${nEmbd}`);
+    }
+    const outDim = nrHeads * headDim;
+    const combinedLen = Wr.len;
+    const ctxT = ((combinedLen / (nrHeads * rank)) | 0) - nEmbd;
+    if (ctxT < T) {
+      throw new Error(`rrpramBroadcastAttention: derived ctxT=${ctxT} < T=${T}`);
+    }
+    if (nrHeads * rank * (nEmbd + ctxT) !== combinedLen) {
+      throw new Error(`rrpramBroadcastAttention: packed Wr shape mismatch (len=${combinedLen})`);
+    }
+    const wraTotal = nrHeads * nEmbd * rank;
+    const sc = 1 / Math.sqrt(headDim);
+    const out = Tensor.zeros([T, outDim]);
+    const midBuf = new Float32Array(rank);
+    const allScores = new Float32Array(T);
+    const attnBuf = new Float32Array(T);
+    for (let h = 0; h < nrHeads; h++) {
+      const wrABase = h * nEmbd * rank;
+      const wrBBase = wraTotal + h * rank * ctxT;
+      const vOff = h * headDim;
+      // mid[r] = Σ_t Σ_e x[t,e]·Wr_a[h,e,r]  (broadcast across all query positions)
+      for (let r = 0; r < rank; r++) midBuf[r] = 0;
+      for (let t = 0; t < T; t++) {
+        const xtOff = t * nEmbd;
+        for (let e2 = 0; e2 < nEmbd; e2++) {
+          const xe = x.data[xtOff + e2];
+          const waRow = wrABase + e2 * rank;
+          for (let r = 0; r < rank; r++) midBuf[r] += xe * Wr.data[waRow + r];
+        }
+      }
+      // score[j] = (Σ_r mid[r]·Wr_b[h,r,j]) · sc
+      for (let j = 0; j < T; j++) {
+        let s = 0;
+        for (let r = 0; r < rank; r++) s += midBuf[r] * Wr.data[wrBBase + r * ctxT + j];
+        allScores[j] = s * sc;
+      }
+      // causal softmax per query i, then weighted sum of v
+      for (let i = 0; i < T; i++) {
+        let mx = -Infinity;
+        for (let j = 0; j <= i; j++) { attnBuf[j] = allScores[j]; if (attnBuf[j] > mx) mx = attnBuf[j]; }
+        let sm = 0;
+        for (let j = 0; j <= i; j++) { attnBuf[j] = Math.exp(attnBuf[j] - mx); sm += attnBuf[j]; }
+        if (sm > 0) for (let j = 0; j <= i; j++) attnBuf[j] /= sm;
+        const oiOff = i * outDim + vOff;
+        for (let d = 0; d < headDim; d++) out.data[oiOff + d] = 0;
+        for (let j = 0; j <= i; j++) {
+          const vjOff = j * outDim + vOff;
+          const aj = attnBuf[j];
+          for (let d = 0; d < headDim; d++) out.data[oiOff + d] += aj * v.data[vjOff + d];
+        }
+      }
+    }
+    // aux4 = rank (headDim derivable as E/H at backward), matching C tape record.
+    return this.tape.record(out, OP.RRPRAM_BCAST, wrCombinedIdx, xIdx, vIdx, T, nEmbd, nrHeads, rank);
   }
 
   /**

--- a/termux-edition/README.md
+++ b/termux-edition/README.md
@@ -52,12 +52,12 @@ ln -sf "$(command -v llvm-ar)" "$PREFIX/bin/ar"
 # 3) Clone and build
 git clone https://github.com/ariannamethod/notorch ~/notorch
 cd ~/notorch
-make            # CPU-only, scalar fallback
-make BLAS=1     # CPU + OpenBLAS (recommended on aarch64)
-./notorch_test  # expect 47/47 pass
+make            # CPU + OpenBLAS (default — auto via pkg-config on Termux)
+make cpu        # CPU scalar fallback (no BLAS)
+./notorch_test  # expect 49/49 pass
 ```
 
-If `make BLAS=1` fails on `cblas.h`, double-check pkg-config:
+If `make` fails on `cblas.h`, double-check pkg-config:
 
 ```bash
 pkg-config --cflags openblas    # → -I$PREFIX/include/openblas


### PR DESCRIPTION
## tri-version op parity + release hygiene → v4.2.0

Brings the JS and Termux editions up to the C canon and cleans the tree for
notorch's first appearance in a major curated list (awesome-machine-learning
#1386).

### JS edition — op parity closed (0–36)
The browser port had stalled at op 33 while C reached op 36. Ported the two
genuinely-missing ops (RELU/35 was already present under JS-local opcode 105):
- **op 36 SEQ_GATE** — `seqGate(x, g, T, nm, gi)` (C `notorch.c:3383` fwd / `:762` bwd)
- **op 34 RRPRAM_BCAST** — `rrpramBroadcastAttention(wr, x, v, T, E, nH, hD, rank)` (C `notorch.c:3796` fwd / `:1578` bwd)

**Verified** (neo, node v25.9.0) — a C emitter built against canonical
`notorch.c` vs a JS runner, identical hardcoded inputs:
- op36 SEQ_GATE bit-identical to C (maxAbs 0.0)
- op34 RRPRAM_BCAST within float32 rounding (OUT 1.5e-8, DWR 2.3e-10, DX 1.5e-11, DV 6.0e-8)
- independent JS finite-difference grad-check: `fails=0` both ops
- `notorch_test` 49/49

### Termux edition
A platform recipe + demo that builds `../../notorch.c` directly (no core fork).
Rebuilt and generated against the current canon; recipe fixed to match the real
Makefile (`make` = CPU+BLAS default, `make cpu` = scalar, no `make BLAS=1`);
test count 47 → 49.

### Tree hygiene
`.gitignore` hardened (compiled test/example binaries via negation globs,
`.claude/`, stepped checkpoints); `git status` now shows only tracked sources.
Docs synced: parity table, op-count (37 ops, IDs 0–36), caveats, JS LOC.

Coordinated with maintainer @iamolegataeff.
