### PR TITLE
security: widen 64 allocation-size products to size_t before int overflow

### DIFF
--- a/examples/infer_janus.c
+++ b/examples/infer_janus.c
@@ -135,41 +135,41 @@ static float siluf(float x) { return x > -20 ? x/(1+expf(-x)) : 0; }
 
 static void forward(Weights *w, int *tok, int T, float *logits) {
     int V = CFG_V, E = CFG_E, H = CFG_H, D = CFG_D, BLK = CFG_BLK, FFN = CFG_FFN, MT = CFG_MT;
-    float *x = (float*)calloc(T*E, sizeof(float));
-    float *rn = (float*)calloc(T*E, sizeof(float));
+    float *x = (float*)calloc((size_t)T*E, sizeof(float));
+    float *rn = (float*)calloc((size_t)T*E, sizeof(float));
     float sc = 1.0f / sqrtf((float)D);
 
     for (int t = 0; t < T; t++)
         for (int e = 0; e < E; e++)
             x[t*E+e] = w->tok_emb[tok[t]*E+e] + w->pos_emb[t*E+e];
 
-    float *cat = (float*)calloc(T*E, sizeof(float));
-    float *ao = (float*)calloc(T*E, sizeof(float));
-    float *r1 = (float*)calloc(T*E, sizeof(float));
-    float *mg = (float*)calloc(T*FFN, sizeof(float));
-    float *mu = (float*)calloc(T*FFN, sizeof(float));
-    float *mo = (float*)calloc(T*E, sizeof(float));
+    float *cat = (float*)calloc((size_t)T*E, sizeof(float));
+    float *ao = (float*)calloc((size_t)T*E, sizeof(float));
+    float *r1 = (float*)calloc((size_t)T*E, sizeof(float));
+    float *mg = (float*)calloc((size_t)T*FFN, sizeof(float));
+    float *mu = (float*)calloc((size_t)T*FFN, sizeof(float));
+    float *mo = (float*)calloc((size_t)T*E, sizeof(float));
 
     for (int bl = 0; bl < BLK; bl++) {
         rmsnorm(rn, x, w->b[bl].rms1, T, E);
 
-        float *qa = (float*)calloc(T*E, sizeof(float));
-        float *ka = (float*)calloc(T*E, sizeof(float));
-        float *va = (float*)calloc(T*E, sizeof(float));
+        float *qa = (float*)calloc((size_t)T*E, sizeof(float));
+        float *ka = (float*)calloc((size_t)T*E, sizeof(float));
+        float *va = (float*)calloc((size_t)T*E, sizeof(float));
         float *vra = NULL;
         mm_t(qa, rn, w->b[bl].wq, T, E, E);
         mm_t(ka, rn, w->b[bl].wk, T, E, E);
         mm_t(va, rn, w->b[bl].wv, T, E, E);
         if (CFG_HAS_JANUS) {
-            vra = (float*)calloc(T*E, sizeof(float));
+            vra = (float*)calloc((size_t)T*E, sizeof(float));
             mm_t(vra, rn, w->b[bl].wvr, T, E, E);
         }
 
         float *echo = NULL, *eback = NULL, *jsc = NULL, *jat = NULL;
         if (CFG_HAS_JANUS) {
-            echo = (float*)calloc(T*E, sizeof(float));
+            echo = (float*)calloc((size_t)T*E, sizeof(float));
             mm_t(echo, rn, w->b[bl].wj, T, E, E);
-            eback = (float*)calloc(T*E, sizeof(float));
+            eback = (float*)calloc((size_t)T*E, sizeof(float));
             mm(eback, echo, w->b[bl].wj, T, E, E);
             jsc = (float*)calloc(T, sizeof(float));
             for (int t = 0; t < T; t++) {
@@ -177,7 +177,7 @@ static void forward(Weights *w, int *tok, int T, float *logits) {
                 for (int e = 0; e < E; e++) s += rn[t*E+e] * eback[t*E+e];
                 jsc[t] = s / sqrtf((float)E);
             }
-            jat = (float*)calloc(T*T, sizeof(float));
+            jat = (float*)calloc((size_t)T*T, sizeof(float));
             for (int i = 0; i < T; i++) {
                 for (int j = 0; j < T; j++)
                     jat[i*T+j] = (j > i) ? -1e9f : jsc[i] * jsc[j];
@@ -203,14 +203,14 @@ static void forward(Weights *w, int *tok, int T, float *logits) {
             }
         }
 
-        memset(cat, 0, T*E*sizeof(float));
-        float *at = (float*)calloc(T*T, sizeof(float));
-        float *ho = (float*)calloc(T*D, sizeof(float));
+        memset(cat, 0, (size_t)T*E*sizeof(float));
+        float *at = (float*)calloc((size_t)T*T, sizeof(float));
+        float *ho = (float*)calloc((size_t)T*D, sizeof(float));
 
         for (int h = 0; h < H; h++) {
-            float *q = (float*)calloc(T*D, sizeof(float));
-            float *k = (float*)calloc(T*D, sizeof(float));
-            float *v = (float*)calloc(T*D, sizeof(float));
+            float *q = (float*)calloc((size_t)T*D, sizeof(float));
+            float *k = (float*)calloc((size_t)T*D, sizeof(float));
+            float *v = (float*)calloc((size_t)T*D, sizeof(float));
             for (int t = 0; t < T; t++)
                 for (int d = 0; d < D; d++) {
                     q[t*D+d] = qa[t*E + h*D + d];
@@ -237,7 +237,7 @@ static void forward(Weights *w, int *tok, int T, float *logits) {
                 for (int e = 0; e < E; e++) s += rn[j*E+e] * wr_h[e*MT+j];
                 rrp_sc[j] = s * sc;
             }
-            float *ra = (float*)calloc(T*T, sizeof(float));
+            float *ra = (float*)calloc((size_t)T*T, sizeof(float));
             for (int i = 0; i < T; i++) {
                 for (int j = 0; j < T; j++)
                     ra[i*T+j] = (j > i) ? -1e9f : rrp_sc[j];
@@ -245,21 +245,21 @@ static void forward(Weights *w, int *tok, int T, float *logits) {
             }
             // RRPRAM values: use vra (Janus) or va (Resonance)
             float *rv_src = CFG_HAS_JANUS ? vra : va;
-            float *rv = (float*)calloc(T*D, sizeof(float));
+            float *rv = (float*)calloc((size_t)T*D, sizeof(float));
             for (int t = 0; t < T; t++)
                 for (int d = 0; d < D; d++)
                     rv[t*D+d] = rv_src[t*E + h*D + d];
-            float *ro = (float*)calloc(T*D, sizeof(float));
+            float *ro = (float*)calloc((size_t)T*D, sizeof(float));
             mm(ro, ra, rv, T, T, D);
 
             // Janus attention (only if Janus mode)
             float *jo = NULL;
             if (CFG_HAS_JANUS) {
-                float *jv = (float*)calloc(T*D, sizeof(float));
+                float *jv = (float*)calloc((size_t)T*D, sizeof(float));
                 for (int t = 0; t < T; t++)
                     for (int d = 0; d < D; d++)
                         jv[t*D+d] = echo[t*E + h*D + d];
-                jo = (float*)calloc(T*D, sizeof(float));
+                jo = (float*)calloc((size_t)T*D, sizeof(float));
                 mm(jo, jat, jv, T, T, D);
                 free(jv);
             }
@@ -446,7 +446,7 @@ int main(int argc, char **argv) {
                 int off = (int)((dsz - T - 1) * wi / n_win);
                 int tok[256], tgt[256];
                 for (int t = 0; t < T; t++) { tok[t] = dt[off+t]; tgt[t] = dt[off+t+1]; }
-                float *lg = (float*)calloc(T * CFG_V, sizeof(float));
+                float *lg = (float*)calloc((size_t)T * CFG_V, sizeof(float));
                 forward(&w, tok, T, lg);
                 float wloss = 0;
                 for (int t = 0; t < T; t++) {
@@ -488,7 +488,7 @@ int main(int argc, char **argv) {
     for (int step = 0; step < max_tokens; step++) {
         int T = len < max_ctx ? len : max_ctx;
         int *tok = ctx + (len > max_ctx ? len - max_ctx : 0);
-        float *lg = (float*)calloc(T * CFG_V, sizeof(float));
+        float *lg = (float*)calloc((size_t)T * CFG_V, sizeof(float));
         forward(&w, tok, T, lg);
         float *last = lg + (T - 1) * CFG_V;
         int next = sample_top_p(last, CFG_V, temp, 0.9f);

--- a/notorch.c
+++ b/notorch.c
@@ -671,7 +671,7 @@ void nt_tape_backward(int loss_idx) {
                 int rows = pw->output->shape[0];
                 int cols = pw->output->ndim >= 2 ? pw->output->shape[1] : pw->output->len / rows;
                 if (rows > 0 && cols > 0) {
-                    float* dw = (float*)calloc(rows * cols, sizeof(float));
+                    float* dw = (float*)calloc((size_t)rows * cols, sizeof(float));
                     if (dw) {
                         for (int i = 0; i < rows; i++)
                             for (int j = 0; j < cols; j++)
@@ -1122,7 +1122,7 @@ void nt_tape_backward(int loss_idx) {
                 float* gamma_data = NULL;
                 if (has_gamma) gamma_data = g_tape.entries[e->parent2].output->data;
 
-                float* gx = (float*)calloc(T * D, sizeof(float));
+                float* gx = (float*)calloc((size_t)T * D, sizeof(float));
                 float* gg = has_gamma ? (float*)calloc(D, sizeof(float)) : NULL;
                 if (gx) {
                     float* Xrn = px->output->data;
@@ -1168,9 +1168,9 @@ void nt_tape_backward(int loss_idx) {
                 int T = (int)e->aux;
                 int D = (int)e->aux2;
                 float sc = 1.0f / sqrtf((float)D);
-                float* dq = (float*)calloc(T * D, sizeof(float));
-                float* dk = (float*)calloc(T * D, sizeof(float));
-                float* dv = (float*)calloc(T * D, sizeof(float));
+                float* dq = (float*)calloc((size_t)T * D, sizeof(float));
+                float* dk = (float*)calloc((size_t)T * D, sizeof(float));
+                float* dv = (float*)calloc((size_t)T * D, sizeof(float));
                 if (dq && dk && dv) {
                     for (int i = 0; i < T; i++) {
                         float* qi = pq->output->data + i * D;
@@ -1231,9 +1231,9 @@ void nt_tape_backward(int loss_idx) {
                 int D = e->output->len / T;
                 int n_heads = D / head_dim;
                 float sc = 1.0f / sqrtf((float)head_dim);
-                float* dq = (float*)calloc(T * D, sizeof(float));
-                float* dk = (float*)calloc(T * D, sizeof(float));
-                float* dv = (float*)calloc(T * D, sizeof(float));
+                float* dq = (float*)calloc((size_t)T * D, sizeof(float));
+                float* dk = (float*)calloc((size_t)T * D, sizeof(float));
+                float* dv = (float*)calloc((size_t)T * D, sizeof(float));
                 int mh_done_gpu = 0;
 #ifdef USE_CUDA
                 /* GPU backward: kernel needs softmaxed scores. Forward did not
@@ -1355,9 +1355,9 @@ void nt_tape_backward(int loss_idx) {
                 int KV_D = n_kv_heads * head_dim;
                 int gqa_ratio = n_heads / n_kv_heads;
                 float sc = 1.0f / sqrtf((float)head_dim);
-                float* dq = (float*)calloc(T * Q_D, sizeof(float));
-                float* dk = (float*)calloc(T * KV_D, sizeof(float));
-                float* dv = (float*)calloc(T * KV_D, sizeof(float));
+                float* dq = (float*)calloc((size_t)T * Q_D, sizeof(float));
+                float* dk = (float*)calloc((size_t)T * KV_D, sizeof(float));
+                float* dv = (float*)calloc((size_t)T * KV_D, sizeof(float));
                 if (dq && dk && dv) {
                     for (int h = 0; h < n_heads; h++) {
                         int kv_h = h / gqa_ratio;
@@ -1727,8 +1727,8 @@ void nt_tape_backward(int loss_idx) {
                 int out_dim = nr * hd;
                 int ctx = pwr->output->len / (nr * n_embd);
                 float* dwr = (float*)calloc(pwr->output->len, sizeof(float));
-                float* dx  = (float*)calloc(T * n_embd, sizeof(float));
-                float* dv  = (float*)calloc(T * out_dim, sizeof(float));
+                float* dx  = (float*)calloc((size_t)T * n_embd, sizeof(float));
+                float* dv  = (float*)calloc((size_t)T * out_dim, sizeof(float));
                 if (dwr && dx && dv) {
                     for (int h = 0; h < nr; h++) {
                         int wr_base = h * n_embd * ctx; int v_off = h * hd;
@@ -1786,8 +1786,8 @@ void nt_tape_backward(int loss_idx) {
                 nt_tape_entry* pb = &g_tape.entries[e->parent2];
                 int T = (int)e->aux;
                 int Da = pa->output->len / T; int Db = pb->output->len / T; int Dc = Da + Db;
-                float* da = (float*)calloc(T * Da, sizeof(float));
-                float* db = (float*)calloc(T * Db, sizeof(float));
+                float* da = (float*)calloc((size_t)T * Da, sizeof(float));
+                float* db = (float*)calloc((size_t)T * Db, sizeof(float));
                 if (da && db) {
                     for (int t = 0; t < T; t++) {
                         for (int d = 0; d < Da; d++) da[t * Da + d] = dout[t * Dc + d];
@@ -1904,7 +1904,7 @@ void nt_tape_backward(int loss_idx) {
                     }
                 }
 #endif
-                float* dl = ce_done_gpu ? NULL : (float*)calloc(T * V, sizeof(float));
+                float* dl = ce_done_gpu ? NULL : (float*)calloc((size_t)T * V, sizeof(float));
                 if (!ce_done_gpu && dl && pt) {
                     for (int t = 0; t < T; t++) {
                         float* logits_t = pl->output->data + t * V;
@@ -1954,7 +1954,7 @@ void nt_tape_backward(int loss_idx) {
                 float n_active = 0;
                 for (int t = 0; t < T; t++) n_active += pm->output->data[t];
                 if (n_active <= 0) break;
-                float* dl = (float*)calloc(T * V, sizeof(float));
+                float* dl = (float*)calloc((size_t)T * V, sizeof(float));
                 if (dl) {
                     for (int t = 0; t < T; t++) {
                         float m = pm->output->data[t];
@@ -1996,9 +1996,9 @@ void nt_tape_backward(int loss_idx) {
                 int T = px->output->len / D_in;
 
                 // Recompute gate and value
-                float* gate = (float*)calloc(T * D_out, sizeof(float));
-                float* val = (float*)calloc(T * D_out, sizeof(float));
-                float* gelu_gate = (float*)calloc(T * D_out, sizeof(float));
+                float* gate = (float*)calloc((size_t)T * D_out, sizeof(float));
+                float* val = (float*)calloc((size_t)T * D_out, sizeof(float));
+                float* gelu_gate = (float*)calloc((size_t)T * D_out, sizeof(float));
                 float* dx = (float*)calloc(px->output->len, sizeof(float));
                 float* dw1 = (float*)calloc(pw1->output->len, sizeof(float));
                 float* dw2 = (float*)calloc(pw2->output->len, sizeof(float));
@@ -2179,7 +2179,7 @@ void nt_tape_backward(int loss_idx) {
                 int has_beta = (e->parent3 >= 0 && e->parent3 < g_tape.count);
                 float* gamma_data = has_gamma ? g_tape.entries[e->parent2].output->data : NULL;
 
-                float* gx = (float*)calloc(T * D, sizeof(float));
+                float* gx = (float*)calloc((size_t)T * D, sizeof(float));
                 float* gg = has_gamma ? (float*)calloc(D, sizeof(float)) : NULL;
                 float* gb = has_beta ? (float*)calloc(D, sizeof(float)) : NULL;
 
@@ -2349,7 +2349,7 @@ void nt_tape_backward(int loss_idx) {
                 int rows = pw->output->shape[0];
                 int cols = pw->output->ndim >= 2 ? pw->output->shape[1] : pw->output->len / rows;
                 if (rows > 0 && cols > 0) {
-                    float* dw = (float*)calloc(rows * cols, sizeof(float));
+                    float* dw = (float*)calloc((size_t)rows * cols, sizeof(float));
                     if (dw) {
                         for (int i = 0; i < rows; i++)
                             for (int j = 0; j < cols; j++)
@@ -2382,7 +2382,7 @@ void nt_tape_backward(int loss_idx) {
                 int rows = pw->output->shape[0];
                 int cols = pw->output->ndim >= 2 ? pw->output->shape[1] : pw->output->len / rows;
                 if (rows > 0 && cols > 0 && T > 0) {
-                    float* dw = (float*)calloc(rows * cols, sizeof(float));
+                    float* dw = (float*)calloc((size_t)rows * cols, sizeof(float));
                     if (dw) {
                         for (int t = 0; t < T; t++) {
                             const float* dout_t = dout + t * rows;
@@ -2397,7 +2397,7 @@ void nt_tape_backward(int loss_idx) {
                         tape_acc_grad(e->parent1, dw, rows * cols);
                     }
                     free(dw);
-                    float* dx = (float*)calloc(T * cols, sizeof(float));
+                    float* dx = (float*)calloc((size_t)T * cols, sizeof(float));
                     if (dx) {
                         for (int t = 0; t < T; t++) {
                             const float* dout_t = dout + t * rows;

--- a/notorch_vision.h
+++ b/notorch_vision.h
@@ -43,7 +43,7 @@ static nt_image* nt_image_load(const char* path, int desired_channels) {
     img->width = w;
     img->height = h;
     img->channels = c;
-    img->data = (float*)malloc(c * h * w * sizeof(float));
+    img->data = (float*)malloc((size_t)c * h * w * sizeof(float));
 
     // Convert uint8 HWC → float CHW, normalized to [0, 1]
     for (int ch = 0; ch < c; ch++)
@@ -66,7 +66,7 @@ static nt_image* nt_image_load_mem(const unsigned char* buf, int len, int desire
     img->width = w;
     img->height = h;
     img->channels = c;
-    img->data = (float*)malloc(c * h * w * sizeof(float));
+    img->data = (float*)malloc((size_t)c * h * w * sizeof(float));
 
     for (int ch = 0; ch < c; ch++)
         for (int y = 0; y < h; y++)
@@ -94,7 +94,7 @@ static nt_image* nt_image_resize(const nt_image* src, int tw, int th) {
     dst->width = tw;
     dst->height = th;
     dst->channels = src->channels;
-    dst->data = (float*)malloc(src->channels * th * tw * sizeof(float));
+    dst->data = (float*)malloc((size_t)src->channels * th * tw * sizeof(float));
 
     float sx = (float)src->width / tw;
     float sy = (float)src->height / th;
@@ -138,7 +138,7 @@ static nt_image* nt_image_center_crop(const nt_image* src, int tw, int th) {
     dst->width = tw;
     dst->height = th;
     dst->channels = src->channels;
-    dst->data = (float*)malloc(src->channels * th * tw * sizeof(float));
+    dst->data = (float*)malloc((size_t)src->channels * th * tw * sizeof(float));
 
     for (int ch = 0; ch < src->channels; ch++) {
         const float* sc = src->data + ch * src->height * src->width;

--- a/stb_image.h
+++ b/stb_image.h
@@ -1817,7 +1817,7 @@ static stbi__uint16 *stbi__convert_format16(stbi__uint16 *data, int img_n, int r
    if (req_comp == img_n) return data;
    STBI_ASSERT(req_comp >= 1 && req_comp <= 4);
 
-   good = (stbi__uint16 *) stbi__malloc(req_comp * x * y * 2);
+   good = (stbi__uint16 *) stbi__malloc((size_t)req_comp * x * y * 2);
    if (good == NULL) {
       STBI_FREE(data);
       return (stbi__uint16 *) stbi__errpuc("outofmem", "Out of memory");
@@ -4821,7 +4821,7 @@ static int stbi__create_png_image_raw(stbi__png *a, stbi_uc *raw, stbi__uint32 r
             stbi__create_png_alpha_expand8(dest, dest, x, img_n);
       } else if (depth == 8) {
          if (img_n == out_n)
-            memcpy(dest, cur, x*img_n);
+            memcpy(dest, cur, (size_t)x*img_n);
          else
             stbi__create_png_alpha_expand8(dest, cur, x, img_n);
       } else if (depth == 16) {

--- a/tests/test_rrpram_broadcast.c
+++ b/tests/test_rrpram_broadcast.c
@@ -112,15 +112,15 @@ static int analytic_grads(const float* wr_data, long wr_len,
     nt_tape_entry* ev = &nt_tape_get()->entries[v_idx];
 
     *out_dwr = (float*)malloc(wr_len * sizeof(float));
-    *out_dx  = (float*)malloc(t_len * e_len * sizeof(float));
-    *out_dv  = (float*)malloc(t_len * out_dim * sizeof(float));
+    *out_dx  = (float*)malloc((size_t)t_len * e_len * sizeof(float));
+    *out_dv  = (float*)malloc((size_t)t_len * out_dim * sizeof(float));
 
     if (ew->grad) memcpy(*out_dwr, ew->grad->data, wr_len * sizeof(float));
     else memset(*out_dwr, 0, wr_len * sizeof(float));
-    if (ex->grad) memcpy(*out_dx,  ex->grad->data,  t_len * e_len * sizeof(float));
-    else memset(*out_dx,  0, t_len * e_len * sizeof(float));
-    if (ev->grad) memcpy(*out_dv,  ev->grad->data,  t_len * out_dim * sizeof(float));
-    else memset(*out_dv,  0, t_len * out_dim * sizeof(float));
+    if (ex->grad) memcpy(*out_dx,  ex->grad->data,  (size_t)t_len * e_len * sizeof(float));
+    else memset(*out_dx,  0, (size_t)t_len * e_len * sizeof(float));
+    if (ev->grad) memcpy(*out_dv,  ev->grad->data,  (size_t)t_len * out_dim * sizeof(float));
+    else memset(*out_dv,  0, (size_t)t_len * out_dim * sizeof(float));
 
     nt_tape_clear();
     return 0;


### PR DESCRIPTION
## What

CodeQL (default setup) flagged 64 `cpp/integer-multiplication-cast-to-long`
alerts — `int * int` (or `int*int*int`) size products that overflow in `int` /
`unsigned int` before the implicit widening to `size_t` at
`malloc` / `calloc` / `memcpy` / `memset`. A crafted-large product wraps to a small
value, under-allocates, and the following write runs off the end of the buffer.

Each flagged size expression now casts its **leading operand** to `size_t`, so the
whole product computes in the wide type. In-place and numerically inert for
non-overflowing sizes — C cast precedence binds `(size_t)A*B` as `((size_t)A)*B`,
so every 2-, 3-, or 4-factor chain evaluates entirely in `size_t`.

| file | sites | shape |
|---|---|---|
| `notorch.c` | 24 | backward-pass `calloc`: `T*D`, `rows*cols`, `T*V`, … |
| `examples/infer_janus.c` | 28 | forward `calloc` buffers + one `memset` |
| `tests/test_rrpram_broadcast.c` | 6 | `malloc` / `memcpy` / `memset` grad buffers |
| `notorch_vision.h` | 4 | image CHW `malloc`: `c*h*w`, `channels*th*tw` |
| `stb_image.h` | 2 | 16-bit convert `malloc` + 8-bit PNG row `memcpy` |

`stb_image.h:1820` (`stbi__convert_format16`) lacked the overflow guard its 8-bit
sibling already gets from `stbi__malloc_mad3` — hardened here as part of notorch.

## Verification

- `make test` → **73/73**
- `make test_vision` (compiles the stb implementation) → **73/73**
- `make infer` compiles
- `tests/test_rrpram_broadcast` → **PASS** (exit 0)
- cast placement and coverage re-checked against all 64 alert locations; the diff
  is a balanced **64+/64−** in-place substitution, so no line numbers shift

Closes the 64 open code-scanning alerts.

---
by Arianna Method · Coordinated with maintainer @iamolegataeff
