### PR TITLE
harness-d0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 # binaries
+notorch
 notorch_test
 notorch_test_gpu
 infer_gemma

--- a/Makefile
+++ b/Makefile
@@ -199,6 +199,28 @@ llama: examples/infer_llama.c examples/bpe.c examples/bpe.h gguf.c gguf.h notorc
 	$(CC) $(CFLAGS) $(BLAS_FLAGS) -o infer_llama examples/infer_llama.c examples/bpe.c gguf.c notorch.c -lm $(BLAS_LIBS)
 	@echo "Compiled: infer_llama (LLaMA/Qwen GGUF + GGUF-BPE tokenizer, $(BLAS_NAME))"
 
+# ── Harness — the simple way to run a model ──
+# One binary, one command: ./notorch model.gguf "prompt". Architectures are a
+# table in harness/main.c; adding a family adds a file, not a branch.
+
+HARNESS_SRC = harness/main.c harness/runtime.c harness/arch_llama.c examples/bpe.c gguf.c notorch.c
+HARNESS_HDR = harness/arch.h harness/runtime.h harness/logo.h examples/bpe.h gguf.h notorch.h
+
+# `harness` is phony because a directory of that name sits right there, and
+# make would otherwise call it up to date and build nothing.
+.PHONY: harness test_harness
+
+harness: notorch
+
+notorch: $(HARNESS_SRC) $(HARNESS_HDR)
+	$(CC) $(CFLAGS) $(BLAS_FLAGS) -o notorch $(HARNESS_SRC) -lm $(BLAS_LIBS)
+	@echo "Compiled: notorch (harness — GGUF in, text out, $(BLAS_NAME))"
+
+# Parity against the reference example, which is what says the move changed
+# nothing. MODEL= to point it at one file, otherwise it looks for its defaults.
+test_harness: notorch llama
+	./harness/test_parity.sh $(MODEL)
+
 # ── Training ──
 
 train_q: examples/train_q.c notorch.c notorch.h

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,59 @@ Newest entries on top.
 
 ---
 
+## 2026-08-24 — a harness, and the tokenizer it caught
+
+`harness/` is the simple way to run a model: `notorch model.gguf "prompt"` for
+one shot, `notorch model.gguf` for a chat in the terminal. The forward, the KV
+cache, the sampler and the scalar pieces moved out of `examples/infer_llama.c`
+into `harness/runtime.c` and `harness/arch_llama.c`, with the arithmetic
+untouched — `harness/test_parity.sh` is what says so, comparing the generated
+continuation against the example at temp 0 and getting six identical answers
+across two models and three prompts. Timing overlaps within run-to-run noise:
+prefill 1352 / 1391 / 1394 t/s against the example's 1321 / 1470 / 1463, decode
+428 / 495 / 597 against 479 / 492 / 592, nano_arianna Q8_0 on an A18 Pro.
+
+The example stays where it is. It is what the phone numbers were measured with
+and what models are tested through, and until the harness has been pointed at
+the same pile of files, replacing the reference with the thing being tested
+would leave nothing to test against. Two copies of one forward is the debt this
+takes on knowingly; it closes when the harness has earned the reference's job.
+
+Two decisions worth naming. **stdout is the model, stderr is everything else** —
+banner, model shape, the prompt you typed, timings, profile — so a redirected
+run is text and not a transcript of the tool. And **architectures are a table**:
+`nt_arch` is names, load, free, forward, and llama registers with `names = NULL`
+as the fallback, which is what the example already did with every architecture
+it had never heard of. Adding a family should be adding a file and one line; if
+it ever needs a branch inside `runtime.c`, the interface is lying and it is the
+interface that gets fixed.
+
+Red hand on both failure modes a move like this has: flipping the RoPE
+convention turned all six parity checks red with fluent text that answers a
+different question, and writing the KV one position early turned them red with
+`,I.AIeiIH:` where the example says `,anewfield,anewarchitecture.`
+
+**And then the harness caught something older than itself.** Its own reason to
+exist is a person typing a sentence and reading one back, which is a harder
+test of the tokenizer than any benchmark, and the text came back without
+spaces. `examples/bpe.c` implements GPT-2 byte-level BPE. nano_arianna carries
+`tokenizer.ggml.model = "llama"` — SentencePiece — where 22965 of 32000 tokens
+begin with U+2581 and none begin with `Ġ`. Encode maps a space to `Ġ`, finds no
+such token, and **drops it silently**: "The capital of France is Paris." is 31
+bytes and comes back as 26 tokens, five short, one per space, every remaining
+token a single character from the tail of the vocabulary rather than a merge.
+Decode cannot map U+2581 back, because the table it reads is 512 entries wide
+and that codepoint is 9601.
+
+The gate for this already existed and had never been pointed here: `bpe.c`
+built with `-DBPE_TEST` prints `BPE_FAIL (roundtrip=0 merges_applied=1)` on
+this file, and the `merges_applied` is only true because five tokens went
+missing. Byte-level vocabularies — Qwen2.5, SmolLM2 — are unaffected and always
+were. This is not from the move; it is what the move made visible, and it is
+the next thing to fix, before another architecture is added.
+
+---
+
 ## 2026-08-24 — the thirteen tensors that were two fifths of the time
 
 Q4_K and Q6_K now have wasm kernels, and the case for writing them was not the

--- a/harness/arch.h
+++ b/harness/arch.h
@@ -1,0 +1,36 @@
+/* arch.h — the one interface a model family implements.
+ *
+ * Adding a family is adding a file next to arch_llama.c and one line to the
+ * table in main.c. If a family cannot be added without also editing runtime.c
+ * or the forward of another family, this interface is lying and it is the
+ * interface that gets fixed, not the family.
+ *
+ * `names` is matched against the GGUF's general.architecture. NULL means the
+ * fallback: the family that takes a file no other family claims. There is
+ * exactly one of those, and today it is llama — which is what the reference
+ * example already did with every architecture it had never heard of. */
+#ifndef NT_HARNESS_ARCH_H
+#define NT_HARNESS_ARCH_H
+
+#include "harness/runtime.h"
+
+/* What the caller needs to size its buffers, filled by load. */
+typedef struct {
+    int n_layers, kv_dim, vocab;
+} nt_dims;
+
+typedef struct {
+    const char *const *names;    /* NULL-terminated, or NULL for the fallback */
+    void *(*load)(gguf_file *gf, nt_dims *dims);
+    void  (*free)(void *model);
+    /* One forward for a group of consecutive positions. Decode calls it with
+     * n = 1; prefill calls it with a chunk of the prompt. `logits` may be NULL,
+     * which asks for the KV cache alone, and when it is not NULL it is filled
+     * for the LAST row only — the only position anybody samples from. */
+    void  (*forward)(void *model, kv_cache *kv, const int *tokens, int n,
+                     int pos0, float *logits);
+} nt_arch;
+
+extern const nt_arch nt_arch_llama;
+
+#endif

--- a/harness/arch_llama.c
+++ b/harness/arch_llama.c
@@ -1,0 +1,286 @@
+/* arch_llama.c — the llama family, and the fallback for everything unnamed.
+ *
+ * SmolLM2, nanollama, Qwen2.5, LLaMA, Mistral: any GGUF whose blocks are
+ * attn_norm / attn_{q,k,v,output} / ffn_norm / ffn_{gate,up,down}. GQA, bias
+ * and tied embeddings are read off the file rather than configured.
+ *
+ * Moved from examples/infer_llama.c with the arithmetic untouched. That file
+ * stays put as the reference this is measured against.
+ *
+ * Prints go to stderr: stdout belongs to the model. */
+#include "harness/arch.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+typedef struct {
+    int n_layers, n_heads, n_kv_heads, embed, ffn, vocab, head_dim, kv_dim, q_dim;
+    float rope_base, rms_eps;
+    int rope_neox;         /* 1 = pair i with i+hd/2 (qwen2 and most non-llama) */
+    int has_output_weight; /* 0 = tied embeddings */
+
+    gguf_file *gf;      /* the packed weights point into it; must outlive this */
+    int emb_ti;         /* token_embd tensor index, for the per-token row read */
+
+    wt tok_emb;         /* [vocab, embed] — also the lm_head when tied */
+    float *out_norm;    /* [embed] */
+    wt out_weight;      /* [vocab, embed], absent when tied */
+
+    struct {
+        float *attn_norm;
+        wt wq, wk, wv, wo;
+        float *q_bias, *k_bias, *v_bias;   /* Qwen has bias */
+        float *ffn_norm;
+        wt wgate, wup, wdown;
+    } layers[];
+} llama_model;
+
+static void *llama_load(gguf_file *gf, nt_dims *dims) {
+    int nl = gf->n_layers;
+    llama_model *m = (llama_model*)calloc(1, sizeof(llama_model) + nl * sizeof(m->layers[0]));
+    if (!m) return NULL;
+
+    m->n_layers = nl;
+    m->n_heads = gf->n_heads;
+    m->n_kv_heads = gf->n_kv_heads;
+    m->embed = gf->embed_dim;
+    m->ffn = gf->ffn_dim;
+    m->rope_base = gf->rope_freq_base;
+    m->rms_eps = gf->rms_eps;
+    /* llama and its direct descendants rotate adjacent lanes; everything else
+     * in this file's reach — qwen2, and the qwen-derived checkpoints people
+     * convert — rotates halves. Unknown architectures get the llama
+     * convention, which is the older one. */
+    m->rope_neox = strcmp(gf->arch, "llama") != 0;
+
+    int ti = gguf_find_tensor(gf, "blk.0.attn_q.weight");
+    if (ti >= 0) {
+        m->q_dim = (int)gf->tensors[ti].shape[1];
+        m->head_dim = m->q_dim / m->n_heads;
+    } else {
+        m->head_dim = m->embed / m->n_heads;
+        m->q_dim = m->n_heads * m->head_dim;
+    }
+    m->kv_dim = m->head_dim * m->n_kv_heads;
+
+    ti = gguf_find_tensor(gf, "token_embd.weight");
+    if (ti >= 0) m->vocab = (int)gf->tensors[ti].shape[1];
+    else if (gf->vocab_size > 0) m->vocab = gf->vocab_size;
+    else m->vocab = 32000;
+
+    fprintf(stderr, "llama: E=%d H=%d KV=%d FFN=%d V=%d L=%d HD=%d Q=%d\n",
+            m->embed, m->n_heads, m->n_kv_heads, m->ffn, m->vocab, nl,
+            m->head_dim, m->q_dim);
+
+    m->gf = gf;
+    m->emb_ti = gguf_find_tensor(gf, "token_embd.weight");
+    wt_load(&m->tok_emb, gf, "token_embd.weight");
+    ti = gguf_find_tensor(gf, "output_norm.weight");
+    if (ti >= 0) m->out_norm = gguf_dequant(gf, ti);   /* [embed], f32 either way */
+    m->has_output_weight = wt_load(&m->out_weight, gf, "output.weight");
+
+    for (int l = 0; l < nl; l++) {
+        char name[128];
+        /* 1-D: norms and biases are a few thousand floats and are read
+         * elementwise, so they are expanded. 2-D: everything the matvec
+         * touches stays packed. */
+        #define L(field, fmt) do { \
+            snprintf(name, sizeof(name), fmt, l); \
+            ti = gguf_find_tensor(gf, name); \
+            if (ti >= 0) m->layers[l].field = gguf_dequant(gf, ti); \
+        } while(0)
+        #define W(field, fmt) do { \
+            snprintf(name, sizeof(name), fmt, l); \
+            wt_load(&m->layers[l].field, gf, name); \
+        } while(0)
+        L(attn_norm, "blk.%d.attn_norm.weight");
+        W(wq, "blk.%d.attn_q.weight");
+        W(wk, "blk.%d.attn_k.weight");
+        W(wv, "blk.%d.attn_v.weight");
+        W(wo, "blk.%d.attn_output.weight");
+        L(q_bias, "blk.%d.attn_q.bias");
+        L(k_bias, "blk.%d.attn_k.bias");
+        L(v_bias, "blk.%d.attn_v.bias");
+        L(ffn_norm, "blk.%d.ffn_norm.weight");
+        W(wgate, "blk.%d.ffn_gate.weight");
+        W(wup, "blk.%d.ffn_up.weight");
+        W(wdown, "blk.%d.ffn_down.weight");
+        #undef L
+        #undef W
+    }
+
+    if (!(m->tok_emb.q || m->tok_emb.f32) || !m->out_norm) {
+        fprintf(stderr, "llama: missing critical weights\n");
+        free(m);
+        return NULL;
+    }
+    if (m->layers[0].q_bias) fprintf(stderr, "  (has attention bias — qwen-style)\n");
+    if (!m->has_output_weight) fprintf(stderr, "  (tied embeddings)\n");
+    fprintf(stderr, "  rope: %s | weights: packed%s\n", m->rope_neox ? "neox" : "norm",
+            m->tok_emb.use_i8 ? " (int8 dot)" : "");
+
+    dims->n_layers = m->n_layers;
+    dims->kv_dim = m->kv_dim;
+    dims->vocab = m->vocab;
+    return m;
+}
+
+/* Only the expanded copies are ours; a packed pointer belongs to the gguf_file. */
+static void llama_free(void *model) {
+    llama_model *m = (llama_model*)model;
+    if (!m) return;
+    free(m->tok_emb.f32); free(m->out_norm); free(m->out_weight.f32);
+    for (int l = 0; l < m->n_layers; l++) {
+        free(m->layers[l].attn_norm);
+        free(m->layers[l].wq.f32); free(m->layers[l].wk.f32);
+        free(m->layers[l].wv.f32); free(m->layers[l].wo.f32);
+        free(m->layers[l].q_bias); free(m->layers[l].k_bias); free(m->layers[l].v_bias);
+        free(m->layers[l].ffn_norm);
+        free(m->layers[l].wgate.f32); free(m->layers[l].wup.f32); free(m->layers[l].wdown.f32);
+    }
+    free(m);
+}
+
+/* One forward for a group of consecutive positions. Decode calls it with n = 1
+ * and gets exactly the old arithmetic; prefill calls it with a chunk of the
+ * prompt and the weight traffic drops by the chunk width, which is the whole
+ * difference between a prompt that costs the same as generating it and one
+ * that does not. Attention still runs per row — it reads the KV cache rather
+ * than the weights, so batching it buys little and costs a mask. */
+static void llama_forward(void *model, kv_cache *kv, const int *tokens, int n,
+                          int pos0, float *logits) {
+    llama_model *m = (llama_model*)model;
+    int E = m->embed, H = m->n_heads, KV = m->n_kv_heads;
+    int HD = m->head_dim, KVD = m->kv_dim, FFN = m->ffn, Q_DIM = m->q_dim;
+    float eps = m->rms_eps;
+    int gqa = H / KV;
+
+    /* Rows of the embedding table, decoded where they lie. For a 1.5B Qwen
+     * that table is the largest tensor in the file and expanding it would cost
+     * 933 MB to read 1536 floats per token. */
+    double pft = pf_mark();
+    float *x = (float*)calloc((size_t)n * E, sizeof(float));
+    for (int j = 0; j < n; j++) {
+        float *xj = x + (long)j * E;
+        if (m->tok_emb.f32) memcpy(xj, m->tok_emb.f32 + (long)tokens[j] * E, E * sizeof(float));
+        else if (gguf_dequant_row(m->gf, m->emb_ti, (uint64_t)tokens[j], xj) != 0)
+            memset(xj, 0, E * sizeof(float));
+    }
+    pf_add(PF_EMBED, pft);
+
+    float *xn = (float*)calloc((size_t)n * E, sizeof(float));
+    float *q_all = (float*)calloc((size_t)n * Q_DIM, sizeof(float));
+    float *k_new = (float*)calloc((size_t)n * KVD, sizeof(float));
+    float *v_new = (float*)calloc((size_t)n * KVD, sizeof(float));
+    float *attn_out = (float*)calloc((size_t)n * Q_DIM, sizeof(float));
+    float *ffn_gate = (float*)calloc((size_t)n * FFN, sizeof(float));
+    float *ffn_up = (float*)calloc((size_t)n * FFN, sizeof(float));
+    float *ffn_out = (float*)calloc((size_t)n * E, sizeof(float));
+
+    for (int l = 0; l < m->n_layers; l++) {
+        pft = pf_mark();
+        for (int j = 0; j < n; j++)
+            rmsnorm(xn + (long)j * E, x + (long)j * E, m->layers[l].attn_norm, E, eps);
+        pf_add(PF_NORM, pft);
+
+        pft = pf_mark();
+        qmm(q_all, &m->layers[l].wq, xn, n);
+        qmm(k_new, &m->layers[l].wk, xn, n);
+        qmm(v_new, &m->layers[l].wv, xn, n);
+        for (int j = 0; j < n; j++) {
+            add_bias(q_all + (long)j * Q_DIM, m->layers[l].q_bias, Q_DIM);
+            add_bias(k_new + (long)j * KVD, m->layers[l].k_bias, KVD);
+            add_bias(v_new + (long)j * KVD, m->layers[l].v_bias, KVD);
+        }
+        pf_add(PF_QKV, pft);
+
+        pft = pf_mark();
+        long base = (long)l * kv->max_seq * KVD;
+        for (int j = 0; j < n; j++) {
+            int pos = pos0 + j;
+            float *qj = q_all + (long)j * Q_DIM, *kj = k_new + (long)j * KVD;
+            for (int h = 0; h < H; h++)
+                rope(qj + h*HD, pos, HD, m->rope_base, m->rope_neox);
+            for (int h = 0; h < KV; h++)
+                rope(kj + h*HD, pos, HD, m->rope_base, m->rope_neox);
+            memcpy(kv->k + base + (long)pos * KVD, kj, KVD * sizeof(float));
+            memcpy(kv->v + base + (long)pos * KVD, v_new + (long)j * KVD, KVD * sizeof(float));
+        }
+        pf_add(PF_ROPE, pft);
+
+        /* GQA attention, causal: row j sees 0..pos0+j, all already in cache */
+        pft = pf_mark();
+        float scale = 1.0f / sqrtf((float)HD);
+        memset(attn_out, 0, (size_t)n * Q_DIM * sizeof(float));
+        for (int j = 0; j < n; j++) {
+            int pos = pos0 + j;
+            for (int h = 0; h < H; h++) {
+                int kv_h = h / gqa;
+                float *q = q_all + (long)j * Q_DIM + h * HD;
+                float *scores = (float*)calloc(pos + 1, sizeof(float));
+                for (int t = 0; t <= pos; t++) {
+                    const float *kt = kv->k + base + (long)t * KVD + kv_h * HD;
+                    scores[t] = dot_f32(q, kt, HD) * scale;
+                }
+                softmax(scores, pos + 1);
+                float *out_h = attn_out + (long)j * Q_DIM + h * HD;
+                for (int t = 0; t <= pos; t++) {
+                    const float *vt = kv->v + base + (long)t * KVD + kv_h * HD;
+                    axpy_f32(out_h, scores[t], vt, HD);
+                }
+                free(scores);
+            }
+        }
+        pf_add(PF_ATTN, pft);
+
+        pft = pf_mark();
+        qmm(ffn_out, &m->layers[l].wo, attn_out, n);
+        pf_add(PF_PROJ, pft);
+        pft = pf_mark();
+        for (long i = 0; i < (long)n * E; i++) x[i] += ffn_out[i];
+        pf_add(PF_RESID, pft);
+
+        pft = pf_mark();
+        for (int j = 0; j < n; j++)
+            rmsnorm(xn + (long)j * E, x + (long)j * E, m->layers[l].ffn_norm, E, eps);
+        pf_add(PF_NORM, pft);
+        pft = pf_mark();
+        qmm(ffn_gate, &m->layers[l].wgate, xn, n);
+        qmm(ffn_up, &m->layers[l].wup, xn, n);
+        pf_add(PF_FFN, pft);
+        pft = pf_mark();
+        for (long i = 0; i < (long)n * FFN; i++) {
+            float g = ffn_gate[i];
+            ffn_gate[i] = (g / (1.0f + expf(-g))) * ffn_up[i];
+        }
+        pf_add(PF_SILU, pft);
+        pft = pf_mark();
+        qmm(ffn_out, &m->layers[l].wdown, ffn_gate, n);
+        pf_add(PF_FFN, pft);
+        pft = pf_mark();
+        for (long i = 0; i < (long)n * E; i++) x[i] += ffn_out[i];
+        pf_add(PF_RESID, pft);
+    }
+
+    /* The head is the single largest matvec in the model — 151936 rows against
+     * 896 for a 0.5B Qwen — so running it at every prompt position spends a
+     * tenth of the prefill on distributions nobody reads. */
+    if (logits) {
+        pft = pf_mark();
+        rmsnorm(xn, x + (long)(n - 1) * E, m->out_norm, E, eps);
+        const wt *lm_head = m->has_output_weight ? &m->out_weight : &m->tok_emb;
+        qmv(logits, lm_head, xn);
+        pf_add(PF_HEAD, pft);
+    }
+
+    free(x); free(xn); free(q_all); free(k_new); free(v_new);
+    free(attn_out); free(ffn_gate); free(ffn_up); free(ffn_out);
+}
+
+const nt_arch nt_arch_llama = {
+    .names = NULL,          /* the fallback: whatever nobody else claims */
+    .load = llama_load,
+    .free = llama_free,
+    .forward = llama_forward,
+};

--- a/harness/logo.h
+++ b/harness/logo.h
@@ -1,0 +1,28 @@
+/* logo.h — the banner, and the one rule about it.
+ *
+ * It goes to stderr. stdout carries what the model said and nothing else, so
+ * `notorch model.gguf "prompt" > out.txt` writes text and not decoration. */
+#ifndef NT_HARNESS_LOGO_H
+#define NT_HARNESS_LOGO_H
+
+#include <stdio.h>
+#include <unistd.h>
+
+static const char *const NT_LOGO[] = {
+    "             _                 _     ",
+    " _ __   ___ | |_ ___  _ __ ___| |__  ",
+    "| '_ \\ / _ \\| __/ _ \\| '__/ __| '_ \\ ",
+    "| | | | (_) | || (_) | | | (__| | | |",
+    "|_| |_|\\___/ \\__\\___/|_|  \\___|_| |_|",
+};
+
+/* Quiet when asked, and quiet when nobody is watching — a pipe or a log file
+ * gets the work, not the letterhead. */
+static void nt_logo(int quiet) {
+    if (quiet || !isatty(2)) return;
+    for (unsigned i = 0; i < sizeof(NT_LOGO) / sizeof(NT_LOGO[0]); i++)
+        fprintf(stderr, "%s\n", NT_LOGO[i]);
+    fprintf(stderr, "  neural networks in C\n\n");
+}
+
+#endif

--- a/harness/main.c
+++ b/harness/main.c
@@ -1,0 +1,246 @@
+/* main.c — notorch, the harness.
+ *
+ *   notorch model.gguf                    chat in the terminal
+ *   notorch model.gguf "prompt"           one shot
+ *   notorch model.gguf "prompt" 64 0.8    tokens, temperature
+ *
+ * One rule about output: stdout carries what the model said, stderr carries
+ * everything else — the banner, the shape of the model, the prompt you typed,
+ * timings, the profile. A run redirected to a file is text, not a transcript
+ * of the tool.
+ *
+ * Architectures are a table. Adding a family is adding a file next to
+ * arch_llama.c and one line to ARCHS. */
+#include "harness/arch.h"
+#include "harness/logo.h"
+#include "examples/bpe.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const nt_arch *const ARCHS[] = {
+    &nt_arch_llama,
+};
+
+/* Exact name first, the unnamed fallback second. The reference example ran any
+ * architecture it had never heard of through the llama forward, and losing
+ * that on the way here would have been a regression dressed as a refactor. */
+static const nt_arch *pick_arch(const char *arch) {
+    const nt_arch *fallback = NULL;
+    for (unsigned i = 0; i < sizeof(ARCHS) / sizeof(ARCHS[0]); i++) {
+        const nt_arch *a = ARCHS[i];
+        if (!a->names) { fallback = a; continue; }
+        for (const char *const *n = a->names; *n; n++)
+            if (strcmp(*n, arch) == 0) return a;
+    }
+    return fallback;
+}
+
+/* Everything a turn needs, so one-shot and chat run the same code. */
+typedef struct {
+    const nt_arch *arch;
+    void *model;
+    kv_cache *kv;
+    bpe_tokenizer *tok;
+    int eos, vocab, max_seq;
+    float *logits;
+} session;
+
+/* GGUF-embedded BPE where the file has one; bytes where it does not, which is
+ * how the char-level models in this tree are read. */
+static int encode_prompt(const session *s, const char *text, int *tokens, int cap) {
+    if (s->tok) return bpe_encode(s->tok, text, tokens, cap);
+    int n = 0;
+    if (cap > 0) tokens[n++] = 1;                  /* BOS */
+    for (int i = 0; text[i] && n < cap; i++) tokens[n++] = (unsigned char)text[i];
+    return n;
+}
+
+static void emit(const session *s, int id) {
+    char piece[256];
+    if (s->tok) {
+        bpe_decode_token(s->tok, id, piece, sizeof(piece));
+        fputs(piece, stdout);
+    } else if (id >= 32 && id < 127) putchar((char)id);
+    else if (id == 10) putchar('\n');
+    else printf("[%d]", id);
+    fflush(stdout);
+}
+
+/* Prompt in, text out, cache advanced. Returns the position after the last
+ * token written, so a chat turn can hand it to the next one.
+ *
+ * Prefill is chunked rather than one call for the whole prompt: the batch
+ * buffers are n × FFN floats, and a chunk of 32 is where the weight traffic is
+ * already amortized while the working set still fits the caches. The KV cache
+ * carries context across chunks, so a chunk sees every position before it
+ * exactly as a single pass would. */
+static int run_turn(session *s, const int *tokens, int n_tok, int pos0,
+                    int max_tokens, float temp, int show_stats) {
+    double gen0 = now_ms();
+    for (int i = 0; i < n_tok; i += NT_PREFILL_CHUNK) {
+        int cn = n_tok - i; if (cn > NT_PREFILL_CHUNK) cn = NT_PREFILL_CHUNK;
+        s->arch->forward(s->model, s->kv, tokens + i, cn, pos0 + i,
+                         (i + cn == n_tok) ? s->logits : NULL);
+    }
+    double prefill_ms = now_ms() - gen0;
+    pf_report("prefill", prefill_ms);
+    pf_reset();
+
+    int pos = pos0 + n_tok, gen = 0;
+    for (int step = 0; step < max_tokens; step++) {
+        int next = sample(s->logits, s->vocab, temp);
+        if (s->tok ? (next == s->eos) : (next <= 2)) break;
+        emit(s, next);
+        gen++;
+        if (pos >= s->max_seq - 1) break;
+        s->arch->forward(s->model, s->kv, &next, 1, pos, s->logits);
+        pos++;
+    }
+    putchar('\n');
+    fflush(stdout);
+
+    double total_ms = now_ms() - gen0;
+    if (show_stats)
+        fprintf(stderr, "\n── prefill: %d tok %.0fms (%.1f t/s) | decode: %d tok %.0fms (%.1f t/s) ──\n",
+                n_tok, prefill_ms, n_tok * 1000.0 / prefill_ms,
+                gen, total_ms - prefill_ms,
+                gen > 0 ? gen * 1000.0 / (total_ms - prefill_ms) : 0);
+    pf_report("decode", total_ms - prefill_ms);
+    return pos;
+}
+
+/* Chat: the cache is the conversation. Each turn appends to it, so the model
+ * sees everything said so far without re-reading a transcript. /reset drops
+ * it, /exit and end-of-input leave. When the context fills, say so rather than
+ * silently answering from a truncated past. */
+static void chat(session *s, int max_tokens, float temp) {
+    int *tokens = (int*)malloc((size_t)s->max_seq * sizeof(int));
+    if (!tokens) return;
+    char line[4096];
+    int pos = 0;
+    fprintf(stderr, "chat — /reset clears the context, /exit leaves (ctx %d)\n\n", s->max_seq);
+    for (;;) {
+        fprintf(stderr, "> ");
+        fflush(stderr);
+        if (!fgets(line, sizeof(line), stdin)) break;
+        line[strcspn(line, "\n")] = '\0';
+        if (strcmp(line, "/exit") == 0 || strcmp(line, "/quit") == 0) break;
+        if (strcmp(line, "/reset") == 0) {
+            memset(s->kv->k, 0, (size_t)s->kv->n_layers * s->kv->max_seq * s->kv->kv_dim * sizeof(float));
+            memset(s->kv->v, 0, (size_t)s->kv->n_layers * s->kv->max_seq * s->kv->kv_dim * sizeof(float));
+            pos = 0;
+            fprintf(stderr, "  (context cleared)\n");
+            continue;
+        }
+        if (!line[0]) continue;
+
+        int room = s->max_seq - pos - max_tokens - 1;
+        if (room <= 0) {
+            fprintf(stderr, "  (context full at %d tokens — /reset to start over)\n", pos);
+            continue;
+        }
+        int n = encode_prompt(s, line, tokens, room);
+        if (n <= 0) continue;
+        pos = run_turn(s, tokens, n, pos, max_tokens, temp, 0);
+    }
+    free(tokens);
+}
+
+static void usage(const char *self) {
+    fprintf(stderr,
+        "usage: %s [-q] [-n tokens] [-t temp] <model.gguf> [prompt] [max_tokens] [temp]\n"
+        "  no prompt        chat in the terminal\n"
+        "  -q               no banner\n"
+        "  -n, -t           tokens and temperature, for chat as well as one shot\n"
+        "  NT_CTX=N         context length for chat (default 2048)\n"
+        "  NT_PROFILE=1     per-section timings\n", self);
+}
+
+int main(int argc, char **argv) {
+    int quiet = 0, ai = 1;
+    int flag_n = -1; float flag_t = -1.0f;
+    /* The positional form is what examples/infer_llama.c takes and what the
+     * parity gate drives; the flags are for chat, which has no prompt to hang
+     * positional arguments behind. */
+    while (ai < argc && argv[ai][0] == '-' && argv[ai][1] && !argv[ai][2]) {
+        char f = argv[ai][1];
+        if (f == 'q') { quiet = 1; ai++; continue; }
+        if ((f == 'n' || f == 't') && ai + 1 < argc) {
+            if (f == 'n') flag_n = atoi(argv[ai + 1]);
+            else flag_t = (float)atof(argv[ai + 1]);
+            ai += 2; continue;
+        }
+        break;
+    }
+    if (ai >= argc) { nt_logo(quiet); usage(argv[0]); return 1; }
+
+    nt_logo(quiet);
+    const char *path = argv[ai];
+
+    double t0 = now_ms();
+    gguf_file *gf = gguf_open(path);
+    if (!gf) return 1;
+
+    const nt_arch *arch = pick_arch(gf->arch);
+    if (!arch) {
+        fprintf(stderr, "notorch: no architecture handles '%s'\n", gf->arch);
+        gguf_close(gf);
+        return 1;
+    }
+
+    nt_dims dims = {0};
+    void *model = arch->load(gf, &dims);
+    if (!model) { gguf_close(gf); return 1; }
+    fprintf(stderr, "loaded in %.0f ms\n", now_ms() - t0);
+
+    session s = { .arch = arch, .model = model, .vocab = dims.vocab, .eos = -1 };
+    s.tok = bpe_load(path);
+    if (s.tok) {
+        const gguf_kv *e = gguf_get_kv(gf, "tokenizer.ggml.eos_token_id");
+        if (e) s.eos = (int)e->val.u32;
+        fprintf(stderr, "tokenizer: GGUF BPE (vocab=%d eos=%d)\n", bpe_n_vocab(s.tok), s.eos);
+    } else {
+        fprintf(stderr, "tokenizer: byte-level fallback (no GGUF BPE vocab)\n");
+    }
+
+    const char *prompt = (ai + 1 < argc) ? argv[ai + 1] : NULL;
+    int max_tokens = (ai + 2 < argc) ? atoi(argv[ai + 2]) : 50;
+    float temp = (ai + 3 < argc) ? (float)atof(argv[ai + 3]) : 0.8f;
+    if (flag_n > 0) max_tokens = flag_n;
+    if (flag_t >= 0.0f) temp = flag_t;
+    if (max_tokens < 1) max_tokens = 1;
+
+    pf_on = getenv("NT_PROFILE") != NULL;
+    s.logits = (float*)calloc(dims.vocab, sizeof(float));
+    int rc = 0;
+
+    if (prompt) {
+        /* Size the cache to the job. The reference example carried a fixed 256
+         * and clamped the prompt into what was left, which turns a long prompt
+         * into a quietly truncated one. */
+        int cap = 8192;
+        int *tokens = (int*)malloc((size_t)cap * sizeof(int));
+        int n_tok = tokens ? encode_prompt(&s, prompt, tokens, cap - max_tokens - 1) : 0;
+        if (n_tok <= 0) { fprintf(stderr, "notorch: empty prompt\n"); rc = 1; }
+        else {
+            s.max_seq = n_tok + max_tokens + 1;
+            s.kv = kv_new(dims.n_layers, s.max_seq, dims.kv_dim);
+            fprintf(stderr, "\nprompt: \"%s\" (%d tokens, temp=%.2f)\n", prompt, n_tok, temp);
+            fputs(prompt, stdout);
+            fflush(stdout);
+            run_turn(&s, tokens, n_tok, 0, max_tokens, temp, 1);
+        }
+        free(tokens);
+    } else {
+        const char *ctx = getenv("NT_CTX");
+        s.max_seq = ctx ? atoi(ctx) : 2048;
+        if (s.max_seq < max_tokens + 2) s.max_seq = max_tokens + 2;
+        s.kv = kv_new(dims.n_layers, s.max_seq, dims.kv_dim);
+        chat(&s, max_tokens, temp);
+    }
+
+    if (s.tok) bpe_free(s.tok);
+    free(s.logits); kv_free(s.kv); arch->free(model); gguf_close(gf);
+    return rc;
+}

--- a/harness/runtime.c
+++ b/harness/runtime.c
@@ -1,0 +1,199 @@
+/* runtime.c — see runtime.h. Lifted from examples/infer_llama.c unchanged in
+ * arithmetic; the gate that keeps it that way is harness/test_parity.sh. */
+#include "harness/runtime.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <sys/time.h>
+#include <time.h>
+#if defined(__ARM_NEON)
+#include <arm_neon.h>
+#endif
+
+#ifdef USE_BLAS
+  #ifdef ACCELERATE
+    #include <Accelerate/Accelerate.h>
+  #else
+    #include <cblas.h>
+  #endif
+#endif
+
+/* Both entry points report whether they could take the shape, so ask them once
+ * with a single row rather than duplicating their dtype tables here and letting
+ * the two drift. */
+static void wt_probe(wt *w) {
+    if (!w->q || w->cols <= 0) return;
+    float *x = (float*)calloc(w->cols, sizeof(float));
+    float out = 0.0f;
+    if (x) {
+        w->use_i8 = (nt_qmatvec_i8(&out, w->q, w->dtype, x, 1, w->cols) == 0);
+        if (!w->use_i8 && nt_qmatvec(&out, w->q, w->dtype, x, 1, w->cols) != 0) {
+            w->q = NULL;   /* no packed path — the loader will expand it */
+        }
+        free(x);
+    }
+}
+
+int wt_load(wt *w, gguf_file *gf, const char *name) {
+    int ti = gguf_find_tensor(gf, name);
+    if (ti < 0) return 0;
+    const gguf_tensor_info *t = &gf->tensors[ti];
+    if (!t->shape[0] || t->n_elements % t->shape[0]) return 0;
+    w->cols  = (int)t->shape[0];
+    w->rows  = (int)(t->n_elements / t->shape[0]);
+    w->dtype = (int)t->dtype;
+    w->q     = gf->data + t->offset;
+    wt_probe(w);
+    if (!w->q) w->f32 = gguf_dequant(gf, ti);
+    return (w->q || w->f32) ? 1 : 0;
+}
+
+kv_cache *kv_new(int nl, int max_seq, int kv_dim) {
+    kv_cache *kv = (kv_cache*)calloc(1, sizeof(kv_cache));
+    if (!kv) return NULL;
+    kv->k = (float*)calloc((long)nl * max_seq * kv_dim, sizeof(float));
+    kv->v = (float*)calloc((long)nl * max_seq * kv_dim, sizeof(float));
+    kv->max_seq = max_seq; kv->n_layers = nl; kv->kv_dim = kv_dim;
+    return kv;
+}
+
+void kv_free(kv_cache *kv) { if (!kv) return; free(kv->k); free(kv->v); free(kv); }
+
+// C[m,n] = A[m,k] @ B^T[n,k]
+void mm_t(float *C, const float *A, const float *B, int m, int k, int n) {
+#ifdef USE_BLAS
+    cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasTrans,
+                m, n, k, 1.0f, A, k, B, k, 0.0f, C, n);
+#else
+    for (int i = 0; i < m; i++)
+        for (int j = 0; j < n; j++) {
+            float s = 0;
+            for (int p = 0; p < k; p++) s += A[i*k+p] * B[j*k+p];
+            C[i*n+j] = s;
+        }
+#endif
+}
+
+void qmv(float *out, const wt *w, const float *x) {
+    if (w->use_i8 && nt_qmatvec_i8(out, w->q, w->dtype, x, w->rows, w->cols) == 0) return;
+    if (w->q && nt_qmatvec(out, w->q, w->dtype, x, w->rows, w->cols) == 0) return;
+    mm_t(out, x, w->f32, 1, w->cols, w->rows);
+}
+
+void qmm(float *out, const wt *w, const float *X, int n) {
+    if (n > 1 && w->use_i8 && w->q &&
+        nt_qmatmul_i8(out, w->q, w->dtype, X, w->rows, w->cols, n) == 0) return;
+    for (int j = 0; j < n; j++)
+        qmv(out + (long)j * w->rows, w, X + (long)j * w->cols);
+}
+
+/* Attention reads the KV cache, not the weights, so batching left it untouched
+ * — and once the matmuls stopped dominating it surfaced as the second line of
+ * the profile. Both loops are f32 over head_dim, which is 64 or 128 in every
+ * model here and always a multiple of four, so four lanes cover them with a
+ * scalar tail for anything odd. The four partial sums make this a different
+ * summation order from the scalar loop, hence a different last bit; that is a
+ * change to attention's arithmetic, not to its meaning. */
+float dot_f32(const float *a, const float *b, int n) {
+    int i = 0; float s = 0.0f;
+#if defined(__ARM_NEON)
+    float32x4_t acc = vdupq_n_f32(0.0f);
+    for (; i + 4 <= n; i += 4) acc = vfmaq_f32(acc, vld1q_f32(a + i), vld1q_f32(b + i));
+    s = vaddvq_f32(acc);
+#endif
+    for (; i < n; i++) s += a[i] * b[i];
+    return s;
+}
+
+void axpy_f32(float *y, float alpha, const float *x, int n) {
+    int i = 0;
+#if defined(__ARM_NEON)
+    float32x4_t va = vdupq_n_f32(alpha);
+    for (; i + 4 <= n; i += 4)
+        vst1q_f32(y + i, vfmaq_f32(vld1q_f32(y + i), va, vld1q_f32(x + i)));
+#endif
+    for (; i < n; i++) y[i] += alpha * x[i];
+}
+
+void rmsnorm(float *out, const float *x, const float *w, int n, float eps) {
+    float ss = 0;
+    for (int i = 0; i < n; i++) ss += x[i] * x[i];
+    float inv = 1.0f / sqrtf(ss / n + eps);
+    for (int i = 0; i < n; i++) out[i] = w[i] * x[i] * inv;
+}
+
+void softmax(float *x, int n) {
+    float mx = x[0];
+    for (int i = 1; i < n; i++) if (x[i] > mx) mx = x[i];
+    float s = 0;
+    for (int i = 0; i < n; i++) { x[i] = expf(x[i] - mx); s += x[i]; }
+    for (int i = 0; i < n; i++) x[i] /= s;
+}
+
+void rope(float *x, int pos, int head_dim, float freq_base, int neox) {
+    int half = head_dim / 2;
+    for (int i = 0; i < half; i++) {
+        float freq = 1.0f / powf(freq_base, 2.0f * i / head_dim);
+        float angle = pos * freq;
+        float cs = cosf(angle), sn = sinf(angle);
+        int a = neox ? i : 2*i, b = neox ? i + half : 2*i + 1;
+        float x0 = x[a], x1 = x[b];
+        x[a] = x0 * cs - x1 * sn;
+        x[b] = x0 * sn + x1 * cs;
+    }
+}
+
+void add_bias(float *x, const float *bias, int n) {
+    if (bias) for (int i = 0; i < n; i++) x[i] += bias[i];
+}
+
+int sample(float *logits, int n, float temp) {
+    /* temp 0 means greedy, and dividing by it means every logit becomes an
+     * infinity, the softmax becomes NaN, the cumulative comparison never fires
+     * and the caller silently receives the last token in the vocabulary on
+     * every step. Take the argmax instead. */
+    if (temp <= 0.0f) {
+        int best = 0;
+        for (int i = 1; i < n; i++) if (logits[i] > logits[best]) best = i;
+        return best;
+    }
+    for (int i = 0; i < n; i++) logits[i] /= temp;
+    softmax(logits, n);
+    float r = (float)rand() / (float)RAND_MAX, cum = 0;
+    for (int i = 0; i < n; i++) { cum += logits[i]; if (cum >= r) return i; }
+    return n - 1;
+}
+
+double now_ms(void) {
+    struct timeval tv; gettimeofday(&tv, NULL);
+    return tv.tv_sec * 1000.0 + tv.tv_usec / 1000.0;
+}
+
+// ── Section timing ───────────────────────────────────────────────────────────
+
+static const char *pf_name[PF_N] = { "embed", "rmsnorm", "qkv+bias", "rope+kv",
+                                     "attention", "attn proj", "ffn matmul",
+                                     "silu", "residual", "head" };
+static double pf_acc[PF_N];
+int pf_on = 0;
+
+static double pf_now(void) {
+    struct timespec ts; clock_gettime(CLOCK_MONOTONIC, &ts);
+    return ts.tv_sec + ts.tv_nsec * 1e-9;
+}
+double pf_mark(void) { return pf_on ? pf_now() : 0.0; }
+void   pf_add(int slot, double t0) { if (pf_on) pf_acc[slot] += pf_now() - t0; }
+void   pf_reset(void) { for (int i = 0; i < PF_N; i++) pf_acc[i] = 0.0; }
+
+void pf_report(const char *phase, double wall_ms) {
+    if (!pf_on) return;
+    double sum = 0;
+    for (int i = 0; i < PF_N; i++) sum += pf_acc[i];
+    fprintf(stderr, "\n[profile] %s — %.0f ms wall, %.0f ms accounted\n",
+            phase, wall_ms, sum * 1e3);
+    for (int i = 0; i < PF_N; i++)
+        if (pf_acc[i] > 0)
+            fprintf(stderr, "  %-11s %8.0f ms  %5.1f%%\n", pf_name[i], pf_acc[i] * 1e3,
+                    wall_ms > 0 ? pf_acc[i] * 1e5 / wall_ms : 0.0);
+}

--- a/harness/runtime.h
+++ b/harness/runtime.h
@@ -1,0 +1,91 @@
+/* runtime.h — the parts of running a transformer that no architecture owns.
+ *
+ * A weight as it sits in the file, a KV cache, the scalar pieces every family
+ * uses, and the two matvec entry points that decide packed vs int8 vs BLAS.
+ * Architectures live next door in arch_*.c and are the only thing that changes
+ * when a new model family arrives.
+ *
+ * Lifted from examples/infer_llama.c, which stays where it is as the reference
+ * this was measured against. */
+#ifndef NT_HARNESS_RUNTIME_H
+#define NT_HARNESS_RUNTIME_H
+
+#include "gguf.h"
+#include "notorch.h"
+
+/* Prompt positions carried through the weights together. Wider amortizes the
+ * weight read further; past the caches it starts paying it back in misses, and
+ * 32 is where the batched kernel's own tile sits. */
+#ifndef NT_PREFILL_CHUNK
+#define NT_PREFILL_CHUNK 32
+#endif
+
+/* A weight as it sits in the file, plus the one thing worth deciding once.
+ *
+ * Expanding every tensor to f32 at load is 6 GB for a 1.5B Q4_0 whose packed
+ * form is 1.1 GB, and on an 8 GB phone that is not a slowdown but a reboot.
+ * The packed bytes are already resident — gguf_open reads the file into one
+ * buffer — so a weight here is a pointer into it and nothing is copied.
+ *
+ * f32 is the escape hatch: a dtype with no packed kernel gets expanded, alone,
+ * and the matvec falls through to BLAS for that one tensor. Probing at load
+ * rather than per call keeps the decision off the hot path. */
+typedef struct {
+    const uint8_t *q;   /* into gf->data; NULL only if the tensor is absent */
+    float *f32;         /* expanded copy, allocated only when q has no kernel */
+    int dtype, rows, cols;
+    int use_i8;         /* the integer path applies to this dtype and shape */
+} wt;
+
+int  wt_load(wt *w, gguf_file *gf, const char *name);
+
+typedef struct {
+    float *k, *v;
+    int max_seq, n_layers, kv_dim;
+} kv_cache;
+
+kv_cache *kv_new(int n_layers, int max_seq, int kv_dim);
+void      kv_free(kv_cache *kv);
+
+/* out[rows] = W[rows,cols] @ x[cols] — the only matmul shape decode asks for. */
+void qmv(float *out, const wt *w, const float *x);
+/* n activation rows through one weight matrix, weights read once for the group
+ * where the batched kernel has the dtype and row-at-a-time where it does not. */
+void qmm(float *out, const wt *w, const float *X, int n);
+
+void  mm_t(float *C, const float *A, const float *B, int m, int k, int n);
+float dot_f32(const float *a, const float *b, int n);
+void  axpy_f32(float *y, float alpha, const float *x, int n);
+void  rmsnorm(float *out, const float *x, const float *w, int n, float eps);
+void  softmax(float *x, int n);
+void  add_bias(float *x, const float *bias, int n);
+
+/* Two rotation conventions share the name RoPE and differ only in which pairs
+ * of lanes rotate together, which makes a mismatch quiet rather than fatal: the
+ * model still emits fluent text, it just answers the wrong question. NORM pairs
+ * adjacent lanes (2i, 2i+1) and is what llama-architecture GGUFs carry; NEOX
+ * pairs a lane with its opposite half (i, i + hd/2) and is what qwen2 and
+ * friends carry. The architecture picks, because one binary reads both. */
+void rope(float *x, int pos, int head_dim, float freq_base, int neox);
+
+int    sample(float *logits, int n, float temp);
+double now_ms(void);
+
+/* ── Section timing ──────────────────────────────────────────────────────────
+ * Off unless NT_PROFILE is set, because the answer to "where does prefill go"
+ * stopped being obvious once the weights were read once per chunk instead of
+ * once per token. Two timestamps per section per chunk, so at 24 layers the
+ * clock reads cost nothing next to the work they bracket, and with the flag
+ * unset each call is one predicted branch. Reports go to stderr with the rest
+ * of the diagnostics. */
+enum { PF_EMBED, PF_NORM, PF_QKV, PF_ROPE, PF_ATTN, PF_PROJ, PF_FFN, PF_SILU,
+       PF_RESID, PF_HEAD, PF_N };
+
+extern int pf_on;
+
+double pf_mark(void);
+void   pf_add(int slot, double t0);
+void   pf_reset(void);
+void   pf_report(const char *phase, double wall_ms);
+
+#endif

--- a/harness/test_parity.sh
+++ b/harness/test_parity.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# test_parity.sh — the harness must say exactly what the example says.
+#
+# examples/infer_llama.c stays in the tree as the reference: it is what the
+# phone numbers were measured with and what Defender runs models through. This
+# moved its forward into harness/ and claimed the arithmetic came along
+# unchanged. At temp 0 that claim is checkable to the byte.
+#
+#   ./harness/test_parity.sh [model.gguf ...]
+#
+# With no argument it uses whichever of its default models are on this machine
+# and says so when none are. Needs ./notorch and ./infer_llama built.
+set -eu
+cd "$(dirname "$0")/.."
+
+[ -x ./notorch ] || { echo "test_parity: ./notorch not built (make harness)"; exit 1; }
+[ -x ./infer_llama ] || { echo "test_parity: ./infer_llama not built (make llama)"; exit 1; }
+
+MODELS="$*"
+if [ -z "$MODELS" ]; then
+  for m in "$HOME/arianna/weights/nano_arianna_full_resft_2026_07_09/nano_arianna_q8_0.gguf" \
+           "$HOME/arianna/weights/nano_arianna_full_resft_2026_07_09/nano_arianna_q4_k_m.gguf"; do
+    [ -f "$m" ] && MODELS="$MODELS $m"
+  done
+fi
+if [ -z "$MODELS" ]; then
+  echo "parity  (no model given and no default on this machine — pass a .gguf)"
+  echo "NOTORCH_PARITY_SKIPPED"
+  exit 0
+fi
+
+# The reference prints its diagnostics on stdout with the text. Take what sits
+# between the prompt line and the timing rule, minus the blank line the rule
+# brings with it. The harness needs no such surgery: its stdout is the text.
+ref_text() {
+  awk '
+    /^prompt: "/  { on = 1; next }
+    on && /^── prefill:/ { exit }
+    on           { buf[n++] = $0 }
+    END          { for (i = 0; i < n - 1; i++) print buf[i] }
+  '
+}
+
+FAILS=0
+for M in $MODELS; do
+  NAME=$(basename "$M")
+  for P in "The capital of France is" "Resonance is" "def fibonacci(n):"; do
+    A=$(./notorch "$M" "$P" 24 0 2>/dev/null)
+    B=$(./infer_llama "$M" "$P" 24 0 2>/dev/null | ref_text)
+    if [ "$A" = "$B" ]; then
+      echo "parity  [$NAME] \"$P\"  identical  PASS"
+    else
+      echo "parity  [$NAME] \"$P\"  FAIL"
+      echo "  harness: $A"
+      echo "  example: $B"
+      FAILS=$((FAILS + 1))
+    fi
+  done
+done
+
+if [ "$FAILS" -eq 0 ]; then
+  echo "NOTORCH_PARITY_OK"
+else
+  echo "NOTORCH_PARITY_FAIL ($FAILS)"
+  exit 1
+fi


### PR DESCRIPTION
`harness/` — the simple way to run a model.

```
notorch model.gguf                 chat in the terminal
notorch model.gguf "prompt"        one shot
notorch -n 64 -t 0.8 model.gguf    tokens, temperature
```

**The move.** The forward, KV cache, sampler and scalar pieces came out of `examples/infer_llama.c` into `harness/runtime.c` and `harness/arch_llama.c` with the arithmetic untouched. `harness/test_parity.sh` is what says so — it compares the generated continuation against the example at temp 0 and gets six identical answers across two models and three prompts. Timing overlaps within run-to-run noise: prefill 1352 / 1391 / 1394 t/s against the example's 1321 / 1470 / 1463, decode 428 / 495 / 597 against 479 / 492 / 592, nano_arianna Q8_0 on an A18 Pro.

The example stays where it is: it is what the phone numbers were measured with and what models are tested through. Two copies of one forward is the debt this takes on knowingly, and it closes when the harness has earned the reference's job.

**Two decisions worth naming.** stdout is the model, stderr is everything else — banner, model shape, the prompt you typed, timings, profile — so a redirected run is text and not a transcript of the tool. And architectures are a table: `nt_arch` is names, load, free, forward, and llama registers with `names = NULL` as the fallback, which is what the example already did with every architecture it had never heard of. Adding a family should be adding a file and one line; if it ever needs a branch inside `runtime.c`, the interface is lying.

**Red hand, both failure modes a move like this has.** Flipping the RoPE convention turned all six parity checks red with fluent text that answers a different question. Writing the KV one position early turned them red with `,I.AIeiIH:` where the example says `,anewfield,anewarchitecture.`

**And the harness caught something older than itself.** Its reason to exist is a person typing a sentence and reading one back, which is a harder test of the tokenizer than any benchmark — and the text came back without spaces.

`examples/bpe.c` implements GPT-2 byte-level BPE. nano_arianna carries `tokenizer.ggml.model = "llama"` — SentencePiece — where 22965 of 32000 tokens begin with U+2581 and none begin with `Ġ`. Encode maps a space to `Ġ`, finds no such token, and drops it silently: "The capital of France is Paris." is 31 bytes and comes back as 26 tokens, five short, one per space, every remaining token a single character from the tail of the vocabulary rather than a merge. Decode cannot map U+2581 back either — the table it reads is 512 entries wide and that codepoint is 9601.

The gate for this already existed and had never been pointed here: `bpe.c` built with `-DBPE_TEST` prints `BPE_FAIL (roundtrip=0 merges_applied=1)` on this file, and `merges_applied` is only true because five tokens went missing. Byte-level vocabularies — Qwen2.5, SmolLM2 — are unaffected and always were.

Not caused by this move; made visible by it. It is the next thing to fix, before another architecture is added.

Gates: `NOTORCH_PARITY_OK`; notorch_test 49/49 and 73/73, test_qmatmul 34/34. `test_quantize` still fails Q8_0 at 2.081e-04 over its 2.067e-04 bound, unchanged since `cd659e8`.