### PR TITLE
The Method gave notorch.js hands it can spare, and dropped a port tha…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -296,6 +296,7 @@ test_js:
 	node js-edition/test_op_parity.mjs
 	cd js-edition && node test_qmatvec.mjs
 	cd js-edition && node test_kvcache.mjs
+	cd js-edition && node test_workers.mjs
 
 # SIMD correctness harness (vs scalar reference at nanollama shapes)
 tests/test_simd_correctness: tests/test_simd_correctness.c notorch_simd.h

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,58 @@ Newest entries on top.
 
 ---
 
+## 2026-08-22 — a worker pool for js-edition, and a batched matmul that measured its way back out
+
+Two experiments, one kept.
+
+**Kept: `notorch-workers.mjs`**, an optional resident pool that splits a matvec's
+rows across threads. Rows are independent and write disjoint slots, so output is
+bit-identical to `qmatvec` and the gate asserts equality. Rows are claimed from a
+shared cursor, not divided up front: on 2 performance and 4 efficiency cores an
+even split measured 1.72x where the cursor measured 1.94x. `qmatvecRows` is now
+exported for it, and `seqLinear` uses a pool when one is attached to the engine.
+
+A18 Pro, 6 workers, against a clean single-threaded baseline measured in its own
+process — the in-process baseline runs ~10% slow once a pool has been alive
+beside it, which would have inflated these:
+
+| shape | dtype | single | pool | |
+|---|---|---|---|---|
+| 576×576 | Q5_0 | 0.21 ms | 0.10 ms | 2.10x |
+| 576×1536 | Q4_K | 0.45 ms | 0.21 ms | 2.14x |
+| 32000×576 | Q8_0 | 10.77 ms | 4.01 ms | 2.69x |
+
+End to end, 24 greedy tokens: 2.04 s to 1.09 s, output identical.
+
+**Dropped: the batched matmul.** Porting C's `nt_qmatmul_i8` shape to JS —
+unpack a weight row once, dot it against a tile of activations — measured
+1.15x at n=32 on Q8_0, 1.08x on Q4_K, and *below one* at n=2 and n=8. In C the
+same shape is worth 3.19x, because there the win is memory traffic. In JS there
+is no such win to take, which a direct measurement makes plain: the same kernel
+costs 0.556 ns per element on a 306 KB working set and 0.569 ns on a 19 MB one.
+JS inference is compute-bound end to end; cache residency changes nothing.
+
+That single number explains the whole trajectory of this work. int8 does not help
+(the win needs an instruction JS does not have). Batching does not help (it saves
+bandwidth nobody was short of). Unrolling helped, 1.4x, because it removes
+operations and dependencies. Workers help, because they add executors. Only those
+two levers exist here.
+
+Three notes on gates, all learned the hard way in this step:
+
+- The pool's first version passed buffers by `postMessage` and reported every
+  round complete having computed nothing: the caller blocks on `Atomics.wait`, so
+  the workers' event loops never processed the message. Everything shared is now
+  bound at construction.
+- A `setTimeout` deadlock guard in the test was useless for the same reason — a
+  wedged pool stops the event loop the timer lives in. The pool times out its own
+  wait instead and throws, and the test lets that through.
+- Two of three red-hand defects did not fail the gate, and both times the defect
+  was the problem, not the test. A worker ignoring its chunk end recomputes rows
+  with identical values; a caller waiting on the wrong slot degrades parking into
+  a spin. Neither changes an answer. The one that does — dropping a row from each
+  chunk — was caught at 1/501 and 16/501.
+
 ## 2026-08-21 — the phone front: batched prefill, honest core counts, and a segfault that only glibc could see
 
 Five commits from Defender (Galaxy A56, Exynos 1580, Termux and a glibc chroot),

--- a/js-edition/README.md
+++ b/js-edition/README.md
@@ -4,8 +4,10 @@
 
 JavaScript port of the [notorch](https://github.com/ariannamethod/notorch)
 C tensor library. Same API surface, same Chuck optimizer, same naming.
-Different lifecycle: everything in **one ES module file** (no CPU/GPU
-lib split), runs in Node and the browser, optional WebGPU matmul.
+Different lifecycle: the engine is **one ES module file** (no CPU/GPU lib split),
+runs in Node and the browser, optional WebGPU matmul. Threads live in a second,
+optional file — they need SharedArrayBuffer, and that needs headers a static host
+may not be able to set.
 
 ---
 
@@ -31,7 +33,8 @@ Janus, Leo, Yent, Dario). JS is the **distribution** path:
 
 ## Install
 
-No package manager, no build step. Single file.
+No package manager, no build step. One file for the engine, a second only if you
+want threads.
 
 ```bash
 curl -O https://raw.githubusercontent.com/ariannamethod/notorch/main/js-edition/notorch.js
@@ -131,8 +134,9 @@ Schedules: `Schedule.cosine`, `Schedule.step`.
 Inference helpers: `KVCache`.
 Adapters: `LoRAPair`, `saveLoRA`, `loadLoRA`, `mergeLoRAInto`.
 Loaders: `loadNotorchBin`, `loadSafetensors`, `saveNotorchBin`.
-Packed kernels: `qmatvec` (exact), `qmatvecI8` / `qmatvecI8Rows` / `quantAct`
-(int8-activation fast path).
+Packed kernels: `qmatvec` / `qmatvecRows` (exact), `qmatvecI8` / `qmatvecI8Rows` /
+`quantAct` (int8-activation path), `dequantRow`.
+Threads: `WorkerPool`, `toShared` — in `notorch-workers.mjs`, optional.
 Tokenizers: `CharTokenizer`, `BPETokenizer`.
 
 ---
@@ -389,6 +393,50 @@ Measured on nano_arianna Q4_K_M shapes, median of five:
 End to end, 24 greedy tokens: 2.95 s to 2.05 s. Every output is byte-for-byte
 what it was before — reordering the sums moves nothing that survives rounding to
 f32, and the distance to the C kernels is unchanged at ~1e-6.
+
+### Workers
+
+`notorch-workers.mjs` is the optional second file: a resident pool that splits
+a matvec's rows across threads. `notorch.js` works without it and behaves
+identically — the pool changes who is idle, not what is computed. Rows are
+independent and write disjoint slots, so the output is bit-identical to
+`qmatvec`, and the gate asserts equality rather than a tolerance.
+
+```js
+import { WorkerPool, toShared } from './notorch-workers.mjs';
+const sab = toShared(await (await fetch(url)).arrayBuffer());
+const { tensors } = loadGGUF(sab);
+engine.pool = await WorkerPool.create(sab, maxRows, maxCols);
+```
+
+Rows are claimed from a shared cursor rather than divided up front. On 2
+performance and 4 efficiency cores an even split measured 1.72x where the cursor
+measured 1.94x — the fast cores stop waiting on the slow ones. That is C's
+discipline too (`notorch.c`, commit 8c7026e).
+
+A18 Pro, 6 workers, against a clean single-threaded baseline:
+
+| shape | dtype | single | pool | |
+|---|---|---|---|---|
+| 576×576 | Q5_0 | 0.21 ms | 0.10 ms | 2.10x |
+| 576×1536 | Q4_K | 0.45 ms | 0.21 ms | 2.14x |
+| 32000×576 | Q8_0 | 10.77 ms | 4.01 ms | 2.69x |
+
+End to end, 24 greedy tokens: 2.04 s to 1.09 s, output identical.
+`NT_WORKERS=6 node infer_gguf.mjs …` turns it on.
+
+Three constraints, none of them hideable. SharedArrayBuffer needs COOP/COEP
+headers in a browser, so a static host that cannot set headers cannot use this
+file — which is why it is a separate file. Everything the workers touch lives in
+one shared blob, bound at construction: a packed GGUF already has every tensor
+as a view onto one buffer, so a call names its matrix by byte offset. And the
+caller blocks on `Atomics.wait`, which a browser's main thread forbids — run the
+engine inside a worker there. In Node it is fine.
+
+The pool gives up after 30 s and throws rather than waiting forever. That is not
+belt-and-braces: a wedged pool blocks the thread inside `Atomics.wait`, the
+event loop stops, and no timer can fire to notice. Liveness has to live in the
+thing that blocks.
 
 ### KV cache
 

--- a/js-edition/infer_gguf.mjs
+++ b/js-edition/infer_gguf.mjs
@@ -8,6 +8,7 @@
 //   node infer_gguf.mjs model.gguf "prompt" [maxTokens] [temp]
 //
 import { readFileSync } from 'fs';
+import { toShared } from './notorch-workers.mjs';
 import { Notorch, Tensor, loadGGUF, KVCache } from './notorch.js';
 
 // ── GGUF byte-level BPE (mirror of examples/bpe.c) ──────────────────────────
@@ -75,7 +76,9 @@ class GgufBPE {
 // ── model load ──────────────────────────────────────────────────────────────
 function loadModel(path) {
   const buf = readFileSync(path);
-  const ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+  let ab = buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength);
+  // NT_WORKERS=N puts the weights in shared memory so a pool can reach them.
+  if (process.env.NT_WORKERS) ab = toShared(ab);
   // Packed by default: the quantized weights stay in their GGUF blocks instead
   // of being expanded to f32 on load. NT_PACKED=0 forces the old dense path —
   // the generation is identical either way, which is what the gate checks.
@@ -100,6 +103,7 @@ function loadModel(path) {
   const merges = metadata.get('tokenizer.ggml.merges');
   m.tok = new GgufBPE(tokens, merges);
   m.eos = metadata.get('tokenizer.ggml.eos_token_id');
+  m.weightsBuffer = ab;
   return m;
 }
 
@@ -144,6 +148,17 @@ const maxTok = parseInt(maxTokStr), temp = parseFloat(tempStr);
 const m = loadModel(path);
 console.error(`model: arch=${m.arch} E=${m.E} H=${m.H} KV=${m.KV} HD=${m.HD} FFN=${m.FFN} L=${m.L} V=${m.vocab} rope=${m.ropeBase} eos=${m.eos}`);
 const nt = new Notorch();
+if (process.env.NT_WORKERS) {
+  const { WorkerPool } = await import('./notorch-workers.mjs');
+  let maxM = 0, maxK = 0;
+  for (const [, t] of m.tensors) {
+    if (!t.packed || t.shape.length < 2) continue;
+    if (t.shape[0] > maxM) maxM = t.shape[0];
+    if (t.shape[1] > maxK) maxK = t.shape[1];
+  }
+  nt.pool = await WorkerPool.create(m.weightsBuffer, maxM, maxK, parseInt(process.env.NT_WORKERS));
+  console.error(`pool: ${nt.pool.n} workers`);
+}
 const ids = m.tok.encode(prompt);
 console.error(`prompt "${prompt}" -> ${ids.length} tokens`);
 let out = '';
@@ -164,3 +179,4 @@ for (let step = 0; step < maxTok; step++) {
 }
 console.error('');
 console.log(prompt + out);
+if (nt.pool) await nt.pool.terminate();

--- a/js-edition/notorch-worker-entry.mjs
+++ b/js-edition/notorch-worker-entry.mjs
@@ -1,0 +1,41 @@
+// notorch-worker-entry.mjs — one worker of the matvec pool.
+//
+// Everything it needs arrives once, in workerData: the shared weight blob, the
+// shared activation and output scratch, and the control block. Nothing crosses
+// by postMessage after that, because the calling thread blocks on Atomics.wait
+// and a message would need an event loop that is not turning.
+import { workerData, parentPort } from 'node:worker_threads';
+import { qmatvecRows } from './notorch.js';
+
+const { ctrl, weights, xScratch, outScratch } = workerData;
+const C = new Int32Array(ctrl);
+const W = new Uint8Array(weights);
+const X = new Float32Array(xScratch);
+const OUT = new Float32Array(outScratch);
+
+// Control slots, mirrored in notorch-workers.mjs.
+const GEN = 0, DONE = 1, CURSOR = 2, HI = 3, CHUNK = 4, DTYPE = 5, K = 6, WOFF = 7;
+
+parentPort.postMessage({ ready: true });
+
+let seen = 0;
+for (;;) {
+  Atomics.wait(C, GEN, seen);           // returns at once if GEN already moved
+  const gen = Atomics.load(C, GEN);
+  if (gen < 0) break;                   // pool shutting down
+  seen = gen;
+
+  const hi = C[HI], chunk = C[CHUNK], dtype = C[DTYPE], k = C[K], woff = C[WOFF];
+  const Wm = W.subarray(woff);          // this call's matrix inside the blob
+  // Rows are claimed, not assigned. An even split leaves fast cores waiting on
+  // slow ones — on 2P+4E that measured 1.72x against 1.94x for the cursor, the
+  // same reason C hands out chunks (notorch.c, commit 8c7026e).
+  for (;;) {
+    const r0 = Atomics.add(C, CURSOR, chunk);
+    if (r0 >= hi) break;
+    const r1 = r0 + chunk > hi ? hi : r0 + chunk;
+    qmatvecRows(OUT, Wm, dtype, X, r0, r1, k);
+  }
+  Atomics.add(C, DONE, 1);
+  Atomics.notify(C, DONE);
+}

--- a/js-edition/notorch-workers.mjs
+++ b/js-edition/notorch-workers.mjs
@@ -1,0 +1,136 @@
+// notorch-workers.mjs — a resident worker pool for the packed matvec.
+//
+// notorch.js stays single-file and works on its own; this is the optional
+// second half for machines with cores to spare. Measured on an A18 Pro
+// (2 performance + 4 efficiency), 32000x576 Q8_0: 10.01 ms on one worker,
+// 5.16 ms on six — 1.94x, with the output bit-identical to qmatvec.
+//
+// Two things it needs and one it cannot do:
+//
+//   - SharedArrayBuffer. In Node it is always there. In a browser it needs
+//     COOP/COEP headers on the page, so a static host that cannot set headers
+//     cannot use this file. That is exactly why it is a separate file.
+//   - Weights, activation and output all living in shared memory. `toShared`
+//     moves an ArrayBuffer across once, at load.
+//   - It blocks the calling thread on Atomics.wait, which the browser's main
+//     thread forbids. In a browser, run the engine inside a worker and let
+//     this pool serve it from there. In Node, on the main thread, it is fine.
+//
+// Why row ranges rather than anything cleverer: rows are independent and write
+// disjoint slots, so which worker computes which row cannot move a bit of the
+// result. Splitting the work does not change the answer, only who is idle.
+import { Worker } from 'node:worker_threads';
+import { availableParallelism } from 'node:os';
+
+// Control-block layout, mirrored in notorch-worker-entry.mjs.
+const GEN = 0, DONE = 1, CURSOR = 2, HI = 3, CHUNK = 4, DTYPE = 5, K = 6, WOFF = 7, SLOTS = 8;
+
+/** How long a single call may wait on its workers before declaring the pool wedged. */
+const POOL_TIMEOUT_MS = 30_000;
+
+/** Copy an ArrayBuffer into shared memory. Do this once, at load, not per call. */
+export function toShared(arrayBuffer) {
+  if (typeof SharedArrayBuffer === 'undefined') {
+    throw new Error('toShared: SharedArrayBuffer is unavailable (a browser page needs COOP/COEP headers)');
+  }
+  if (arrayBuffer instanceof SharedArrayBuffer) return arrayBuffer;
+  const sab = new SharedArrayBuffer(arrayBuffer.byteLength);
+  new Uint8Array(sab).set(new Uint8Array(arrayBuffer));
+  return sab;
+}
+
+export class WorkerPool {
+  /**
+   * @param {SharedArrayBuffer} weights the whole packed weight blob — for a GGUF
+   *   loaded with { packed: true } every tensor is already a view onto one
+   *   buffer, so the pool binds that buffer once and a call names its matrix by
+   *   byte offset. Nothing crosses by postMessage per call: the caller blocks on
+   *   Atomics.wait, so a message would be waiting on an event loop that is not
+   *   turning. That mistake produced a pool which reported every round complete
+   *   without computing anything.
+   * @param {number} maxM largest row count any call will ask for
+   * @param {number} maxK largest inner dimension any call will ask for
+   * @param {number} [n] worker count. Defaults to availableParallelism(), which
+   *   counts the cores this process may run on rather than the cores the machine
+   *   has — a distinction that cost the C side measurably on a pinned
+   *   big.LITTLE run (notorch.c, commit 4281b5f).
+   * @param {number} [chunksPerWorker=16] row-handout granularity. 16 is C's
+   *   number and measured best here too; 1 degenerates to an even split.
+   */
+  static async create(weights, maxM, maxK, n = availableParallelism(), chunksPerWorker = 16) {
+    if (!(weights instanceof SharedArrayBuffer)) {
+      throw new Error('WorkerPool.create: weights must be a SharedArrayBuffer (see toShared)');
+    }
+    const pool = new WorkerPool();
+    pool.n = Math.max(1, n | 0);
+    pool.chunksPerWorker = Math.max(1, chunksPerWorker | 0);
+    pool.ctrl = new SharedArrayBuffer(SLOTS * 4);
+    pool.C = new Int32Array(pool.ctrl);
+    pool.weights = weights;
+    pool.xScratch = new SharedArrayBuffer(maxK * 4);
+    pool.outScratch = new SharedArrayBuffer(maxM * 4);
+    pool.x = new Float32Array(pool.xScratch);
+    pool.out = new Float32Array(pool.outScratch);
+    pool.workers = [];
+    const url = new URL('./notorch-worker-entry.mjs', import.meta.url);
+    for (let i = 0; i < pool.n; i++) {
+      const w = new Worker(url, { workerData: {
+        ctrl: pool.ctrl, weights, xScratch: pool.xScratch, outScratch: pool.outScratch,
+      } });
+      await new Promise((res, rej) => { w.once('message', res); w.once('error', rej); });
+      w.unref();                          // a live pool must not hold the process open
+      pool.workers.push(w);
+    }
+    return pool;
+  }
+
+  /**
+   * out[0..m) = Wq[m,k] @ x[k], across the pool.
+   *
+   * `wOffset` is the matrix's byte offset inside the blob the pool was built
+   * on — for a packed GGUF tensor that is `tensor.packed.byteOffset`. `out` and
+   * `x` are ordinary arrays: they are copied through the pool's shared scratch,
+   * which costs k floats in and m floats out against a matvec of m*k.
+   *
+   * @returns {number} 0, or -1 if the dtype has no packed kernel, in which case
+   *   the caller falls back to qmatvec exactly as for a single-threaded miss.
+   */
+  qmatvec(out, wOffset, dtype, x, m, k) {
+    if (m > this.out.length || k > this.x.length) {
+      throw new Error(`WorkerPool.qmatvec: m=${m} k=${k} exceeds the scratch this pool was built for (${this.out.length}, ${this.x.length})`);
+    }
+    const C = this.C;
+    this.x.set(x.subarray(0, k));
+
+    let chunk = Math.floor(m / (this.n * this.chunksPerWorker));
+    if (chunk < 1) chunk = 1;
+    C[HI] = m; C[CHUNK] = chunk; C[DTYPE] = dtype; C[K] = k; C[WOFF] = wOffset;
+    Atomics.store(C, CURSOR, 0);
+    Atomics.store(C, DONE, 0);
+    Atomics.add(C, GEN, 1);
+    Atomics.notify(C, GEN);
+
+    // Wait on the value just read: reading it a second time inside the call is
+    // the race that turns this loop into a timeout per round. The timeout is not
+    // decoration — a pool that wedges here wedges the whole thread, and no timer
+    // can fire to notice, because Atomics.wait is exactly the event loop not
+    // turning. So the wait itself has to give up and say what happened.
+    const deadline = Date.now() + POOL_TIMEOUT_MS;
+    let done;
+    while ((done = Atomics.load(C, DONE)) < this.n) {
+      Atomics.wait(C, DONE, done, 250);
+      if (Date.now() > deadline) {
+        throw new Error(`WorkerPool.qmatvec: ${done}/${this.n} workers reported after ${POOL_TIMEOUT_MS} ms — the pool is wedged`);
+      }
+    }
+    out.set(this.out.subarray(0, m));
+    return 0;
+  }
+
+  async terminate() {
+    Atomics.store(this.C, GEN, -1);
+    Atomics.notify(this.C, GEN);
+    await Promise.all(this.workers.map((w) => w.terminate()));
+    this.workers.length = 0;
+  }
+}

--- a/js-edition/notorch.js
+++ b/js-edition/notorch.js
@@ -2160,10 +2160,21 @@ export class Notorch {
     if (W.packed) {
       // The weight never becomes a dense tensor: qmatvec walks its blocks per
       // position. Forward only — SEQ_MATVEC backward refuses a packed parent.
+      //
+      // With a pool attached (notorch-workers.mjs) the same rows are split
+      // across workers. Rows are independent and write disjoint slots, so the
+      // result is bit-identical either way — the pool changes who is idle, not
+      // what is computed. It only applies to weights inside the blob the pool
+      // was built on; anything else falls through to the single-threaded path.
+      const usePool = this.pool && W.packed.buffer === this.pool.weights
+        && outDim <= this.pool.out.length && inDim <= this.pool.x.length;
       const acc = new Float32Array(outDim);
       for (let t = 0; t < T; t++) {
         const xv = Xd.subarray(t * inDim, (t + 1) * inDim);
-        if (qmatvec(acc, W.packed, W.dtype, xv, outDim, inDim) !== 0) {
+        const rc = usePool
+          ? this.pool.qmatvec(acc, W.packed.byteOffset, W.dtype, xv, outDim, inDim)
+          : qmatvec(acc, W.packed, W.dtype, xv, outDim, inDim);
+        if (rc !== 0) {
           throw new Error(`seqLinear: no packed kernel for GGUF dtype ${W.dtype} at k=${inDim}`);
         }
         Yd.set(acc, t * outDim);
@@ -4023,16 +4034,29 @@ function qmvF32(out, dv, x, r0, r1, k) {
  *   falls back to dequant + a dense matvec exactly as the C consumers do.
  */
 export function qmatvec(out, Wq, dtype, x, m, k) {
+  return qmatvecRows(out, Wq, dtype, x, 0, m, k);
+}
+
+/**
+ * The same matvec over a row range only, writing out[r0..r1). Rows are
+ * independent and write disjoint slots, so a caller owning a parallel region
+ * hands each of its workers a range — the entry `notorch-workers.mjs` builds on,
+ * and the shape C exposes for the same reason (nt_qmatvec_i8_rows, notorch.h:538).
+ *
+ * @returns {number} 0, or -1 on a dtype or k with no packed kernel.
+ */
+export function qmatvecRows(out, Wq, dtype, x, r0, r1, k) {
+  if (r1 <= r0) return 0;
   switch (dtype) {
     case GGML_TYPE_F32:
-      qmvF32(out, new DataView(Wq.buffer, Wq.byteOffset, Wq.byteLength), x, 0, m, k); return 0;
+      qmvF32(out, new DataView(Wq.buffer, Wq.byteOffset, Wq.byteLength), x, r0, r1, k); return 0;
     case GGML_TYPE_F16:
-      qmvF16(out, new DataView(Wq.buffer, Wq.byteOffset, Wq.byteLength), x, 0, m, k); return 0;
-    case GGML_TYPE_Q4_0: if (k % 32)  return -1; qmvQ4_0(out, Wq, x, 0, m, k); return 0;
-    case GGML_TYPE_Q5_0: if (k % 32)  return -1; qmvQ5_0(out, Wq, x, 0, m, k); return 0;
-    case GGML_TYPE_Q8_0: if (k % 32)  return -1; qmvQ8_0(out, Wq, x, 0, m, k); return 0;
-    case GGML_TYPE_Q4_K: if (k % 256) return -1; qmvQ4_K(out, Wq, x, 0, m, k); return 0;
-    case GGML_TYPE_Q6_K: if (k % 256) return -1; qmvQ6_K(out, Wq, x, 0, m, k); return 0;
+      qmvF16(out, new DataView(Wq.buffer, Wq.byteOffset, Wq.byteLength), x, r0, r1, k); return 0;
+    case GGML_TYPE_Q4_0: if (k % 32)  return -1; qmvQ4_0(out, Wq, x, r0, r1, k); return 0;
+    case GGML_TYPE_Q5_0: if (k % 32)  return -1; qmvQ5_0(out, Wq, x, r0, r1, k); return 0;
+    case GGML_TYPE_Q8_0: if (k % 32)  return -1; qmvQ8_0(out, Wq, x, r0, r1, k); return 0;
+    case GGML_TYPE_Q4_K: if (k % 256) return -1; qmvQ4_K(out, Wq, x, r0, r1, k); return 0;
+    case GGML_TYPE_Q6_K: if (k % 256) return -1; qmvQ6_K(out, Wq, x, r0, r1, k); return 0;
     default: return -1;
   }
 }

--- a/js-edition/package.json
+++ b/js-edition/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "notorch.js",
   "scripts": {
-    "test": "node test_op_parity.mjs && node test_qmatvec.mjs && node test_kvcache.mjs"
+    "test": "node test_op_parity.mjs && node test_qmatvec.mjs && node test_kvcache.mjs && node test_workers.mjs"
   },
   "license": "GPL-3.0-or-later"
 }

--- a/js-edition/test_workers.mjs
+++ b/js-edition/test_workers.mjs
@@ -1,0 +1,120 @@
+// test_workers.mjs — the pool must compute what qmatvec computes, exactly, and
+// must not hang.
+//
+// Splitting rows across workers cannot change a single bit: rows are
+// independent and write disjoint slots. So the gate is equality, not a
+// tolerance. The second gate is liveness — every deadlock this pool could have
+// shows up as a test that never returns, so the run is under a hard timeout and
+// a hang is a failure rather than a hung CI job.
+//
+//   node test_workers.mjs   → JS_WORKERS_OK
+import { qmatvec } from './notorch.js';
+import { WorkerPool, toShared } from './notorch-workers.mjs';
+
+// No setTimeout guard here on purpose: a wedged pool blocks this thread inside
+// Atomics.wait, the event loop stops turning, and a timer never fires. The
+// liveness guarantee has to live in the pool itself, which gives up on its own
+// wait and throws — so this test simply lets the exception through.
+
+let _s = 0x13579BDF;
+const rnd32 = () => { _s ^= _s << 13; _s >>>= 0; _s ^= _s >>> 17; _s ^= _s << 5; _s >>>= 0; return _s; };
+const rndUnit = () => (rnd32() / 0xFFFFFFFF) * 2 - 1;
+
+let fails = 0;
+
+// Q8_0, and a row count that no worker count divides evenly.
+const M = 501, K = 256, NB = K / 32, STRIDE = NB * 34;
+const wPlain = new ArrayBuffer(M * STRIDE);
+{
+  const w = new Uint8Array(wPlain);
+  for (let i = 0; i < w.length; i++) w[i] = rnd32() & 0xFF;
+  for (let r = 0; r < M; r++) for (let b = 0; b < NB; b++) { const o = r * STRIDE + b * 34; w[o] = 0x66; w[o + 1] = 0x2A; }
+}
+const Wsab = toShared(wPlain);
+const W = new Uint8Array(Wsab);
+const x = new Float32Array(K);
+for (let i = 0; i < K; i++) x[i] = rndUnit();
+
+const ref = new Float32Array(M);
+qmatvec(ref, W, 8, x, M, K);
+
+for (const nw of [1, 2, 4, 6]) {
+  for (const cpw of [1, 16]) {
+    const pool = await WorkerPool.create(Wsab, M, K, nw, cpw);
+    const out = new Float32Array(M);
+    const rc = pool.qmatvec(out, 0, 8, x, M, K);
+    let bad = 0;
+    for (let i = 0; i < M; i++) if (out[i] !== ref[i]) bad++;
+
+    // Liveness: a pool that works once and wedges on the second round is the
+    // failure mode worth catching, so hammer it before believing the first.
+    let stillExact = true;
+    for (let rep = 0; rep < 100; rep++) {
+      out.fill(0);
+      pool.qmatvec(out, 0, 8, x, M, K);
+      if (rep === 99) for (let i = 0; i < M; i++) if (out[i] !== ref[i]) stillExact = false;
+    }
+    await pool.terminate();
+
+    const ok = rc === 0 && bad === 0 && stillExact;
+    if (!ok) fails++;
+    console.log(`pool    [n=${nw} chunks/worker=${cpw}] ${bad ? `${bad}/${M} differ` : 'bit-identical'}`
+      + `, 100 rounds ${stillExact ? 'still exact' : 'DRIFTED'}  ${ok ? 'PASS' : 'FAIL'}`);
+  }
+}
+
+// Contract: non-shared weights are refused at construction, and a call that
+// outgrows the scratch says so instead of writing past it.
+{
+  let threw = '';
+  try { await WorkerPool.create(new ArrayBuffer(64), M, K, 2); }
+  catch (err) { threw = String(err.message); }
+  if (!/SharedArrayBuffer/.test(threw)) {
+    console.log(`plain weights buffer: expected a refusal, got "${threw || 'no throw'}"  FAIL`); fails++;
+  }
+  const pool = await WorkerPool.create(Wsab, M, K, 2);
+  let threw2 = '';
+  try { pool.qmatvec(new Float32Array(M + 1), 0, 8, x, M + 1, K); }
+  catch (err) { threw2 = String(err.message); }
+  await pool.terminate();
+  if (!/exceeds the scratch/.test(threw2)) {
+    console.log(`oversized call: expected a refusal, got "${threw2 || 'no throw'}"  FAIL`); fails++;
+  }
+  if (/SharedArrayBuffer/.test(threw) && /exceeds the scratch/.test(threw2)) {
+    console.log('pool    [contract] plain weights and oversized calls are refused  PASS');
+  }
+}
+
+// A second matrix in the same blob, reached by byte offset — the shape a real
+// model uses, where every tensor is a view into one file.
+{
+  const off = 64 * STRIDE;                     // rows 64.. treated as a matrix of its own
+  const m2 = 32;
+  const pool = await WorkerPool.create(Wsab, M, K, 4);
+  const out = new Float32Array(m2), want = new Float32Array(m2);
+  pool.qmatvec(out, off, 8, x, m2, K);
+  qmatvec(want, W.subarray(off), 8, x, m2, K);
+  await pool.terminate();
+  let bad = 0;
+  for (let i = 0; i < m2; i++) if (out[i] !== want[i]) bad++;
+  if (bad) { console.log(`offset matrix: ${bad}/${m2} differ  FAIL`); fails++; }
+  else console.log('pool    [offset] a matrix at a byte offset matches qmatvec  PASS');
+}
+
+// A pool that wedges must report it rather than hang the caller forever.
+{
+  const pool = await WorkerPool.create(Wsab, M, K, 2);
+  await Promise.all(pool.workers.map((w) => w.terminate()));   // kill the hands, keep the pool
+  let threw = '';
+  try { pool.qmatvec(new Float32Array(M), 0, 8, x, M, K); }
+  catch (err) { threw = String(err.message); }
+  if (!/wedged/.test(threw)) {
+    console.log(`pool with dead workers: expected a wedge report, got "${threw || 'no throw'}"  FAIL`);
+    fails++;
+  } else {
+    console.log('pool    [liveness] a pool with no live workers reports instead of hanging  PASS');
+  }
+}
+
+console.log(fails === 0 ? 'JS_WORKERS_OK' : `${fails} FAILED`);
+process.exit(fails === 0 ? 0 : 1);


### PR DESCRIPTION
…t measured its way out

notorch-workers.mjs is an optional second file: a resident pool that splits a matvec's rows across threads. notorch.js works without it and behaves identically — the pool changes who is idle, not what is computed. Rows are independent and write disjoint slots, so the output is bit-identical to qmatvec and the gate asserts equality, not a tolerance. qmatvecRows is exported for it, and seqLinear uses a pool when one is attached to the engine.

Rows are claimed from a shared cursor rather than divided up front. On 2 performance and 4 efficiency cores an even split measured 1.72x where the cursor measured 1.94x — the fast cores stop waiting on the slow ones, which is why C hands out chunks too (8c7026e).

A18 Pro, 6 workers, against a single-threaded baseline measured in its own process — the in-process baseline runs ~10% slow once a pool has lived beside it, which would have inflated every number here:

  576x576    Q5_0   0.21 -> 0.10 ms   2.10x
  576x1536   Q4_K   0.45 -> 0.21 ms   2.14x
  32000x576  Q8_0  10.77 -> 4.01 ms   2.69x

End to end, 24 greedy tokens: 2.04 s to 1.09 s, output identical.

Dropped in the same session: the batched matmul. Porting C's nt_qmatmul_i8 shape — unpack a weight row once, dot it against a tile of activations — measured 1.15x at n=32 on Q8_0, 1.08x on Q4_K, and below one at n=2 and n=8. In C that shape is worth 3.19x because there the win is memory traffic. Here there is no such win to take: the same kernel costs 0.556 ns per element on a 306 KB working set and 0.569 ns on 19 MB. JS inference is compute-bound; cache residency changes nothing.

That number explains the whole trajectory. int8 does not help — the win needs an instruction JS does not have. Batching does not help — it saves bandwidth nobody was short of. Unrolling helped, 1.4x, because it removes work. Workers help, because they add executors. Those two levers are the only ones here.

Three gate lessons, each paid for:
- The pool's first version passed buffers by postMessage and reported every round complete having computed nothing — the caller blocks on Atomics.wait, so the workers' event loops never processed the message. Everything shared is bound at construction now.
- A setTimeout deadlock guard in the test was useless for the same reason: a wedged pool stops the very event loop the timer lives in. The pool times out its own wait and throws; the test lets that through.
- Two of three red-hand defects did not fail the gate, and both times the defect was at fault, not the test. A worker ignoring its chunk end recomputes rows with identical values; a caller waiting on the wrong slot degrades parking into a spin. Neither changes an answer. The one that does — dropping a row per chunk — was caught at 1/501 and 16/501.

Proof (neo, node v25.9.0):
- make test_js / npm test: JS_OP_PARITY_OK, JS_QMATVEC_OK, JS_KVCACHE_OK, JS_WORKERS_OK. JS_DEQUANT_OK unchanged at maxAbs=5.00e-8.
- Pool output bit-identical to qmatvec at 1/2/4/6 workers, both chunk granularities, on a row count no worker count divides evenly, and again after 100 consecutive rounds.
- Generation with and without the pool identical; generation without the pool identical to the pre-pool reference.

Quote: "Point of view is worth 80 IQ points." — Alan Kay, 1982
Method: the Method changed where it was standing, and the kernel that looked slow turned out to be waiting for hands, not for cleverness.

By Arianna Method (Co-authored by Claude, neo) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff