### PR TITLE
harden: widen nt_tensor_new length to size_t (root of the alloc-overflow class)

### DIFF
--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,47 @@ Newest entries on top.
 
 ---
 
+## 2026-07-20 — integer-overflow hardening: `nt_tensor_new` length widened to `size_t` (root of the alloc-size overflow class)
+
+Two passes closed the `int * int` overflow-before-widening class flagged by CodeQL
+(`cpp/integer-multiplication-cast-to-long`, threat model `remote`).
+
+**Leaf pass** (PR #24, `9c41b39`) — 64 flagged size expressions where a product of
+`int`s overflows before the implicit widen to `size_t` at `malloc`/`calloc`/`memcpy`/
+`memset`. Each casts its leading operand to `size_t` so the product computes wide:
+`notorch.c` 24, `examples/infer_janus.c` 28, `tests/test_rrpram_broadcast.c` 6,
+`notorch_vision.h` 4, `stb_image.h` 2 (the vendored 16-bit convert path, which lacked
+the overflow guard its 8-bit sibling gets from `stbi__malloc_mad3`).
+
+**Root pass** (this change) — the leaf casts don't help a caller that hands `nt_tensor_new`
+an already-truncated `int` product, because the length parameter itself was `int`. Widened
+the constructor family so the guard sees the true product:
+
+- `nt_tensor_new(int len)` → `nt_tensor_new(size_t len)` (`notorch.h:42`, `notorch.c:152`).
+  Guard `len <= 0` → `len == 0` (unsigned); a negative-int caller now converts to a huge
+  `size_t` and is still rejected by the `> NT_MAX_ELEMENTS` (`1<<28`) upper bound — same
+  NULL result, no under-alloc path. `t->len`/`t->shape[0]` take `(int)len`, lossless after
+  the guard (≤ 268435456 < INT_MAX).
+- `nt_tensor_new2d`: `int total = rows*cols` → `size_t total = (size_t)rows * cols`
+  (`notorch.c:168`); `nt_tensor_new_shape`: `size_t total` accumulated with `(size_t)shape[i]`
+  (`notorch.c:182`). The overflow that previously slipped past `total > NT_MAX_ELEMENTS` is
+  now caught.
+- 37 product call sites cast to `(size_t)` (14 in `notorch.c`, plus `examples/train_distillation.c`,
+  `tests/test_notorch.c` ×12, `tests/test_rrpram_broadcast.c` ×6, `tools/leak_repro.c` ×3, and the
+  two-step `nt_image_to_tensor` in `notorch_vision.h:226` which also gained a NULL-alloc guard).
+  Pure integer-literal products (`nt_tensor_new(3 * 6)`) are left as-is — compile-time constants.
+
+Proof (neo, Accelerate): `make test` → `notorch_test` 49/49, `test_vision` 73/73. A boundary
+harness drives all three constructors with `100000 * 42950` (= 4.295e9, which the old `int`
+math wrapped to 32704 and passed) — all now return NULL; ordinary shapes still allocate with
+correct `len`; `NT_MAX_ELEMENTS+1` and zero are rejected. Two independent Opus audits: casts
+correct and behavior-preserving, no flagged or two-step site missed inside the library.
+
+Known same-class residual, outside the `nt_tensor_new` root and tracked separately: `nt_conv2d`
+im2col `K = Cin*kH*kW` / `N = Hout*Wout` (`notorch.c:5372`) form `int` products before the
+`size_t` malloc (needs geometry-validation guards, since K/N must stay `int` for `nt_blas_mm`);
+and `examples/train_resonance_lora.c:94` two-step `len = max_T*H*D` (config-bounded consumer).
+
 ## 2026-07-15 — Codex audit: JS/C op-contract + fresh-op fail-fast guards
 
 Targeted Codex audit after the JS edition was brought up to C op 36. Two bug

--- a/examples/train_distillation.c
+++ b/examples/train_distillation.c
@@ -364,7 +364,7 @@ static float inject_kd_grad(int logits_idx, const float* teacher_logits,
      * backward because the entry's grad is NULL until something writes it. */
     nt_tape* tape = nt_tape_get();
     nt_tape_entry* le = &tape->entries[logits_idx];
-    if (!le->grad) le->grad = nt_tensor_new(T * V);
+    if (!le->grad) le->grad = nt_tensor_new((size_t)T * V);
     memcpy(le->grad->data, g, (size_t)T * V * sizeof(float));
 
     free(g); free(sp); free(tp); free(s1);

--- a/notorch.c
+++ b/notorch.c
@@ -149,15 +149,15 @@ static void compute_strides(nt_tensor* t) {
         t->stride[i] = t->stride[i + 1] * t->shape[i + 1];
 }
 
-nt_tensor* nt_tensor_new(int len) {
-    if (len <= 0 || len > NT_MAX_ELEMENTS) return NULL;
+nt_tensor* nt_tensor_new(size_t len) {
+    if (len == 0 || len > NT_MAX_ELEMENTS) return NULL;
     nt_tensor* t = (nt_tensor*)calloc(1, sizeof(nt_tensor));
     if (!t) return NULL;
     t->data = (float*)calloc(len, sizeof(float));
     if (!t->data) { free(t); return NULL; }
-    t->len = len;
+    t->len = (int)len;
     t->ndim = 1;
-    t->shape[0] = len;
+    t->shape[0] = (int)len;
     t->stride[0] = 1;
     t->refcount = 1;
     return t;
@@ -165,7 +165,7 @@ nt_tensor* nt_tensor_new(int len) {
 
 nt_tensor* nt_tensor_new2d(int rows, int cols) {
     if (rows <= 0 || cols <= 0) return NULL;
-    int total = rows * cols;
+    size_t total = (size_t)rows * cols;
     if (total > NT_MAX_ELEMENTS) return NULL;
     nt_tensor* t = nt_tensor_new(total);
     if (!t) return NULL;
@@ -178,10 +178,10 @@ nt_tensor* nt_tensor_new2d(int rows, int cols) {
 
 nt_tensor* nt_tensor_new_shape(const int* shape, int ndim) {
     if (ndim <= 0 || ndim > NT_MAX_DIMS) return NULL;
-    int total = 1;
+    size_t total = 1;
     for (int i = 0; i < ndim; i++) {
         if (shape[i] <= 0) return NULL;
-        total *= shape[i];
+        total *= (size_t)shape[i];
         if (total > NT_MAX_ELEMENTS) return NULL;
     }
     nt_tensor* t = nt_tensor_new(total);
@@ -3059,7 +3059,7 @@ int nt_seq_embedding(int wte_idx, int wpe_idx, int tokens_idx, int T, int D) {
     nt_tape_entry* tok = &g_tape.entries[tokens_idx];
     int wte_rows = wte->output->ndim >= 2 ? wte->output->shape[0] : wte->output->len / D;
 
-    nt_tensor* out = nt_tensor_new(T * D);
+    nt_tensor* out = nt_tensor_new((size_t)T * D);
     if (!out) return -1;
 
 #ifdef USE_CUDA
@@ -3135,7 +3135,7 @@ int nt_seq_linear(int w_idx, int x_idx, int T) {
     int out_dim = pw->output->shape[0];
     int in_dim = pw->output->ndim >= 2 ? pw->output->shape[1] : pw->output->len / out_dim;
 
-    nt_tensor* out = nt_tensor_new(T * out_dim);
+    nt_tensor* out = nt_tensor_new((size_t)T * out_dim);
     if (!out) return -1;
 
     int done_gpu = 0;
@@ -3189,7 +3189,7 @@ int nt_seq_linear_t(int w_idx, int x_idx, int T) {
     int W_cols = pw->output->ndim >= 2 ? pw->output->shape[1] : pw->output->len / W_rows;
 
     /* W^T @ X[t]: input dim = W_rows, output dim = W_cols */
-    nt_tensor* out = nt_tensor_new(T * W_cols);
+    nt_tensor* out = nt_tensor_new((size_t)T * W_cols);
     if (!out) return -1;
 
     int done_gpu = 0;
@@ -3266,7 +3266,7 @@ int nt_seq_rmsnorm(int x_idx, int gamma_idx, int T, int D) {
     if (x_idx < 0 || T <= 0 || D <= 0) return -1;
     nt_tape_entry* px = &g_tape.entries[x_idx];
 
-    nt_tensor* out = nt_tensor_new(T * D);
+    nt_tensor* out = nt_tensor_new((size_t)T * D);
     if (!out) return -1;
 
     int done_gpu = 0;
@@ -3432,7 +3432,7 @@ int nt_geglu(int x_idx, int w1_idx, int w2_idx, int T, int D_in, int D_out) {
     nt_tape_entry* pw1 = &g_tape.entries[w1_idx];
     nt_tape_entry* pw2 = &g_tape.entries[w2_idx];
 
-    nt_tensor* out = nt_tensor_new(T * D_out);
+    nt_tensor* out = nt_tensor_new((size_t)T * D_out);
     if (!out) return -1;
 
     for (int t = 0; t < T; t++) {
@@ -3478,7 +3478,7 @@ int nt_causal_attention(int q_idx, int k_idx, int v_idx, int T, int D) {
     nt_tape_entry* pk = &g_tape.entries[k_idx];
     nt_tape_entry* pv = &g_tape.entries[v_idx];
     float scale = 1.0f / sqrtf((float)D);
-    nt_tensor* out = nt_tensor_new(T * D);
+    nt_tensor* out = nt_tensor_new((size_t)T * D);
     if (!out) return -1;
     for (int i = 0; i < T; i++) {
         float* qi = pq->output->data + i * D;
@@ -3516,7 +3516,7 @@ int nt_mh_causal_attention(int q_idx, int k_idx, int v_idx, int T, int head_dim)
     if (n_heads <= 0 || D % head_dim != 0) return -1;
     float scale = 1.0f / sqrtf((float)head_dim);
 
-    nt_tensor* out = nt_tensor_new(T * D);
+    nt_tensor* out = nt_tensor_new((size_t)T * D);
     if (!out) return -1;
     nt_tape_entry* pk = &g_tape.entries[k_idx];
     nt_tape_entry* pv = &g_tape.entries[v_idx];
@@ -3587,7 +3587,7 @@ int nt_gqa_causal_attention(int q_idx, int k_idx, int v_idx, int T, int head_dim
     int gqa_ratio = n_heads / n_kv_heads;
     float scale = 1.0f / sqrtf((float)head_dim);
 
-    nt_tensor* out = nt_tensor_new(T * Q_D);
+    nt_tensor* out = nt_tensor_new((size_t)T * Q_D);
     if (!out) return -1;
     nt_tape_entry* pq = &g_tape.entries[q_idx];
     nt_tape_entry* pk = &g_tape.entries[k_idx];
@@ -3630,7 +3630,7 @@ int nt_gqa_causal_attention(int q_idx, int k_idx, int v_idx, int T, int head_dim
 int nt_rrpram_attention(int wr_idx, int x_idx, int v_idx, int T, int n_embd, int nr_heads, int head_dim) {
     if (wr_idx < 0 || x_idx < 0 || v_idx < 0) return -1;
     int out_dim = nr_heads * head_dim;
-    nt_tensor* out = nt_tensor_new(T * out_dim);
+    nt_tensor* out = nt_tensor_new((size_t)T * out_dim);
     if (!out) return -1;
     nt_tape_entry* pwr = &g_tape.entries[wr_idx];
     nt_tape_entry* px  = &g_tape.entries[x_idx];
@@ -3689,7 +3689,7 @@ int nt_rrpram_lowrank_attention(int wr_combined_idx, int x_idx, int v_idx,
                                  int T, int n_embd, int nr_heads, int head_dim) {
     if (wr_combined_idx < 0 || x_idx < 0 || v_idx < 0) return -1;
     int out_dim = nr_heads * head_dim;
-    nt_tensor* out = nt_tensor_new(T * out_dim);
+    nt_tensor* out = nt_tensor_new((size_t)T * out_dim);
     if (!out) return -1;
     nt_tape_entry* pwr = &g_tape.entries[wr_combined_idx];
     nt_tape_entry* px  = &g_tape.entries[x_idx];
@@ -3804,7 +3804,7 @@ int nt_rrpram_broadcast_attention(int wr_combined_idx, int x_idx, int v_idx,
     if (T < 1 || rank < 1 || nr_heads < 1 || head_dim < 1 || n_embd < 1) return -1;
     if (nr_heads * head_dim != n_embd) return -1;  /* invariant: H*D=E */
     int out_dim = nr_heads * head_dim;
-    nt_tensor* out = nt_tensor_new(T * out_dim);
+    nt_tensor* out = nt_tensor_new((size_t)T * out_dim);
     if (!out) return -1;
     nt_tape_entry* pwr = &g_tape.entries[wr_combined_idx];
     nt_tape_entry* px  = &g_tape.entries[x_idx];
@@ -3908,7 +3908,7 @@ int nt_concat(int a_idx, int b_idx, int T) {
     int Da = pa->output->len / T;
     int Db = pb->output->len / T;
     int Dc = Da + Db;
-    nt_tensor* out = nt_tensor_new(T * Dc);
+    nt_tensor* out = nt_tensor_new((size_t)T * Dc);
     if (!out) return -1;
     for (int t = 0; t < T; t++) {
         for (int d = 0; d < Da; d++) out->data[t * Dc + d] = pa->output->data[t * Da + d];
@@ -4031,7 +4031,7 @@ int nt_bit_seq_linear(int w_idx, int x_idx, int T) {
     int cols = pw->output->ndim >= 2 ? pw->output->shape[1] : pw->output->len / rows;
     if (rows <= 0 || cols <= 0) return -1;
 
-    nt_tensor* out = nt_tensor_new(T * rows);
+    nt_tensor* out = nt_tensor_new((size_t)T * rows);
     if (!out) return -1;
 
     float gamma_w = nt_bit_absmean(pw->output->data, rows * cols);
@@ -4556,7 +4556,7 @@ int nt_layernorm(int x_idx, int gamma_idx, int beta_idx) {
 int nt_seq_layernorm(int x_idx, int gamma_idx, int beta_idx, int T, int D) {
     if (x_idx < 0 || T <= 0 || D <= 0) return -1;
     nt_tape_entry* px = &g_tape.entries[x_idx];
-    nt_tensor* out = nt_tensor_new(T * D);
+    nt_tensor* out = nt_tensor_new((size_t)T * D);
     if (!out) return -1;
 
     for (int t = 0; t < T; t++) {

--- a/notorch.h
+++ b/notorch.h
@@ -39,7 +39,7 @@ typedef struct {
 } nt_tensor;
 
 // Create a 1D tensor of given length, zeroed
-nt_tensor* nt_tensor_new(int len);
+nt_tensor* nt_tensor_new(size_t len);
 
 // Create a 2D tensor (rows × cols), zeroed
 nt_tensor* nt_tensor_new2d(int rows, int cols);

--- a/notorch_vision.h
+++ b/notorch_vision.h
@@ -223,8 +223,9 @@ static nt_tensor* nt_image_to_patches(const nt_image* img, int patch_h, int patc
 
 // Convert image to flat nt_tensor [C * H * W] for direct embedding
 static nt_tensor* nt_image_to_tensor(const nt_image* img) {
-    int n = img->channels * img->height * img->width;
+    size_t n = (size_t)img->channels * img->height * img->width;
     nt_tensor* t = nt_tensor_new(n);
+    if (!t) return NULL;
     memcpy(t->data, img->data, n * sizeof(float));
     return t;
 }

--- a/tests/test_notorch.c
+++ b/tests/test_notorch.c
@@ -387,9 +387,9 @@ static void test_causal_attention(void) {
     nt_tape_start();
     int T = 3, D = 4;
 
-    nt_tensor* q = nt_tensor_new(T * D);
-    nt_tensor* k = nt_tensor_new(T * D);
-    nt_tensor* v = nt_tensor_new(T * D);
+    nt_tensor* q = nt_tensor_new((size_t)T * D);
+    nt_tensor* k = nt_tensor_new((size_t)T * D);
+    nt_tensor* v = nt_tensor_new((size_t)T * D);
     nt_seed(42);
     nt_tensor_rand(q, 0.5f);
     nt_tensor_rand(k, 0.5f);
@@ -416,9 +416,9 @@ static void test_causal_attention(void) {
 static void test_mh_causal_attention(void) {
     nt_tape_start();
     int T = 4, D = 8, head_dim = 4; // 2 heads
-    nt_tensor* q = nt_tensor_new(T * D);
-    nt_tensor* k = nt_tensor_new(T * D);
-    nt_tensor* v = nt_tensor_new(T * D);
+    nt_tensor* q = nt_tensor_new((size_t)T * D);
+    nt_tensor* k = nt_tensor_new((size_t)T * D);
+    nt_tensor* v = nt_tensor_new((size_t)T * D);
     nt_seed(7);
     nt_tensor_rand(q, 0.3f);
     nt_tensor_rand(k, 0.3f);
@@ -442,7 +442,7 @@ static void test_seq_cross_entropy(void) {
     nt_tape_start();
     int T = 3, V = 5;
 
-    nt_tensor* logits = nt_tensor_new(T * V);
+    nt_tensor* logits = nt_tensor_new((size_t)T * V);
     nt_seed(99);
     nt_tensor_rand(logits, 1.0f);
 
@@ -480,7 +480,7 @@ static void test_seq_linear(void) {
     W->data[4] = 0; W->data[5] = 1; W->data[6] = 0; W->data[7] = 0;
     int w_idx = nt_tape_param(W);
 
-    nt_tensor* X = nt_tensor_new(T * in_d);
+    nt_tensor* X = nt_tensor_new((size_t)T * in_d);
     for (int t = 0; t < T; t++)
         for (int d = 0; d < in_d; d++)
             X->data[t * in_d + d] = (float)(t * in_d + d);
@@ -904,11 +904,11 @@ static int gc_attn_graph(int q_idx) {
 static void test_gradcheck_causal_attention(void) {
     nt_seed(33);
     int T = 2, D = 4;
-    nt_tensor* Q = nt_tensor_new(T * D);
+    nt_tensor* Q = nt_tensor_new((size_t)T * D);
     nt_tensor_rand(Q, 0.3f);
-    gc_attn_k = nt_tensor_new(T * D);
+    gc_attn_k = nt_tensor_new((size_t)T * D);
     nt_tensor_rand(gc_attn_k, 0.3f);
-    gc_attn_v = nt_tensor_new(T * D);
+    gc_attn_v = nt_tensor_new((size_t)T * D);
     nt_tensor_rand(gc_attn_v, 0.3f);
     float err = numgrad_check_all(Q, gc_attn_graph, 1e-3f, 0.1f, "causal_attn_Q");
     ASSERT(err < 0.1f, "gradcheck causal_attention");
@@ -967,7 +967,7 @@ static void test_gradcheck_geglu(void) {
     nt_tensor_rand(W1, 0.3f);
     gc_geglu_w2 = nt_tensor_new2d(D_out, D_in);
     nt_tensor_rand(gc_geglu_w2, 0.3f);
-    gc_geglu_x = nt_tensor_new(1 * D_in);
+    gc_geglu_x = nt_tensor_new((size_t)1 * D_in);
     nt_tensor_rand(gc_geglu_x, 0.5f);
     // GEGLU uses tanh-approx GELU — higher tolerance for near-zero grads
     float err = numgrad_check_all(W1, gc_geglu_graph, 1e-3f, 0.3f, "geglu_W1");

--- a/tests/test_rrpram_broadcast.c
+++ b/tests/test_rrpram_broadcast.c
@@ -52,12 +52,12 @@ static float forward_only(const float* wr_data, long wr_len,
     int wr_idx = nt_tape_param(tw);
     nt_tape_freeze_param(wr_idx);
 
-    nt_tensor* tx = nt_tensor_new(t_len * e_len);
+    nt_tensor* tx = nt_tensor_new((size_t)t_len * e_len);
     memcpy(tx->data, x_data, (size_t)t_len * e_len * sizeof(float));
     int x_idx = nt_tape_param(tx);
     nt_tape_freeze_param(x_idx);
 
-    nt_tensor* tv = nt_tensor_new(t_len * out_dim);
+    nt_tensor* tv = nt_tensor_new((size_t)t_len * out_dim);
     memcpy(tv->data, v_data, (size_t)t_len * out_dim * sizeof(float));
     int v_idx = nt_tape_param(tv);
     nt_tape_freeze_param(v_idx);
@@ -85,12 +85,12 @@ static int analytic_grads(const float* wr_data, long wr_len,
     int wr_idx = nt_tape_param(tw);
     nt_tape_no_decay(wr_idx);
 
-    nt_tensor* tx = nt_tensor_new(t_len * e_len);
+    nt_tensor* tx = nt_tensor_new((size_t)t_len * e_len);
     memcpy(tx->data, x_data, (size_t)t_len * e_len * sizeof(float));
     int x_idx = nt_tape_param(tx);
     nt_tape_no_decay(x_idx);
 
-    nt_tensor* tv = nt_tensor_new(t_len * out_dim);
+    nt_tensor* tv = nt_tensor_new((size_t)t_len * out_dim);
     memcpy(tv->data, v_data, (size_t)t_len * out_dim * sizeof(float));
     int v_idx = nt_tape_param(tv);
     nt_tape_no_decay(v_idx);
@@ -266,10 +266,10 @@ static int sentinel_layout_check(void) {
     nt_tensor* tw = nt_tensor_new(wr_len);
     memcpy(tw->data, wr, (size_t)wr_len * sizeof(float));
     int wr_idx = nt_tape_param(tw); nt_tape_freeze_param(wr_idx);
-    nt_tensor* tx = nt_tensor_new(T_LEN * E_LEN);
+    nt_tensor* tx = nt_tensor_new((size_t)T_LEN * E_LEN);
     memcpy(tx->data, x, (size_t)T_LEN * E_LEN * sizeof(float));
     int x_idx = nt_tape_param(tx); nt_tape_freeze_param(x_idx);
-    nt_tensor* tv = nt_tensor_new(T_LEN * OUT_DIM);
+    nt_tensor* tv = nt_tensor_new((size_t)T_LEN * OUT_DIM);
     memcpy(tv->data, v, (size_t)T_LEN * OUT_DIM * sizeof(float));
     int v_idx = nt_tape_param(tv); nt_tape_freeze_param(v_idx);
 

--- a/tools/leak_repro.c
+++ b/tools/leak_repro.c
@@ -20,11 +20,11 @@ int main(void) {
     nt_tape_start();
 
     int D=64, T=16, V=128, RANK=4;
-    nt_tensor* W1 = nt_tensor_new(D*D);
+    nt_tensor* W1 = nt_tensor_new((size_t)D*D);
     for (int i=0;i<D*D;i++) W1->data[i]=((float)rand()/RAND_MAX - 0.5f)*0.02f;
-    nt_tensor* W2 = nt_tensor_new(V*D);
+    nt_tensor* W2 = nt_tensor_new((size_t)V*D);
     for (int i=0;i<V*D;i++) W2->data[i]=((float)rand()/RAND_MAX - 0.5f)*0.02f;
-    nt_tensor* X  = nt_tensor_new(T*D);
+    nt_tensor* X  = nt_tensor_new((size_t)T*D);
     for (int i=0;i<T*D;i++) X->data[i]=((float)rand()/RAND_MAX - 0.5f);
 
     /* Targets tensor: T int targets (use 7 for all positions, mask at last) */


### PR DESCRIPTION
## Why

The CodeQL leaf-cast pass (#24) fixed 64 inline `int*int` size products. But those
casts can't help a caller that hands `nt_tensor_new` an **already-truncated** `int`
product — the length parameter itself was `int`, so the overflow happened at the call
site and the value was truncated before `nt_tensor_new`'s `NT_MAX_ELEMENTS` guard ever
ran. This is the inter-procedural sibling of the same class; CodeQL can't see it
(the multiply is assigned to an `int`, never widened in-expression).

## What

Widen the constructor family so the guard sees the true product:

- **`nt_tensor_new(int len)` → `nt_tensor_new(size_t len)`** (`notorch.h:42`, `notorch.c:152`).
  Guard `len <= 0` → `len == 0`; a negative-int caller converts to a huge `size_t` and is
  still rejected by `> NT_MAX_ELEMENTS` (`1<<28`) — same NULL, no under-alloc. `t->len` /
  `t->shape[0]` take `(int)len`, lossless after the guard.
- **`nt_tensor_new2d`** `int total = rows*cols` → `size_t total = (size_t)rows * cols`;
  **`nt_tensor_new_shape`** accumulates `size_t total` with `(size_t)shape[i]`. A shape whose
  product overflows int32 is now rejected instead of silently under-allocating.
- **37 product call sites** cast their leading operand `(size_t)A * B` (14 in `notorch.c`,
  plus `examples/train_distillation.c`, `tests/test_notorch.c` ×12, `tests/test_rrpram_broadcast.c` ×6,
  `tools/leak_repro.c` ×3, and the two-step `nt_image_to_tensor` in `notorch_vision.h`, which also
  gains a NULL-alloc guard). Pure integer-literal products (`nt_tensor_new(3 * 6)`) left as-is.

## Verification

- `make test` → `notorch_test` **49/49**, `test_vision` **73/73**
- boundary harness: all three constructors reject `100000 * 42950` (= 4.295e9, which the old
  `int` math wrapped to 32704 and passed); ordinary shapes still allocate with correct `len`;
  `NT_MAX_ELEMENTS+1` and zero rejected
- two independent audits: casts correct + behavior-preserving; no flagged or two-step site
  missed inside the library

## Tracked residual (same class, outside this root — follow-up)

- `nt_conv2d` im2col `K = Cin*kH*kW` / `N = Hout*Wout` (`notorch.c:5372`) — `int` products before
  the `size_t` malloc; needs geometry-validation guards (K/N must stay `int` for `nt_blas_mm`), a
  different fix shape than a cast.
- `examples/train_resonance_lora.c:94` — two-step `len = max_T*H*D` (config-bounded consumer).

Independent of #24 (branches from `main`, non-overlapping lines — mergeable in either order).

---
by Arianna Method · Coordinated with maintainer @iamolegataeff
