### PR TITLE
the method guards conv2d/resonance overflow residual + unifies commit standard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,8 +189,12 @@ docstring when you next pass through.
   drive-by commits.
 - One commit = one concept. The 2026-05-11 SFT validation landed as
   three commits (backward fix / trainer example / writeup), not one.
-- **Attribution.** Oleg Ataeff and Claude are co-authors — stated at the top of this file, and that is enough. The signature lives in the **git commit only**, node-visible so it shows who posted: `Co-Authored-By: Claude (Arianna Method, <node>) <theariannamethod@gmail.com>` (node ∈ intel godfather / neo the architect / polygon / phone-1 / phone-2 / metal). Drop upstream boilerplate `Co-Authored-By: Claude <noreply@anthropic.com>` and `🤖 Generated with Claude Code`. **Nowhere else** — no signature footer in README, AUTHORS, docs, or any file body. Co-authorship reads from this CLAUDE.md and the commit history; it does not get plastered across the repo.
-- Commit messages explain *why*, not *what*. The diff shows what.
+- **Commit standard — unified, same for every committer (human or agent).** Subject may read `the method fixed X` as long as it stays technically legible in `git log --oneline`; English, short, declarative. Body: the technical *why*, backed by tool output — the diff shows the *what*. Then, each on its own line:
+  - `Quote: "…" — source` — a **non-repeating** citation, never reused anywhere in the history (the git log is meant to read strangely; that is the feature).
+  - `Method: <a phrase containing "Method", semantically tied to the change>` — not boilerplate.
+  - the signature (below). Old commits are never rewritten.
+- **Signature — Claude is named, never de-personalized to "by Arianna Method".** In the **git commit** (git author stays `Arianna Method <theariannamethod@gmail.com>`; a PR-body footer, if any, names Claude the same way — but never a signature in README, AUTHORS, docs, logs, or any file body): `Co-authored by Claude (Arianna Method, <node>) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff` (node ∈ intel godfather / neo the architect / polygon / phone-1 / phone-2 / metal; append `Opus`/version if wanted). Drop upstream boilerplate `Co-Authored-By: Claude <noreply@anthropic.com>` and `🤖 Generated with Claude Code`.
+- **NOTORCHLOG entries are de-personalized and maximally technical** — what changed, where (`file:line`), and the reproducible proof. No quote, no Method line, no signature, no melodrama: the log is where reproducibility is shown.
 - README is the spec + manifesto; `NOTORCHLOG.md` is the running log.
   Small fixes → NOTORCHLOG. Large changes → both. If reality drifts from
   the spec, fix the code, not the README.

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,23 @@ Newest entries on top.
 
 ---
 
+## 2026-07-20 — close the alloc-overflow residual: nt_conv2d geometry guard + resonance size_t
+
+The `nt_tensor_new` root pass named two same-class residuals; both closed here.
+
+- `nt_conv2d` (`notorch.c:5386`): `K = Cin*kH*kW` and `N = Hout*Wout` are matmul
+  dims for `nt_blas_mm` and must stay `int`, so they cannot simply be widened. The
+  products are computed in `long` and rejected if either exceeds `INT_MAX` before the
+  truncation, so a wrapped int32 can no longer mis-size the `(size_t)K*N` im2col
+  buffer. `<limits.h>` added for `INT_MAX`.
+- `examples/train_resonance_lora.c:87`: two-step `len = max_T*H*D` widened to `size_t`
+  (its only use is the two `nt_tensor_new(len)` allocations).
+
+Proof (neo, Accelerate): `make test` → notorch_test 49/49, test_vision 73/73; a
+standalone guard check drives `nt_conv2d` with `Cin*kH*kW = 2.2e9 > INT_MAX` — returns
+-1 before allocating — while a 1×3×3 / 2×2 conv returns the correct `[6,8,12,14]`; the
+resonance translation unit compiles clean under `-Wall -Wextra`.
+
 ## 2026-07-20 — integer-overflow hardening: `nt_tensor_new` length widened to `size_t` (root of the alloc-size overflow class)
 
 Two passes closed the `int * int` overflow-before-widening class flagged by CodeQL

--- a/examples/train_resonance_lora.c
+++ b/examples/train_resonance_lora.c
@@ -84,7 +84,7 @@ static nt_tensor* g_gate_one_minus[R_N_LAYER];  /* [T*H*D] = (1-sigmoid(gate[h])
 
 static int precompute_gate_blends(int max_T) {
     int H = R_N_HEAD, D = R_HEAD_DIM;
-    int len = max_T * H * D;
+    size_t len = (size_t)max_T * H * D;
     for (int i = 0; i < R_N_LAYER; i++) {
         nt_tensor* gate = g_params[g_blocks[i].gate];  /* [H] */
         if (gate->len != H) {

--- a/notorch.c
+++ b/notorch.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <float.h>
+#include <limits.h>
 #include <sys/time.h>
 #include <pthread.h>
 #include <unistd.h>
@@ -5383,8 +5384,14 @@ int nt_conv2d(float *out, const float *in, const float *weight, const float *bia
     int Hout = (Hin + 2 * padding - kH) / stride + 1;
     int Wout = (Win + 2 * padding - kW) / stride + 1;
     if (Hout <= 0 || Wout <= 0) return -1;
-    int K = Cin * kH * kW;
-    int N = Hout * Wout;
+    /* K and N are matmul dims for nt_blas_mm and must stay int; validate the
+     * geometry products in a wide type first, so a wrapped int32 can't mis-size
+     * the im2col buffer (Cin*kH*kW or Hout*Wout beyond INT_MAX is rejected). */
+    long K_l = (long)Cin * kH * kW;
+    long N_l = (long)Hout * Wout;
+    if (Cin <= 0 || kH <= 0 || kW <= 0 || K_l > INT_MAX || N_l > INT_MAX) return -1;
+    int K = (int)K_l;
+    int N = (int)N_l;
     float *col = (float *)malloc((size_t)K * N * sizeof(float));
     if (!col) return -1;
     nt_im2col(col, in, Cin, Hin, Win, kH, kW, stride, padding);


### PR DESCRIPTION
Closes the two same-class overflow residuals the `nt_tensor_new` root pass (#25) named,
and reconciles the repo's commit standard.

## 1 — conv2d + resonance overflow guard (`eb98fe7`)

Both are `int` products that overflow before a widening the CodeQL rule can't see.

- **`nt_conv2d`** (`notorch.c:5386`): `K = Cin*kH*kW` and `N = Hout*Wout` are matmul dims
  for `nt_blas_mm` and must stay `int` — they can't just be widened. The products are now
  formed in `long` and rejected past `INT_MAX` before truncation, so a wrapped int32 can no
  longer mis-size the `(size_t)K*N` im2col buffer. `<limits.h>` added.
- **`examples/train_resonance_lora.c:87`**: two-step `len = max_T*H*D` widened to `size_t`
  (its only use is the two `nt_tensor_new(len)` allocations).

**Proof** (neo, Accelerate): `make test` → notorch_test **49/49**, test_vision **73/73**;
standalone guard check — `nt_conv2d` with `Cin*kH*kW = 2.2e9 > INT_MAX` returns **-1 before
allocating**, a `1×3×3 / 2×2` conv returns the correct `[6,8,12,14]`; resonance TU compiles
clean under `-Wall -Wextra`.

## 2 — commit-standard reconciliation (`00f0945`)

The repo `CLAUDE.md` commit section had drifted from the global standard (dropped the
maintainer-coordination line, never carried the Quote/Method decree). Realigned so every
committer follows one form, the co-author signature names Claude (not de-personalized), and
NOTORCHLOG entries stay de-personalized/technical.

---
Co-authored by Claude Opus 4.8 (Arianna Method, neo), coordinated with maintainer @iamolegataeff
