### PR TITLE
The Method answers to `from notorch import`, and proves the layout it…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,9 @@ examples/train_*
 
 # stepped checkpoints (e.g. model.bin.step100)
 *.bin.*
+
+# shared library, built by `make shared`
+libnotorch.so
+libnotorch.dylib
+__pycache__/
+*.pyc

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ SIMD_LIBS  = -lpthread
 
 # ── Targets ──
 
-.PHONY: all test test_qpool test_js clean cpu gpu simd help lib install metal test_metal infer_gguf_metal
+.PHONY: all test test_qpool test_js test_python clean cpu gpu simd help lib shared install metal test_metal infer_gguf_metal
 
 all: notorch_test
 	@echo "Built with $(BLAS_NAME). Run: ./notorch_test"
@@ -136,6 +136,29 @@ libnotorch_gpu.a: notorch.c notorch.h gguf.c gguf.h notorch_cuda.cu notorch_cuda
 	nvcc -O2 -DUSE_CUDA -c notorch_cuda.cu -o notorch_cuda.o
 	$(AR) rcs libnotorch_gpu.a notorch_gpu.o gguf_gpu.o notorch_cuda.o
 	@echo "Built: libnotorch_gpu.a (CPU + BLAS + CUDA)"
+
+# ── Python binding gate ──
+# The binding is ctypes over the shared library: no numpy, no build step. What
+# can silently go wrong is the struct layout, so the gate compares every offset
+# ctypes believes in against what the C compiler actually produced.
+test_python: shared
+	$(CC) -O2 -I. tests/gguf_layout.c -o /tmp/gguf_layout
+	/tmp/gguf_layout > /tmp/gguf_layout.txt
+	python3 python/test_binding.py /tmp/gguf_layout.txt $(MODEL)
+
+# ── Shared library — for callers that dlopen rather than link ──
+# ctypes, Node's ffi bindings, Ruby's Fiddle, anything with a C FFI. The static
+# library is what organisms link; this is what a script loads at runtime.
+SOEXT = so
+ifeq ($(UNAME), Darwin)
+  SOEXT = dylib
+endif
+
+shared: libnotorch.$(SOEXT)
+
+libnotorch.$(SOEXT): notorch.c notorch.h gguf.c gguf.h
+	$(CC) $(CFLAGS) $(BLAS_FLAGS) -fPIC -shared -o libnotorch.$(SOEXT) notorch.c gguf.c -lm $(BLAS_LIBS)
+	@echo "Built: libnotorch.$(SOEXT) ($(BLAS_NAME)) — load it with any FFI"
 
 # ── Install — system-wide baseline at $PREFIX (default /opt/homebrew) ──
 PREFIX ?= /opt/homebrew

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,32 @@ Newest entries on top.
 
 ---
 
+## 2026-08-22 — notorch answers to `from notorch import`
+
+`make shared` builds libnotorch.so (dylib on macOS), and `python/notorch.py` is
+a ctypes layer over it: 246 lines of type declarations and no arithmetic. No
+numpy, no build step on the Python side, no dependencies — ctypes is standard
+library. Weights stay packed: `tensor.packed` is a pointer into the file's own
+bytes and the kernels read them in place, so a Q4_K tensor costs roughly half a
+byte per weight in Python exactly as it does in C.
+
+The failure mode a binding like this has is not a crash. A ctypes Structure
+whose offsets have drifted from the header reads its neighbouring fields and
+reports them as data, and nothing about that looks wrong. So
+`tests/gguf_layout.c` prints what the compiler actually laid out, and
+`make test_python MODEL=…` compares every offset against it before touching a
+model. Red hand, all three caught: a field dropped from gguf_file (sizeof 443544
+against 443552), a name array one size short (tensor_info 184 against 192),
+GGUF_MAX_TENSORS off by one (443360 against 443552).
+
+Then it checks a real file: nano_arianna Q4_K_M reads back as
+`llama L=13 E=576 V=32000 tensors=120`, `gguf_dequant_row` equals its slice of
+`gguf_dequant`, and `nt_qmatvec` matches dequant-then-matvec at rel 8.6e-07.
+
+The README says so on the second screen rather than the last, because someone
+who wants to read a GGUF and multiply by it should not have to scroll to find
+out they can.
+
 ## 2026-08-22 — a worker pool for js-edition, and a batched matmul that measured its way back out
 
 Two experiments, one kept.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 ## table of contents
 
 - [what is this](#what)
+- [use it from Python](#use-it-from-python)
 - [why](#why)
 - [the funeral](#the-funeral)
 - [architecture](#architecture)
@@ -59,6 +60,49 @@ it's part of [the Arianna Method](https://github.com/ariannamethod/ariannamethod
 extracted from the core of [ariannamethod.ai](https://ariannamethod.ai) where it actually runs in production. training actual models. in C. like adults.
 
 ---
+
+## use it from Python
+
+notorch is C, and it stays C. But the thing most people want on a Tuesday is to
+read a GGUF and multiply something by it without installing a framework first,
+so there is a ctypes binding: no numpy, no build step for the Python side, no
+dependencies at all. `ctypes` ships with Python; the shared library is one make
+target.
+
+```bash
+make shared          # libnotorch.so, or libnotorch.dylib on macOS
+```
+
+```python
+from notorch import Notorch
+
+nt = Notorch()                       # finds libnotorch next to the repo, or $NOTORCH_LIB
+
+with nt.open("model.gguf") as g:
+    print(g)                         # <GGUF llama L=13 E=576 V=32000 tensors=120>
+
+    w = g["output.weight"]           # <Tensor output.weight (32000, 576) Q8_0>
+    row = w.dequant_row(3)           # one row, decoded on its own — an embedding lookup
+
+    import ctypes
+    x = (ctypes.c_float * w.shape[1])()
+    out = (ctypes.c_float * w.shape[0])()
+    nt.qmatvec(out, w.packed, w.dtype, x, w.shape[0], w.shape[1])
+```
+
+Nothing is computed in Python. `w.packed` is a pointer into the file's own
+bytes, `qmatvec` is the C kernel reading them in place, and the weights are
+never expanded to f32 — a Q4_K tensor stays at roughly half a byte per weight
+instead of four. Buffers are plain ctypes arrays, so `memoryview(out)` reads
+them with no copy, and `numpy.frombuffer(out)` does too if you happen to want
+numpy. Nothing here requires it.
+
+The binding is `python/notorch.py`, 246 lines of type declarations and no
+arithmetic. What can silently break in a layer like this is the struct layout —
+a field description that has drifted reads its neighbours and reports them as
+data — so `make test_python MODEL=your.gguf` compares every offset ctypes
+believes in against what the C compiler actually emitted, then checks a real
+model through both paths.
 
 ## why
 
@@ -457,6 +501,9 @@ make gpu
 # Apple Silicon Metal — packed-Q4_K/Q6_K GGUF inference (runs 24B on a 24GB Mac)
 make metal               # Q4_K matvec correctness test
 make infer_gguf_metal    # the GGUF inference binary
+
+# Shared library (for ctypes, Node FFI, Ruby Fiddle — anything that dlopens)
+make shared
 
 # Static library (for embedding in your project)
 make lib

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,0 +1,1 @@
+from .notorch import Notorch, GGUF, GGUF_TYPES, find_library   # noqa: F401

--- a/python/notorch.py
+++ b/python/notorch.py
@@ -1,0 +1,246 @@
+"""notorch — Python access to the C library.
+
+    from notorch import Notorch, GGUF
+
+Nothing is computed here. Every kernel call goes straight into libnotorch, and
+this file is the thin layer that finds it and describes its types. No numpy, no
+build step, no dependencies: ctypes is in the standard library and the .so or
+.dylib is what `make shared` produces.
+
+Buffers are plain ctypes arrays, and `memoryview` on one of them is a zero-copy
+view any Python code can read. If you want numpy, `numpy.frombuffer` takes them
+without copying either — but nothing here requires it.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import sys
+from ctypes import (POINTER, Structure, c_char, c_char_p, c_float, c_int,
+                    c_int32, c_uint8, c_uint32, c_uint64, c_void_p)
+
+__all__ = ["Notorch", "GGUF", "GGUF_TYPES", "find_library"]
+
+GGUF_MAX_NAME = 128
+GGUF_MAX_TENSORS = 2048
+GGUF_MAX_KV = 128
+
+#: GGUF type code -> name. These are the types the packed kernels understand.
+GGUF_TYPES = {0: "F32", 1: "F16", 2: "Q4_0", 3: "Q4_1", 6: "Q5_0", 8: "Q8_0",
+              12: "Q4_K", 14: "Q6_K"}
+
+
+class _TensorInfo(Structure):
+    _fields_ = [("name", c_char * GGUF_MAX_NAME),
+                ("ndim", c_uint32),
+                ("shape", c_uint64 * 4),
+                ("dtype", c_uint32),
+                ("offset", c_uint64),
+                ("n_elements", c_uint64)]
+
+
+class _KVValue(ctypes.Union):
+    _fields_ = [("u32", c_uint32), ("i32", c_int32), ("f32", c_float),
+                ("b", c_uint8), ("str", c_char * 256), ("u64", c_uint64)]
+
+
+class _KV(Structure):
+    _fields_ = [("key", c_char * GGUF_MAX_NAME),
+                ("type", c_uint32),
+                ("val", _KVValue)]
+
+
+class _GGUFFile(Structure):
+    _fields_ = [("version", c_uint32),
+                ("n_tensors", c_uint64),
+                ("n_kv", c_uint64),
+                ("kv", _KV * GGUF_MAX_KV),
+                ("n_kv_parsed", c_int),
+                ("tensors", _TensorInfo * GGUF_MAX_TENSORS),
+                ("data", POINTER(c_uint8)),
+                ("data_offset", c_uint64),
+                ("data_size", c_uint64),
+                ("n_layers", c_int), ("n_heads", c_int), ("n_kv_heads", c_int),
+                ("embed_dim", c_int), ("ffn_dim", c_int), ("vocab_size", c_int),
+                ("ctx_len", c_int),
+                ("rope_freq_base", c_float), ("rms_eps", c_float),
+                ("arch", c_char * 64)]
+
+
+def find_library(path: str | None = None) -> str:
+    """Locate libnotorch. Pass a path, set NOTORCH_LIB, or run `make shared`."""
+    if path:
+        return path
+    env = os.environ.get("NOTORCH_LIB")
+    if env:
+        return env
+    ext = "dylib" if sys.platform == "darwin" else "so"
+    here = os.path.dirname(os.path.abspath(__file__))
+    for candidate in (os.path.join(here, os.pardir, f"libnotorch.{ext}"),
+                      os.path.join(here, f"libnotorch.{ext}"),
+                      f"libnotorch.{ext}"):
+        if os.path.exists(candidate):
+            return os.path.abspath(candidate)
+    raise OSError(
+        f"libnotorch.{ext} not found. Build it with `make shared`, or point "
+        f"NOTORCH_LIB at it.")
+
+
+class Notorch:
+    """The loaded library, with its signatures declared."""
+
+    def __init__(self, path: str | None = None):
+        self.path = find_library(path)
+        self.lib = ctypes.CDLL(self.path)
+        lib = self.lib
+
+        lib.gguf_open.argtypes = [c_char_p]
+        lib.gguf_open.restype = POINTER(_GGUFFile)
+        lib.gguf_close.argtypes = [POINTER(_GGUFFile)]
+        lib.gguf_close.restype = None
+        lib.gguf_find_tensor.argtypes = [POINTER(_GGUFFile), c_char_p]
+        lib.gguf_find_tensor.restype = c_int
+        lib.gguf_dequant.argtypes = [POINTER(_GGUFFile), c_int]
+        lib.gguf_dequant.restype = POINTER(c_float)
+        lib.gguf_dequant_row.argtypes = [POINTER(_GGUFFile), c_int, c_uint64,
+                                         POINTER(c_float)]
+        lib.gguf_dequant_row.restype = c_int
+
+        lib.nt_qmatvec.argtypes = [POINTER(c_float), POINTER(c_uint8), c_int,
+                                   POINTER(c_float), c_int, c_int]
+        lib.nt_qmatvec.restype = c_int
+        lib.nt_qmatvec_i8.argtypes = lib.nt_qmatvec.argtypes
+        lib.nt_qmatvec_i8.restype = c_int
+        lib.nt_blas_matvec.argtypes = [POINTER(c_float), POINTER(c_float),
+                                       POINTER(c_float), c_int, c_int]
+        lib.nt_blas_matvec.restype = None
+        lib.nt_qmv_set_thread_min.argtypes = [ctypes.c_long]
+        lib.nt_qmv_set_thread_min.restype = None
+
+    # ── kernels ─────────────────────────────────────────────────────────────
+
+    def qmatvec(self, out, packed, dtype: int, x, m: int, k: int) -> int:
+        """out[m] = W[m,k] @ x[k], weights read straight from their GGUF blocks.
+
+        Returns 0, or -1 if the dtype has no packed kernel for this k.
+        """
+        return self.lib.nt_qmatvec(
+            ctypes.cast(out, POINTER(c_float)),
+            ctypes.cast(packed, POINTER(c_uint8)), dtype,
+            ctypes.cast(x, POINTER(c_float)), m, k)
+
+    def qmatvec_i8(self, out, packed, dtype: int, x, m: int, k: int) -> int:
+        """The int8-activation path: faster on ARM, approximate by construction."""
+        return self.lib.nt_qmatvec_i8(
+            ctypes.cast(out, POINTER(c_float)),
+            ctypes.cast(packed, POINTER(c_uint8)), dtype,
+            ctypes.cast(x, POINTER(c_float)), m, k)
+
+    def matvec(self, out, W, x, m: int, n: int) -> None:
+        """Dense f32 matvec, through BLAS where the build has one."""
+        self.lib.nt_blas_matvec(ctypes.cast(out, POINTER(c_float)),
+                                ctypes.cast(W, POINTER(c_float)),
+                                ctypes.cast(x, POINTER(c_float)), m, n)
+
+    def set_thread_floor(self, elems: int) -> None:
+        """Weight-element count below which a matvec stays single-threaded."""
+        self.lib.nt_qmv_set_thread_min(elems)
+
+    def open(self, path: str) -> "GGUF":
+        return GGUF(self, path)
+
+
+class Tensor:
+    """One tensor in a GGUF: its shape, its type, and its packed bytes."""
+
+    def __init__(self, gguf: "GGUF", index: int):
+        self._gguf = gguf
+        self.index = index
+        info = gguf._f.contents.tensors[index]
+        self.name = info.name.decode()
+        self.ndim = info.ndim
+        # GGML stores dims innermost-first; row-major is what callers expect.
+        self.shape = tuple(reversed([info.shape[i] for i in range(info.ndim)]))
+        self.dtype = info.dtype
+        self.dtype_name = GGUF_TYPES.get(info.dtype, str(info.dtype))
+        self.n_elements = info.n_elements
+        self._offset = info.offset
+
+    @property
+    def packed(self):
+        """A ctypes view of this tensor's bytes inside the file, no copy."""
+        base = ctypes.cast(self._gguf._f.contents.data, c_void_p).value
+        return ctypes.cast(base + self._offset, POINTER(c_uint8))
+
+    def dequant(self):
+        """Dequantize the whole tensor to f32. Allocates n_elements floats."""
+        ptr = self._gguf._nt.lib.gguf_dequant(self._gguf._f, self.index)
+        if not ptr:
+            raise RuntimeError(f"gguf_dequant failed for {self.name}")
+        buf = (c_float * self.n_elements)()
+        ctypes.memmove(buf, ptr, self.n_elements * 4)
+        return buf
+
+    def dequant_row(self, row: int, out=None):
+        """One row, decoded in place of the whole tensor — an embedding lookup."""
+        cols = self.shape[-1]
+        if out is None:
+            out = (c_float * cols)()
+        rc = self._gguf._nt.lib.gguf_dequant_row(
+            self._gguf._f, self.index, row, ctypes.cast(out, POINTER(c_float)))
+        if rc != 0:
+            raise ValueError(
+                f"gguf_dequant_row({self.name}, row={row}) refused: the row is "
+                f"not a whole number of blocks, or it is past the end")
+        return out
+
+    def __repr__(self):
+        return f"<Tensor {self.name} {self.shape} {self.dtype_name}>"
+
+
+class GGUF:
+    """An open GGUF file. Use as a context manager, or call close()."""
+
+    def __init__(self, nt: Notorch, path: str):
+        self._nt = nt
+        self._f = nt.lib.gguf_open(path.encode())
+        if not self._f:
+            raise OSError(f"gguf_open failed: {path}")
+        c = self._f.contents
+        self.arch = c.arch.decode()
+        self.n_layers, self.n_heads = c.n_layers, c.n_heads
+        self.n_kv_heads, self.embed_dim = c.n_kv_heads, c.embed_dim
+        self.ffn_dim, self.vocab_size, self.ctx_len = c.ffn_dim, c.vocab_size, c.ctx_len
+        self.rope_freq_base, self.rms_eps = c.rope_freq_base, c.rms_eps
+        self._tensors = {}
+        for i in range(int(c.n_tensors)):
+            t = Tensor(self, i)
+            self._tensors[t.name] = t
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    def close(self):
+        if self._f:
+            self._nt.lib.gguf_close(self._f)
+            self._f = None
+
+    def __getitem__(self, name: str) -> Tensor:
+        return self._tensors[name]
+
+    def __contains__(self, name: str) -> bool:
+        return name in self._tensors
+
+    def __len__(self) -> int:
+        return len(self._tensors)
+
+    def tensors(self):
+        return self._tensors.values()
+
+    def __repr__(self):
+        return (f"<GGUF {self.arch} L={self.n_layers} E={self.embed_dim} "
+                f"V={self.vocab_size} tensors={len(self._tensors)}>")

--- a/python/test_binding.py
+++ b/python/test_binding.py
@@ -1,0 +1,121 @@
+"""test_binding.py — the binding must describe the library, not resemble it.
+
+Two gates. First, every struct offset ctypes believes in is compared against
+what the C compiler actually laid out (tests/gguf_layout.c prints it): a
+Structure whose fields have drifted reads its neighbours and reports them as
+data, which is the kind of wrong that looks right. Second, values read through
+the binding are compared against the same values read by a C program.
+
+    cc -O2 -I. tests/gguf_layout.c -o /tmp/gguf_layout && /tmp/gguf_layout > /tmp/layout.txt
+    python3 python/test_binding.py /tmp/layout.txt [model.gguf]
+"""
+
+import ctypes
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from notorch import GGUF_TYPES, Notorch, _GGUFFile, _KV, _TensorInfo  # noqa: E402
+
+fails = 0
+
+
+def check(name, got, want):
+    global fails
+    if got != want:
+        print(f"  {name}: binding says {got}, C says {want}  FAIL")
+        fails += 1
+
+
+layout_path = sys.argv[1] if len(sys.argv) > 1 else None
+if not layout_path or not os.path.exists(layout_path):
+    print("usage: test_binding.py layout.txt [model.gguf]")
+    print("  layout.txt comes from tests/gguf_layout.c — see the docstring")
+    sys.exit(2)
+
+want = {}
+for line in open(layout_path):
+    key, value = line.rsplit(" ", 1)
+    want[key.strip()] = int(value)
+
+off = lambda s, f: getattr(s, f).offset  # noqa: E731
+
+check("sizeof tensor_info", ctypes.sizeof(_TensorInfo), want["tensor_info"])
+for field in ("name", "ndim", "shape", "dtype", "offset", "n_elements"):
+    check(f"tensor_info.{field}", off(_TensorInfo, field), want[f"tensor_info.{field}"])
+check("sizeof kv", ctypes.sizeof(_KV), want["kv"])
+for field in ("type", "val"):
+    check(f"kv.{field}", off(_KV, field), want[f"kv.{field}"])
+check("sizeof file", ctypes.sizeof(_GGUFFile), want["file"])
+for field in ("n_tensors", "kv", "tensors", "data", "data_size", "n_layers",
+              "rope_freq_base", "arch"):
+    check(f"file.{field}", off(_GGUFFile, field), want[f"file.{field}"])
+
+if fails == 0:
+    print("layout  every struct offset matches what the C compiler produced  PASS")
+
+model = sys.argv[2] if len(sys.argv) > 2 else None
+if model and os.path.exists(model):
+    nt = Notorch()
+    with nt.open(model) as g:
+        print(f"model   {g!r}")
+        if g.n_layers <= 0 or g.embed_dim <= 0 or not g.arch:
+            print(f"  metadata came back empty: arch={g.arch!r} L={g.n_layers} "
+                  f"E={g.embed_dim}  FAIL")
+            fails += 1
+        # A tensor the kernels can actually consume, dequantized two ways: the
+        # whole thing, and one row on its own. They must agree exactly — one is
+        # a slice of the other, not an approximation of it.
+        picked = None
+        for t in g.tensors():
+            if t.dtype in (2, 6, 8, 12, 14) and len(t.shape) == 2 and t.shape[0] > 4:
+                picked = t
+                break
+        if picked is None:
+            print("  no quantized 2-D tensor in this file  FAIL")
+            fails += 1
+        else:
+            cols = picked.shape[-1]
+            full = picked.dequant()
+            row = picked.dequant_row(3)
+            bad = sum(1 for i in range(cols) if full[3 * cols + i] != row[i])
+            if bad:
+                print(f"  {picked.name}: dequant_row differs from dequant in "
+                      f"{bad}/{cols} values  FAIL")
+                fails += 1
+            else:
+                print(f"row     {picked.name} {picked.dtype_name}: one row equals "
+                      f"its slice of the whole tensor  PASS")
+
+            # The packed kernel against the dequantized reference, the same
+            # comparison tests/test_qmatvec.c makes on the C side.
+            m, k = picked.shape[0], picked.shape[1]
+            m = min(m, 64)
+            x = (ctypes.c_float * k)()
+            for i in range(k):
+                x[i] = ((i * 37) % 101) / 101.0 - 0.5
+            got = (ctypes.c_float * m)()
+            rc = nt.qmatvec(got, picked.packed, picked.dtype, x, m, k)
+            if rc != 0:
+                print(f"  nt_qmatvec returned {rc} for {picked.dtype_name}  FAIL")
+                fails += 1
+            else:
+                dense = (ctypes.c_float * (m * k))()
+                for i in range(m * k):
+                    dense[i] = full[i]
+                ref = (ctypes.c_float * m)()
+                nt.matvec(ref, dense, x, m, k)
+                worst = max(abs(ref[i] - got[i]) for i in range(m))
+                scale = max(abs(ref[i]) for i in range(m)) or 1.0
+                if worst / scale > 1e-3:
+                    print(f"  qmatvec vs dequant+matvec: rel {worst/scale:.2e}  FAIL")
+                    fails += 1
+                else:
+                    print(f"kernel  nt_qmatvec matches dequant+matvec, rel "
+                          f"{worst/scale:.1e}  PASS")
+elif model:
+    print(f"model file not found: {model}")
+    fails += 1
+
+print("NOTORCH_PY_OK" if fails == 0 else f"{fails} FAILED")
+sys.exit(0 if fails == 0 else 1)

--- a/tests/gguf_layout.c
+++ b/tests/gguf_layout.c
@@ -1,0 +1,33 @@
+/* gguf_layout.c — print the layout the C side actually has, so a binding can
+ * be checked against it instead of against a guess. A ctypes Structure whose
+ * offsets have drifted reads neighbouring fields and reports them as data,
+ * which is the kind of wrong that looks right.
+ *
+ * Build: cc -O2 -I. tests/gguf_layout.c -o /tmp/gguf_layout
+ */
+#include "gguf.h"
+#include <stddef.h>
+#include <stdio.h>
+
+int main(void) {
+    printf("tensor_info %zu\n", sizeof(gguf_tensor_info));
+    printf("tensor_info.name %zu\n", offsetof(gguf_tensor_info, name));
+    printf("tensor_info.ndim %zu\n", offsetof(gguf_tensor_info, ndim));
+    printf("tensor_info.shape %zu\n", offsetof(gguf_tensor_info, shape));
+    printf("tensor_info.dtype %zu\n", offsetof(gguf_tensor_info, dtype));
+    printf("tensor_info.offset %zu\n", offsetof(gguf_tensor_info, offset));
+    printf("tensor_info.n_elements %zu\n", offsetof(gguf_tensor_info, n_elements));
+    printf("kv %zu\n", sizeof(gguf_kv));
+    printf("kv.type %zu\n", offsetof(gguf_kv, type));
+    printf("kv.val %zu\n", offsetof(gguf_kv, val));
+    printf("file %zu\n", sizeof(gguf_file));
+    printf("file.n_tensors %zu\n", offsetof(gguf_file, n_tensors));
+    printf("file.kv %zu\n", offsetof(gguf_file, kv));
+    printf("file.tensors %zu\n", offsetof(gguf_file, tensors));
+    printf("file.data %zu\n", offsetof(gguf_file, data));
+    printf("file.data_size %zu\n", offsetof(gguf_file, data_size));
+    printf("file.n_layers %zu\n", offsetof(gguf_file, n_layers));
+    printf("file.rope_freq_base %zu\n", offsetof(gguf_file, rope_freq_base));
+    printf("file.arch %zu\n", offsetof(gguf_file, arch));
+    return 0;
+}


### PR DESCRIPTION
… claims

make shared builds libnotorch.so — dylib on macOS — and python/notorch.py is a ctypes layer over it: 246 lines of type declarations and no arithmetic. No numpy, no build step on the Python side, no dependencies of any kind, because ctypes is standard library. Weights stay packed: tensor.packed is a pointer into the file's own bytes and the kernels read them in place, so a Q4_K tensor costs roughly half a byte per weight from Python exactly as it does from C.

The failure mode a binding like this has is not a crash. A ctypes Structure whose offsets have drifted from the header reads its neighbouring fields and hands them back as data, and nothing about that looks wrong from either side. So tests/gguf_layout.c prints what the compiler actually laid out, and make test_python MODEL=... compares every offset ctypes believes in against it before a model is opened at all.

The README carries this on its second screen rather than its last. Somebody who wants to read a GGUF and multiply by it should not have to scroll past the funeral to find out they can.

Proof (neo, Python 3.14, Accelerate):
- Layout gate: every offset in gguf_tensor_info, gguf_kv and gguf_file matches the compiler.
- Red hand, all three caught: a field dropped from gguf_file — sizeof 443544 against 443552; a name array one size short — tensor_info 184 against 192; GGUF_MAX_TENSORS off by one — 443360 against 443552.
- Real model: nano_arianna Q4_K_M reads back as llama L=13 E=576 V=32000 tensors=120; gguf_dequant_row equals its slice of gguf_dequant exactly; nt_qmatvec matches dequant-then-matvec at rel 8.6e-07.
- notorch_test unchanged.

Quote: "A ship in port is safe, but that is not what ships are built for." — Grace Hopper, 1976
Method: the Method keeps its arithmetic in C and lends its doorway to whoever knocks.

By Arianna Method (Co-authored by Claude, neo) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff