### PR TITLE
tokenizer-spm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,6 +221,12 @@ notorch: $(HARNESS_SRC) $(HARNESS_HDR)
 test_harness: notorch llama
 	./harness/test_parity.sh $(MODEL)
 
+# Tokenizer round-trip. Needs a model, because the thing being tested is what
+# the file says about itself: MODEL=path/to.gguf make test_bpe
+test_bpe: examples/bpe.c gguf.c notorch.c
+	$(CC) $(CFLAGS) -DBPE_TEST -o /tmp/nt_bpe_test examples/bpe.c gguf.c notorch.c -lm
+	/tmp/nt_bpe_test $(MODEL)
+
 # ── Training ──
 
 train_q: examples/train_q.c notorch.c notorch.h

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,57 @@ Newest entries on top.
 
 ---
 
+## 2026-08-24 — the tokenizer speaks SentencePiece
+
+`examples/bpe.c` implemented byte-level BPE and nothing else, and every
+LLaMA-family GGUF in this tree carries SentencePiece. The two schemes share a
+file format and share nothing else: one has a merge list and merges by rank,
+the other has a score per token, writes space as U+2581, and falls back to
+`<0xHH>` tokens for anything its vocabulary does not cover. Run the first over
+the second and a space encodes to `Ġ`, which is not in the vocabulary, and the
+old code dropped it without a word.
+
+Which scheme a file carries is now decided by what it hands over — a merge
+list, or scores without one — and not by the name in `tokenizer.ggml.model`.
+That is deliberate: the name is a label, the arrays are what make an algorithm
+possible.
+
+The SentencePiece path prepends the dummy space these vocabularies were built
+over, splits into UTF-8 characters, and merges the highest-scoring adjacent
+pair until no adjacent pair is a token. Pair scores live beside the symbols and
+only the two around a merge are recomputed, so the vocabulary is consulted O(n)
+times for a whole string instead of once per scan; finding the best pair is a
+walk, which at the length of a chat line is cheaper than a heap. Anything the
+vocabulary does not carry goes out as bytes, and anything that cannot even do
+that now says so on stderr instead of vanishing.
+
+On nano_arianna Q8_0: "The capital of France is Paris." was 26 tokens, five
+short of its 31 bytes, one missing per space, every token a single character
+from the tail of the vocabulary. It is now **7 tokens** and decodes back to
+itself. What the model does with that is the whole point — the same prompt at
+temp 0 used to continue `,anewfield,anewarchitecture.` and now continues `the
+cathedral of the French language, the most important document in the world.`
+
+The gate had existed and had never been aimed here. It now runs six strings
+including a leading-and-trailing-space case and an emoji no vocabulary carries,
+across both schemes, and it asserts one thing a round-trip alone cannot:
+**merges have to be doing something.** Red hand proved why. Removing the U+2581
+substitution left every round-trip green — the byte fallback rebuilds the text
+from `<0x20>` — and only the token count gave it away, 15 against 7. Removing
+the byte fallback turned the emoji case red as `'🔥 fire' -> '  fire'`, which is
+the original bug's exact shape. A round-trip is not enough; a round-trip plus a
+count is.
+
+Byte-level vocabularies were correct before and are untouched: smallcoder-303M
+at 49152 tokens and a Qwen3 at 151936 both pass all seven checks. `make test_bpe
+MODEL=…`. Harness/example parity stays green, because the fix landed in the file
+they share.
+
+Open and named: the JS edition's `GgufBPE` in `js-edition/infer_gguf.mjs` splits
+on spaces the same way and has the same hole for SentencePiece files.
+
+---
+
 ## 2026-08-24 — a harness, and the tokenizer it caught
 
 `harness/` is the simple way to run a model: `notorch model.gguf "prompt"` for

--- a/examples/bpe.c
+++ b/examples/bpe.c
@@ -69,10 +69,33 @@ static int utf8_dec(const char *s, int *cp) {
 struct bpe_tokenizer {
     char **tokens; int n_tokens;   /* id -> token string */
     smap vocab;                    /* token string -> id */
-    smap merges;                   /* "A B" -> rank */
+    smap merges;                   /* "A B" -> rank (byte-level only) */
     int byte_cp[256];
     int cp2byte[512];
+    /* SentencePiece: no merge list, a score per token, space written U+2581,
+     * and every byte available as a "<0xHH>" token to fall back on. */
+    int spm;
+    float *scores;
+    int byte_id[256];              /* byte -> id of "<0xHH>", or -1 */
 };
+
+/* U+2581 LOWER ONE EIGHTH BLOCK — SentencePiece's space. */
+#define SPM_SPACE "\xE2\x96\x81"
+
+/* The value of a "<0xHH>" token, or -1 for anything else. */
+static int byte_token_value(const char *s) {
+    if (!s || s[0] != '<' || s[1] != '0' || s[2] != 'x' || s[5] != '>' || s[6]) return -1;
+    int hi = -1, lo = -1;
+    for (int k = 0; k < 2; k++) {
+        char c = s[3 + k];
+        int v = (c >= '0' && c <= '9') ? c - '0'
+              : (c >= 'A' && c <= 'F') ? c - 'A' + 10
+              : (c >= 'a' && c <= 'f') ? c - 'a' + 10 : -1;
+        if (v < 0) return -1;
+        if (k == 0) hi = v; else lo = v;
+    }
+    return hi * 16 + lo;
+}
 
 bpe_tokenizer *bpe_load(const char *path) {
     int nt = 0;
@@ -90,6 +113,27 @@ bpe_tokenizer *bpe_load(const char *path) {
     for (int i = 0; i < nm; i++) if (mg[i]) smap_put(&t->merges, mg[i], i); /* rank = line index */
     for (int i = 0; i < nm; i++) free(mg[i]);
     free(mg);
+
+    /* Which scheme this file carries is decided by what it gives us to work
+     * with, not by the name it goes under: a merge list means byte-level BPE
+     * and merge ranks; a score per token and no merges means SentencePiece,
+     * where the same two operations do not exist. Getting this wrong is quiet
+     * — byte-level encode over a SentencePiece vocabulary finds no token for a
+     * space and used to drop it, which reads as text with the spaces missing. */
+    int ns = 0;
+    float *scores = gguf_read_f32_array(path, "tokenizer.ggml.scores", &ns);
+    if (nm <= 0 && scores && ns == nt) {
+        t->spm = 1;
+        t->scores = scores;
+        for (int b = 0; b < 256; b++) {
+            char name[8];
+            snprintf(name, sizeof(name), "<0x%02X>", b);
+            t->byte_id[b] = smap_get(&t->vocab, name);
+        }
+    } else {
+        free(scores);
+        for (int b = 0; b < 256; b++) t->byte_id[b] = -1;
+    }
     return t;
 }
 
@@ -98,13 +142,113 @@ void bpe_free(bpe_tokenizer *t) {
     for (int i = 0; i < t->n_tokens; i++) free(t->tokens[i]);
     free(t->tokens);
     smap_free(&t->vocab); smap_free(&t->merges);
+    free(t->scores);
     free(t);
 }
 
 int bpe_n_vocab(const bpe_tokenizer *t) { return t ? t->n_tokens : 0; }
 int bpe_token_id(const bpe_tokenizer *t, const char *token) { return t ? smap_get(&t->vocab, token) : -1; }
 
+/* A symbol that no token covers and no byte token can carry. Said once per
+ * process, because the alternative — the old behaviour — was saying nothing
+ * and returning a sentence with holes in it. */
+static void warn_dropped(const char *what) {
+    static int said = 0;
+    if (said) return;
+    said = 1;
+    fprintf(stderr, "bpe: no token and no byte fallback for %s — input is being lost\n", what);
+}
+
+/* ── SentencePiece ──────────────────────────────────────────────────────────
+ * Spaces become U+2581 and one is prepended, which is what these vocabularies
+ * were built over: 22965 of nano_arianna's 32000 tokens begin with it. Symbols
+ * start as UTF-8 characters and the adjacent pair with the highest score is
+ * merged until no adjacent pair is a token, which is SentencePiece's rule and
+ * not BPE's rank order.
+ *
+ * The pair scores are kept beside the symbols and only the two around a merge
+ * are recomputed, so the vocabulary is consulted O(n) times for the whole
+ * string rather than once per scan. Finding the best pair is still a walk, and
+ * at the length of a chat line that walk is cheaper than a heap. */
+static int spm_encode(const bpe_tokenizer *t, const char *text, int *out, int cap) {
+    size_t L = strlen(text);
+    char *buf = (char*)malloc((L + 1) * 3 + 1);
+    if (!buf) return 0;
+    size_t bl = 0;
+    memcpy(buf + bl, SPM_SPACE, 3); bl += 3;            /* add_dummy_prefix */
+    for (size_t i = 0; i < L; i++) {
+        if (text[i] == ' ') { memcpy(buf + bl, SPM_SPACE, 3); bl += 3; }
+        else buf[bl++] = text[i];
+    }
+    buf[bl] = 0;
+
+    int *off = (int*)malloc((bl + 1) * sizeof(int));
+    int *len = (int*)malloc((bl + 1) * sizeof(int));
+    int *prv = (int*)malloc((bl + 1) * sizeof(int));
+    int *nxt = (int*)malloc((bl + 1) * sizeof(int));
+    float *ps = (float*)malloc((bl + 1) * sizeof(float));
+    char *tmp = (char*)malloc(bl + 1);
+    if (!off || !len || !prv || !nxt || !ps || !tmp) {
+        free(buf); free(off); free(len); free(prv); free(nxt); free(ps); free(tmp);
+        return 0;
+    }
+
+    int n = 0;
+    for (size_t i = 0; i < bl; ) {
+        unsigned char c = (unsigned char)buf[i];
+        int adv = (c < 0x80) ? 1 : (c < 0xE0) ? 2 : (c < 0xF0) ? 3 : 4;
+        if (i + (size_t)adv > bl) adv = 1;
+        off[n] = (int)i; len[n] = adv;
+        prv[n] = n - 1; nxt[n] = -1;
+        if (n > 0) nxt[n - 1] = n;
+        n++; i += adv;
+    }
+
+    /* score of merging symbol i with the one after it, or "not a token" */
+    #define PAIR(i) do { \
+        int r_ = nxt[i]; \
+        if (r_ < 0) { ps[i] = -1e30f; break; } \
+        memcpy(tmp, buf + off[i], (size_t)(len[i] + len[r_])); \
+        tmp[len[i] + len[r_]] = 0; \
+        int id_ = smap_get(&t->vocab, tmp); \
+        ps[i] = (id_ >= 0) ? t->scores[id_] : -1e30f; \
+    } while (0)
+
+    for (int i = 0; i < n; i++) PAIR(i);
+
+    for (;;) {
+        int bi = -1; float best = -1e30f;
+        for (int i = 0; i >= 0; i = nxt[i]) if (ps[i] > best) { best = ps[i]; bi = i; }
+        if (bi < 0) break;                       /* nothing adjacent is a token */
+        int r = nxt[bi];
+        len[bi] += len[r];
+        nxt[bi] = nxt[r];
+        if (nxt[r] >= 0) prv[nxt[r]] = bi;
+        PAIR(bi);
+        if (prv[bi] >= 0) PAIR(prv[bi]);
+    }
+    #undef PAIR
+
+    int no = 0;
+    for (int i = 0; i >= 0 && no < cap; i = nxt[i]) {
+        memcpy(tmp, buf + off[i], (size_t)len[i]);
+        tmp[len[i]] = 0;
+        int id = smap_get(&t->vocab, tmp);
+        if (id >= 0) { out[no++] = id; continue; }
+        /* One character the vocabulary does not carry. Its bytes do. */
+        for (int b = 0; b < len[i] && no < cap; b++) {
+            int bid = t->byte_id[(unsigned char)buf[off[i] + b]];
+            if (bid >= 0) out[no++] = bid;
+            else warn_dropped(tmp);
+        }
+    }
+
+    free(buf); free(off); free(len); free(prv); free(nxt); free(ps); free(tmp);
+    return no;
+}
+
 int bpe_encode(const bpe_tokenizer *t, const char *text, int *out, int cap) {
+    if (t && t->spm) return spm_encode(t, text, out, cap);
     int no = 0, L = (int)strlen(text), i = 0;
     while (i < L) {
         /* pre-tok piece: [i, j) — a leading space (if any) stays with the run that follows */
@@ -136,7 +280,8 @@ int bpe_encode(const bpe_tokenizer *t, const char *text, int *out, int cap) {
         }
         for (int b = 0; b < ns; b++) {
             int id = smap_get(&t->vocab, sym[b]);
-            if (id >= 0 && no < cap) out[no++] = id;
+            if (id >= 0) { if (no < cap) out[no++] = id; }
+            else warn_dropped(sym[b]);
             free(sym[b]);
         }
         free(sym);
@@ -148,6 +293,25 @@ int bpe_encode(const bpe_tokenizer *t, const char *text, int *out, int cap) {
 int bpe_decode_token(const bpe_tokenizer *t, int id, char *buf, int cap) {
     if (!t || id < 0 || id >= t->n_tokens || !t->tokens[id]) return 0;
     const char *s = t->tokens[id];
+    if (t->spm) {
+        /* A byte token carries one byte. Everything else is text in which
+         * U+2581 stands for a space — three bytes wide, so the table the
+         * byte-level path reads (512 entries) could never have mapped it. */
+        int bv = byte_token_value(s);
+        if (bv >= 0) {
+            if (cap < 2) { if (cap > 0) buf[0] = 0; return 0; }
+            buf[0] = (char)bv; buf[1] = 0; return 1;
+        }
+        int n = 0;
+        for (int i = 0; s[i] && n < cap - 1; ) {
+            if ((unsigned char)s[i] == 0xE2 && (unsigned char)s[i+1] == 0x96
+                                            && (unsigned char)s[i+2] == 0x81) {
+                buf[n++] = ' '; i += 3;
+            } else buf[n++] = s[i++];
+        }
+        buf[n] = 0;
+        return n;
+    }
     int L = (int)strlen(s), i = 0, n = 0;
     while (i < L && n < cap - 1) {
         int cp; int adv = utf8_dec(s + i, &cp); i += adv;
@@ -159,24 +323,63 @@ int bpe_decode_token(const bpe_tokenizer *t, int id, char *buf, int cap) {
 }
 
 #ifdef BPE_TEST
+/* The gate this file had all along, pointed at both schemes instead of one.
+ *
+ * What it asserts is the property a tokenizer has to have and the one that was
+ * broken: text goes in and the same text comes back. SentencePiece prepends a
+ * space to what it encodes — add_dummy_prefix, which is what these vocabularies
+ * were built over — so the expected answer there carries one leading space and
+ * says so rather than being trimmed into looking tidy.
+ *
+ *   cc -O2 -I. -DBPE_TEST -o bpe_test examples/bpe.c gguf.c notorch.c -lm
+ *   ./bpe_test model.gguf   → BPE_OK
+ */
 int main(int argc, char **argv) {
-    if (argc < 2) { printf("usage: %s <gguf> [text]\n", argv[0]); return 1; }
+    if (argc < 2) { printf("usage: %s <gguf> [text ...]\n", argv[0]); return 1; }
     bpe_tokenizer *t = bpe_load(argv[1]);
     if (!t) { printf("bpe_load failed\n"); return 1; }
-    printf("vocab=%d\n", bpe_n_vocab(t));
-    const char *text = argc > 2 ? argv[2] : "Privet, mir! Hello world.";
-    int ids[1024];
-    int n = bpe_encode(t, text, ids, 1024);
-    printf("input '%s' (%d bytes) -> %d tokens\n", text, (int)strlen(text), n);
-    printf("ids:"); for (int i = 0; i < n && i < 24; i++) printf(" %d", ids[i]); printf("\n");
-    char out[4096]; int on = 0;
-    for (int i = 0; i < n; i++) on += bpe_decode_token(t, ids[i], out + on, (int)sizeof(out) - on);
-    out[on] = 0;
-    printf("decode '%s'\n", out);
-    int roundtrip = (strcmp(out, text) == 0);
-    int merged = (n < (int)strlen(text));
-    printf("%s (roundtrip=%d merges_applied=%d)\n", (roundtrip && merged) ? "BPE_OK" : "BPE_FAIL", roundtrip, merged);
+    printf("bpe  vocab=%d scheme=%s\n", bpe_n_vocab(t),
+           t->spm ? "sentencepiece (scores, U+2581, byte fallback)"
+                  : "byte-level BPE (merge ranks)");
+
+    static const char *DEFAULT_CASES[] = {
+        "The capital of France is Paris.",
+        "Privet, mir! Hello world.",
+        "  leading and trailing  ",
+        "1234567890 !@#$%^&*()",
+        "resonance",
+        "\xF0\x9F\x94\xA5 fire",          /* not in any of these vocabularies */
+    };
+    const char **cases = DEFAULT_CASES;
+    int ncase = (int)(sizeof(DEFAULT_CASES) / sizeof(DEFAULT_CASES[0]));
+    if (argc > 2) { cases = (const char**)&argv[2]; ncase = argc - 2; }
+
+    int fails = 0, ids[4096];
+    char out[8192], want[8192];
+    for (int c = 0; c < ncase; c++) {
+        const char *text = cases[c];
+        int n = bpe_encode(t, text, ids, 4096);
+        int on = 0;
+        for (int i = 0; i < n; i++)
+            on += bpe_decode_token(t, ids[i], out + on, (int)sizeof(out) - on);
+        out[on] = 0;
+        snprintf(want, sizeof(want), "%s%s", t->spm ? " " : "", text);
+        int ok = (strcmp(out, want) == 0);
+        if (!ok) fails++;
+        printf("bpe  [%d tok / %d bytes] '%s' -> '%s'  %s\n",
+               n, (int)strlen(text), text, out, ok ? "PASS" : "FAIL");
+    }
+
+    /* Merges have to be doing something: a sentence of words must cost far
+     * fewer tokens than it has bytes. Character-at-a-time encoding passes a
+     * round-trip and is still wrong, which is exactly how this hid. */
+    int n = bpe_encode(t, "The capital of France is Paris.", ids, 4096);
+    int merged = (n * 3 <= 31);
+    if (!merged) fails++;
+    printf("bpe  [merges] 31 bytes -> %d tokens  %s\n", n, merged ? "PASS" : "FAIL");
+
+    printf("%s\n", fails ? "BPE_FAIL" : "BPE_OK");
     bpe_free(t);
-    return (roundtrip && merged) ? 0 : 1;
+    return fails ? 1 : 0;
 }
 #endif

--- a/examples/bpe.h
+++ b/examples/bpe.h
@@ -1,8 +1,17 @@
-/* bpe.h — byte-level BPE (GPT-2 / Tekken style) over a GGUF tokenizer.
- * Reads tokenizer.ggml.tokens + tokenizer.ggml.merges from the GGUF and
- * implements encode (UTF-8 text -> token ids) and per-token decode.
- * Generic: works for any GGUF whose tokenizer is byte-level BPE
- * (LFM2.5 dev target, Qwen3 qyent, Mistral/Tekken oyent).
+/* bpe.h — the GGUF tokenizer, in both schemes GGUF files come in.
+ *
+ * Byte-level BPE (GPT-2 / Tekken): tokenizer.ggml.tokens + .merges, merged by
+ * rank. Qwen3, SmolLM2, Mistral/Tekken.
+ *
+ * SentencePiece: tokenizer.ggml.tokens + .scores and no merges, space written
+ * U+2581, merged by score, with "<0xHH>" tokens to fall back on. LLaMA,
+ * Mistral's older vocabularies, and every nanollama in this tree.
+ *
+ * Which one a file carries is decided by what it provides — a merge list, or
+ * scores without one — not by the name in tokenizer.ggml.model. Running the
+ * wrong one is quiet: byte-level encode over a SentencePiece vocabulary finds
+ * no token for a space and used to drop it, and the model read a sentence with
+ * the spaces missing.
  */
 #ifndef BPE_H
 #define BPE_H

--- a/gguf.c
+++ b/gguf.c
@@ -251,6 +251,39 @@ char** gguf_read_str_array(const char* path, const char* key, int* out_n) {
     return result;
 }
 
+float* gguf_read_f32_array(const char* path, const char* key, int* out_n) {
+    if (out_n) *out_n = 0;
+    FILE* f = fopen(path, "rb");
+    if (!f) return NULL;
+    uint32_t magic;
+    if (!read_u32(f, &magic) || magic != GGUF_MAGIC) { fclose(f); return NULL; }
+    uint32_t version; uint64_t n_tensors, n_kv;
+    read_u32(f, &version); read_u64(f, &n_tensors); read_u64(f, &n_kv);
+    float* result = NULL;
+    for (uint64_t i = 0; i < n_kv; i++) {
+        char k[512] = {0};
+        uint32_t vtype;
+        if (!read_string(f, k, sizeof(k)) || !read_u32(f, &vtype)) break;
+        if (strcmp(k, key) == 0 && vtype == 9) {
+            uint32_t atype; uint64_t alen;
+            if (!read_u32(f, &atype) || !read_u64(f, &alen) || atype != 6) break;  // 6 = FLOAT32
+            if (alen > GGUF_MAX_STR_ARRAY) {
+                fprintf(stderr, "gguf: f32-array '%s' len %llu exceeds GGUF_MAX_STR_ARRAY=%u; refusing\n",
+                        key, (unsigned long long)alen, (unsigned)GGUF_MAX_STR_ARRAY);
+                break;
+            }
+            result = (float*)calloc(alen ? alen : 1, sizeof(float));
+            if (!result) break;
+            uint64_t got = fread(result, sizeof(float), alen, f);
+            if (out_n) *out_n = (int)got;   // actually-read count, not claimed alen
+            break;
+        }
+        if (!skip_value(f, vtype)) break;
+    }
+    fclose(f);
+    return result;
+}
+
 // ── Dequantization ───────────────────────────────────────────────────────────
 
 // F16 → F32 conversion

--- a/gguf.h
+++ b/gguf.h
@@ -105,6 +105,10 @@ const gguf_kv* gguf_get_kv(const gguf_file* gf, const char* key);
 // of *out_n strdup'd strings, or NULL if absent. Caller frees each string + the array.
 char** gguf_read_str_array(const char* path, const char* key, int* out_n);
 
+// Same for a type-9 FLOAT32 array (e.g. "tokenizer.ggml.scores"). Returns a
+// malloc'd float* of *out_n values, or NULL if the key is absent or not f32.
+float* gguf_read_f32_array(const char* path, const char* key, int* out_n);
+
 // Print GGUF summary
 void gguf_print_info(const gguf_file* gf);
 


### PR DESCRIPTION
`examples/bpe.c` implemented byte-level BPE and nothing else, and every LLaMA-family GGUF in this tree carries SentencePiece.

The two schemes share a file format and share nothing else: one has a merge list and merges by rank, the other has a score per token, writes space as U+2581, and falls back to `<0xHH>` tokens for anything its vocabulary does not cover. Run the first over the second and a space encodes to `Ġ`, which is not in the vocabulary — and the old code dropped it without a word.

**Detection is by capability, not by name.** Which scheme a file carries is decided by what it hands over — a merge list, or scores without one — not by the string in `tokenizer.ggml.model`. The name is a label; the arrays are what make an algorithm possible.

**The SentencePiece path** prepends the dummy space these vocabularies were built over, splits into UTF-8 characters, and merges the highest-scoring adjacent pair until no adjacent pair is a token. Pair scores live beside the symbols and only the two around a merge are recomputed, so the vocabulary is consulted O(n) times for a whole string instead of once per scan; finding the best pair is a walk, which at the length of a chat line is cheaper than a heap. Anything the vocabulary does not carry goes out as bytes, and anything that cannot even do that now says so on stderr instead of vanishing.

**What it was worth.** On nano_arianna Q8_0, "The capital of France is Paris." was 26 tokens against its 31 bytes — five short, one per space, every token a single character from the tail of the vocabulary. It is now **7 tokens** and decodes back to itself. The same prompt at temp 0 used to continue

> ,anewfield,anewarchitecture.

and now continues

> the cathedral of the French language, the most important document in the world.

**The gate existed and had never been aimed here.** It now runs six strings across both schemes — including leading-and-trailing spaces and an emoji no vocabulary carries — and asserts one thing a round-trip alone cannot: *merges have to be doing something*.

Red hand proved that necessary. Removing the U+2581 substitution left **every round-trip green** — the byte fallback rebuilds the text out of `<0x20>` — and only the token count gave it away, 15 against 7. Removing the byte fallback turned the emoji case red as `'🔥 fire' -> '  fire'`, which is the original bug's exact shape.

Byte-level vocabularies were correct before and are untouched: smallcoder-303M at 49152 tokens and a Qwen3 at 151936 both pass all seven checks. `make test_bpe MODEL=…`.

`gguf` gained `gguf_read_f32_array` for the scores. Harness/example parity stays green because the fix landed in the file they share — `infer_llama` is fixed by the same commit, which matters for the models being tested through it.

Gates: `BPE_OK` on nano_arianna Q8_0 and smallcoder-303M, `NOTORCH_PARITY_OK`, notorch_test 49/49 and 73/73, test_qmatmul 34/34. `test_quantize` still fails Q8_0 at 2.081e-04 over its 2.067e-04 bound, unchanged since `cd659e8`.

**Open and named:** `js-edition/infer_gguf.mjs`'s `GgufBPE` splits on spaces the same way and has the same hole for SentencePiece files.