### PR TITLE
the method read the tokenizer the file actually carries

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ SIMD_LIBS  = -lpthread
 
 # ── Targets ──
 
-.PHONY: all test test_qpool test_js test_python clean cpu gpu simd help lib shared install metal test_metal infer_gguf_metal
+.PHONY: all test test_qpool test_js test_python test_tokenizer clean cpu gpu simd help lib shared install metal test_metal infer_gguf_metal
 
 all: notorch_test
 	@echo "Built with $(BLAS_NAME). Run: ./notorch_test"
@@ -220,6 +220,11 @@ notorch: $(HARNESS_SRC) $(HARNESS_HDR)
 # nothing. MODEL= to point it at one file, otherwise it looks for its defaults.
 test_harness: notorch llama
 	./harness/test_parity.sh $(MODEL)
+
+# Tokenizer ids against llama.cpp's, which is the only definition of a tokenizer being
+# right. Skips itself where llama-tokenize is not installed. MODEL= to aim it.
+test_tokenizer: notorch
+	./harness/test_tokenizer.sh $(MODEL)
 
 # Tokenizer round-trip. Needs a model, because the thing being tested is what
 # the file says about itself: MODEL=path/to.gguf make test_bpe

--- a/examples/bpe.c
+++ b/examples/bpe.c
@@ -57,11 +57,20 @@ static int utf8_enc(int cp, char *out) {
     if (cp < 0x800) { out[0] = (char)(0xC0 | (cp >> 6)); out[1] = (char)(0x80 | (cp & 0x3F)); return 2; }
     out[0] = (char)(0xE0 | (cp >> 12)); out[1] = (char)(0x80 | ((cp >> 6) & 0x3F)); out[2] = (char)(0x80 | (cp & 0x3F)); return 3;
 }
+/* Four-byte sequences are not an edge case, they are every emoji. Without this arm a lead
+ * byte of 0xF0 was taken as one character and the three continuation bytes as three more,
+ * none of which is a legal token, so a vocabulary that has 🍦 whole fell back to four byte
+ * tokens for it — correct text out, wrong ids, and the ids are the model's input. */
 static int utf8_dec(const char *s, int *cp) {
     unsigned char c = (unsigned char)s[0];
     if (c < 0x80) { *cp = c; return 1; }
     if ((c >> 5) == 0x6) { *cp = ((c & 0x1F) << 6) | ((unsigned char)s[1] & 0x3F); return 2; }
     if ((c >> 4) == 0xE) { *cp = ((c & 0xF) << 12) | (((unsigned char)s[1] & 0x3F) << 6) | ((unsigned char)s[2] & 0x3F); return 3; }
+    if ((c >> 3) == 0x1E) {
+        *cp = ((c & 0x07) << 18) | (((unsigned char)s[1] & 0x3F) << 12)
+            | (((unsigned char)s[2] & 0x3F) << 6) | ((unsigned char)s[3] & 0x3F);
+        return 4;
+    }
     *cp = c; return 1;
 }
 
@@ -77,6 +86,14 @@ struct bpe_tokenizer {
     int spm;
     float *scores;
     int byte_id[256];              /* byte -> id of "<0xHH>", or -1 */
+    /* Gemma 4 is the third shape and it is not deducible from the file's contents: it
+     * carries BOTH a merge list and a score per token, so the "merges means byte-level,
+     * scores means SentencePiece" rule sends it to the wrong one. It is SPM-style BPE —
+     * spaces written U+2581 and byte fallback like SentencePiece, merges by rank on raw
+     * UTF-8 like BPE, and no word-level pre-split at all, only a break at newlines. The
+     * only signal is the name in tokenizer.ggml.model, which is what llama.cpp reads too. */
+    int spm_bpe;
+    int add_bos, bos_id;
 };
 
 /* U+2581 LOWER ONE EIGHTH BLOCK — SentencePiece's space. */
@@ -133,6 +150,26 @@ bpe_tokenizer *bpe_load(const char *path) {
     } else {
         free(scores);
         for (int b = 0; b < 256; b++) t->byte_id[b] = -1;
+    }
+
+    /* The name settles what the contents cannot. Gemma 4 hands us merges and scores both,
+     * and it wants neither of the two paths above. */
+    char model_name[64] = {0};
+    if (gguf_read_str_kv(path, "tokenizer.ggml.model", model_name, sizeof(model_name)) == 0 &&
+        strcmp(model_name, "gemma4") == 0 && nm > 0) {
+        t->spm = 0;
+        t->spm_bpe = 1;
+        for (int b = 0; b < 256; b++) {
+            char name[8];
+            snprintf(name, sizeof(name), "<0x%02X>", b);
+            t->byte_id[b] = smap_get(&t->vocab, name);
+        }
+        /* This family always opens with <bos>, and the file says so rather than the code
+         * assuming it. Getting it wrong costs more than a token: Gemma without its opening
+         * marker answers a different question. */
+        uint64_t v = 0;
+        t->bos_id = (gguf_read_uint_kv(path, "tokenizer.ggml.bos_token_id", &v) == 0) ? (int)v : 2;
+        t->add_bos = (gguf_read_uint_kv(path, "tokenizer.ggml.add_bos_token", &v) == 0) ? (int)v : 1;
     }
     return t;
 }
@@ -247,13 +284,116 @@ static int spm_encode(const bpe_tokenizer *t, const char *text, int *out, int ca
     return no;
 }
 
+/* Gemma 4: spaces become U+2581, the text is broken only where newlines are, and each piece
+ * is merged by rank over its UTF-8 characters. No word-level pre-split, which is the part
+ * that separates this from byte-level BPE — a merge is allowed to cross what other families
+ * treat as a word boundary, and forbidding that is what produced nine tokens where the
+ * reference produces five. */
+static int spm_bpe_encode(const bpe_tokenizer *t, const char *text, int *out, int cap) {
+    int no = 0;
+    if (t->add_bos && no < cap) out[no++] = t->bos_id;
+
+    /* Escape first: one pass, ' ' -> three bytes. */
+    int L = (int)strlen(text);
+    char *esc = (char*)malloc((size_t)L * 3 + 1);
+    if (!esc) return no;
+    int el = 0;
+    for (int i = 0; i < L; i++) {
+        if (text[i] == ' ') { memcpy(esc + el, SPM_SPACE, 3); el += 3; }
+        else esc[el++] = text[i];
+    }
+    esc[el] = 0;
+
+    int i = 0;
+    while (i < el) {
+        /* One chunk is a run of newlines or a run of everything else. */
+        int nl = (esc[i] == '\n');
+        int j = i;
+        while (j < el && ((esc[j] == '\n') == nl)) j++;
+
+        /* A pure run of newlines that the vocabulary already has stays whole — the merge
+         * table cannot be consulted for it, and llama.cpp special-cases it the same way. */
+        char whole[64];
+        if (nl && j - i < (int)sizeof(whole)) {
+            memcpy(whole, esc + i, (size_t)(j - i));
+            whole[j - i] = 0;
+            int id = smap_get(&t->vocab, whole);
+            if (id >= 0) {
+                if (no < cap) out[no++] = id;
+                i = j;
+                continue;
+            }
+        }
+
+        /* Symbols start as UTF-8 characters, then merge by lowest rank. */
+        int nsym = 0;
+        for (int p = i; p < j; ) { int cp; p += utf8_dec(esc + p, &cp); nsym++; }
+        char **sym = (char**)malloc((size_t)nsym * sizeof(char*));
+        int s = 0;
+        for (int p = i; p < j; ) {
+            int cp; int n = utf8_dec(esc + p, &cp);
+            sym[s] = (char*)malloc((size_t)n + 1);
+            memcpy(sym[s], esc + p, (size_t)n); sym[s][n] = 0;
+            p += n; s++;
+        }
+        int ns = nsym;
+        while (ns > 1) {
+            int best_rank = INT_MAX, bi = -1;
+            char key[512];
+            for (int b = 0; b < ns - 1; b++) {
+                if (strlen(sym[b]) + strlen(sym[b + 1]) + 2 > sizeof(key)) continue;
+                snprintf(key, sizeof(key), "%s %s", sym[b], sym[b + 1]);
+                int r = smap_get(&t->merges, key);
+                if (r >= 0 && r < best_rank) { best_rank = r; bi = b; }
+            }
+            if (bi < 0) break;
+            char *merged = (char*)malloc(strlen(sym[bi]) + strlen(sym[bi + 1]) + 1);
+            strcpy(merged, sym[bi]); strcat(merged, sym[bi + 1]);
+            free(sym[bi]); free(sym[bi + 1]); sym[bi] = merged;
+            for (int b = bi + 1; b < ns - 1; b++) sym[b] = sym[b + 1];
+            ns--;
+        }
+        for (int b = 0; b < ns; b++) {
+            int id = smap_get(&t->vocab, sym[b]);
+            if (id >= 0) { if (no < cap) out[no++] = id; }
+            else {
+                /* Byte fallback, one <0xHH> per byte of whatever did not resolve. */
+                for (const unsigned char *p = (const unsigned char*)sym[b]; *p; p++) {
+                    int bid = t->byte_id[*p];
+                    if (bid >= 0) { if (no < cap) out[no++] = bid; }
+                    else warn_dropped(sym[b]);
+                }
+            }
+            free(sym[b]);
+        }
+        free(sym);
+        i = j;
+    }
+    free(esc);
+    return no;
+}
+
 int bpe_encode(const bpe_tokenizer *t, const char *text, int *out, int cap) {
+    if (t && t->spm_bpe) return spm_bpe_encode(t, text, out, cap);
     if (t && t->spm) return spm_encode(t, text, out, cap);
     int no = 0, L = (int)strlen(text), i = 0;
     while (i < L) {
-        /* pre-tok piece: [i, j) — a leading space (if any) stays with the run that follows */
-        int j = i + 1;
-        while (j < L && text[j] != ' ') j++;
+        /* pre-tok piece: [i, j). One space belongs to the run that follows it, but a RUN of
+         * spaces does not — GPT-2 splits `\s+(?!\S)` off first, so four spaces before a word
+         * are three spaces and then " word". Taking each space as its own piece instead is
+         * quiet on prose and loud on code: an indented line came out as three separate
+         * space tokens where the reference emits one, and every position after it shifted. */
+        int j;
+        int run = 0;
+        while (i + run < L && text[i + run] == ' ') run++;
+        if (run > 1) {
+            /* A run of spaces: all but the last are one piece, and the last one goes with
+             * the word after it. At end of text there is no word, so the run stays whole. */
+            j = (i + run < L) ? i + run - 1 : L;
+        } else {
+            j = i + 1;
+            while (j < L && text[j] != ' ') j++;
+        }
         int nsym = j - i;
         char **sym = (char**)malloc(nsym * sizeof(char*));
         for (int b = 0; b < nsym; b++) {
@@ -293,7 +433,7 @@ int bpe_encode(const bpe_tokenizer *t, const char *text, int *out, int cap) {
 int bpe_decode_token(const bpe_tokenizer *t, int id, char *buf, int cap) {
     if (!t || id < 0 || id >= t->n_tokens || !t->tokens[id]) return 0;
     const char *s = t->tokens[id];
-    if (t->spm) {
+    if (t->spm || t->spm_bpe) {
         /* A byte token carries one byte. Everything else is text in which
          * U+2581 stands for a space — three bytes wide, so the table the
          * byte-level path reads (512 entries) could never have mapped it. */
@@ -383,3 +523,16 @@ int main(int argc, char **argv) {
     return fails ? 1 : 0;
 }
 #endif
+
+/* End of generation is not always one id. Gemma 4 closes a turn with <turn|> and answers a
+ * tool call with <|tool_response>, and a run that only watches <eos> prints those markers as
+ * text and keeps going — which is what this harness did on its first gemma run. llama.cpp
+ * carries the same list for this family; nothing is assumed for the others, where the eos id
+ * from the file is the whole answer. */
+int bpe_is_eog(const bpe_tokenizer *t, int id) {
+    if (!t || id < 0 || id >= t->n_tokens || !t->tokens[id]) return 0;
+    if (!t->spm_bpe) return 0;
+    const char *s = t->tokens[id];
+    return strcmp(s, "<eos>") == 0 || strcmp(s, "<turn|>") == 0 ||
+           strcmp(s, "<|tool_response>") == 0;
+}

--- a/examples/bpe.h
+++ b/examples/bpe.h
@@ -35,4 +35,8 @@ int bpe_decode_token(const bpe_tokenizer *t, int id, char *buf, int cap);
 /* id of an exact token string (e.g. "<|im_start|>"), or -1 if absent. */
 int bpe_token_id(const bpe_tokenizer *t, const char *token);
 
+/* Whether an id ends the generation for this file, beyond the eos id in the metadata.
+ * Some families close a turn with a marker of their own. */
+int bpe_is_eog(const bpe_tokenizer *t, int id);
+
 #endif /* BPE_H */

--- a/gguf.c
+++ b/gguf.c
@@ -212,6 +212,66 @@ const gguf_kv* gguf_get_kv(const gguf_file* gf, const char* key) {
 // Arrays are skipped during gguf_open, so this re-scans the file. Returns a malloc'd
 // char** of *out_n strdup'd strings, or NULL if the key/array is absent. Caller frees
 // each string and the array.
+/* One string value by key, without opening the tensor data. gguf_open reads the whole data
+ * section, which for a 2.6 GB model is a strange price for one word, and the tokenizer needs
+ * exactly one: which scheme the file was written in. Scans the metadata and stops. */
+int gguf_read_str_kv(const char* path, const char* key, char* out, int cap) {
+    if (!out || cap <= 0) return -1;
+    out[0] = 0;
+    FILE* f = fopen(path, "rb");
+    if (!f) return -1;
+    uint32_t magic;
+    if (!read_u32(f, &magic) || magic != GGUF_MAGIC) { fclose(f); return -1; }
+    uint32_t version; uint64_t n_tensors, n_kv;
+    read_u32(f, &version); read_u64(f, &n_tensors); read_u64(f, &n_kv);
+    int found = -1;
+    for (uint64_t i = 0; i < n_kv; i++) {
+        char k[512] = {0};
+        uint32_t vtype;
+        if (!read_string(f, k, sizeof(k)) || !read_u32(f, &vtype)) break;
+        if (strcmp(k, key) == 0 && vtype == 8) {
+            char buf[512] = {0};
+            if (read_string(f, buf, sizeof(buf))) {
+                snprintf(out, (size_t)cap, "%s", buf);
+                found = 0;
+            }
+            break;
+        }
+        if (!skip_value(f, vtype)) break;
+    }
+    fclose(f);
+    return found;
+}
+
+/* One integer-ish value by key — u32, i32, bool or u64 — on the same terms as the string
+ * reader above: metadata only, no tensor bytes. The tokenizer needs its BOS id and whether
+ * to add one, and both are scalars sitting next to a 262144-entry vocabulary. */
+int gguf_read_uint_kv(const char* path, const char* key, uint64_t* out) {
+    if (!out) return -1;
+    FILE* f = fopen(path, "rb");
+    if (!f) return -1;
+    uint32_t magic;
+    if (!read_u32(f, &magic) || magic != GGUF_MAGIC) { fclose(f); return -1; }
+    uint32_t version; uint64_t n_tensors, n_kv;
+    read_u32(f, &version); read_u64(f, &n_tensors); read_u64(f, &n_kv);
+    int found = -1;
+    for (uint64_t i = 0; i < n_kv; i++) {
+        char k[512] = {0};
+        uint32_t vtype;
+        if (!read_string(f, k, sizeof(k)) || !read_u32(f, &vtype)) break;
+        if (strcmp(k, key) == 0) {
+            if (vtype == 4)      { uint32_t v; if (read_u32(f, &v)) { *out = v; found = 0; } }
+            else if (vtype == 5) { int32_t v; if (fread(&v, 4, 1, f) == 1) { *out = (uint64_t)v; found = 0; } }
+            else if (vtype == 7) { uint8_t v; if (fread(&v, 1, 1, f) == 1) { *out = v; found = 0; } }
+            else if (vtype == 10 || vtype == 12) { uint64_t v; if (read_u64(f, &v)) { *out = v; found = 0; } }
+            break;
+        }
+        if (!skip_value(f, vtype)) break;
+    }
+    fclose(f);
+    return found;
+}
+
 char** gguf_read_str_array(const char* path, const char* key, int* out_n) {
     if (out_n) *out_n = 0;
     FILE* f = fopen(path, "rb");

--- a/gguf.h
+++ b/gguf.h
@@ -106,6 +106,12 @@ const gguf_kv* gguf_get_kv(const gguf_file* gf, const char* key);
 // of *out_n strdup'd strings, or NULL if absent. Caller frees each string + the array.
 char** gguf_read_str_array(const char* path, const char* key, int* out_n);
 
+// One string metadata value by key, read without loading tensor data. Returns 0 on success.
+int gguf_read_str_kv(const char* path, const char* key, char* out, int cap);
+
+// One integer metadata value by key (u32, i32, bool or u64). Returns 0 on success.
+int gguf_read_uint_kv(const char* path, const char* key, uint64_t* out);
+
 // Same for a type-9 FLOAT32 array (e.g. "tokenizer.ggml.scores"). Returns a
 // malloc'd float* of *out_n values, or NULL if the key is absent or not f32.
 float* gguf_read_f32_array(const char* path, const char* key, int* out_n);

--- a/harness/main.c
+++ b/harness/main.c
@@ -106,7 +106,7 @@ static int run_turn(session *s, const int *tokens, int n_tok, int pos0,
     int pos = pos0 + n_tok, gen = 0;
     for (int step = 0; step < max_tokens; step++) {
         int next = sample(s->logits, s->vocab, temp);
-        if (s->tok ? (next == s->eos) : (next <= 2)) break;
+        if (s->tok ? (next == s->eos || bpe_is_eog(s->tok, next)) : (next <= 2)) break;
         emit(s, next);
         gen++;
         if (pos >= s->max_seq - 1) break;
@@ -179,9 +179,14 @@ int main(int argc, char **argv) {
     /* The positional form is what examples/infer_llama.c takes and what the
      * parity gate drives; the flags are for chat, which has no prompt to hang
      * positional arguments behind. */
+    int tokenize_only = 0;
     while (ai < argc && argv[ai][0] == '-' && argv[ai][1] && !argv[ai][2]) {
         char f = argv[ai][1];
         if (f == 'q') { quiet = 1; ai++; continue; }
+        /* -T prints the ids and stops. A family arrives with two ways to be wrong and this
+         * separates them: the tokenizer can be diffed against another implementation without
+         * loading a single weight, and the forward can be fed ids through NT_TOKENS. */
+        if (f == 'T') { tokenize_only = 1; quiet = 1; ai++; continue; }
         if ((f == 'n' || f == 't') && ai + 1 < argc) {
             if (f == 'n') flag_n = atoi(argv[ai + 1]);
             else flag_t = (float)atof(argv[ai + 1]);
@@ -193,6 +198,18 @@ int main(int argc, char **argv) {
 
     nt_logo(quiet);
     const char *path = argv[ai];
+
+    if (tokenize_only) {
+        bpe_tokenizer *tok = bpe_load(path);
+        if (!tok) { fprintf(stderr, "notorch: no tokenizer in %s\n", path); return 1; }
+        const char *text = (ai + 1 < argc) ? argv[ai + 1] : "";
+        int ids[8192];
+        int n = bpe_encode(tok, text, ids, (int)(sizeof(ids) / sizeof(ids[0])));
+        for (int i = 0; i < n; i++) printf("%d%s", ids[i], i + 1 < n ? "," : "\n");
+        if (n == 0) printf("\n");
+        bpe_free(tok);
+        return 0;
+    }
 
     double t0 = now_ms();
     gguf_file *gf = gguf_open(path);

--- a/harness/test_tokenizer.sh
+++ b/harness/test_tokenizer.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+# test_tokenizer.sh — our ids against llama.cpp's, on the same file, for the same text.
+#
+# A tokenizer is either identical to the reference or it is a different model wearing the
+# same weights: one token of drift moves every position after it. So the gate is the id
+# sequence, not the round-trip — a tokenizer can round-trip perfectly and still split
+# differently, which is exactly how gemma-4 arrived here (nine tokens where llama.cpp makes
+# six, and the text decoded back fine).
+#
+#   ./harness/test_tokenizer.sh <model.gguf> [more.gguf ...]
+#
+# Needs ./notorch built (make harness) and llama-tokenize on PATH or in the Termux prefix.
+# Says so and skips when either is missing, because a gate that cannot run should not pass.
+set -eu
+cd "$(dirname "$0")/.."
+
+[ -x ./notorch ] || { echo "test_tokenizer: ./notorch not built (make harness)"; exit 1; }
+
+REF=""
+for c in llama-tokenize /data/data/com.termux/files/usr/bin/llama-tokenize; do
+  command -v "$c" >/dev/null 2>&1 && REF="$c" && break
+  [ -x "$c" ] && REF="$c" && break
+done
+if [ -z "$REF" ]; then
+  echo "tokenizer  (no llama-tokenize on this machine — nothing to compare against)"
+  echo "NOTORCH_TOKENIZER_SKIPPED"
+  exit 0
+fi
+
+MODELS="$*"
+if [ -z "$MODELS" ]; then
+  # $HOME is not always where the models are — this tree is often run from a chroot whose
+  # home is elsewhere than the one holding the files, so look beside the repo as well.
+  for m in "$HOME/models/gemma-4-E2B-it-Q4_0.gguf" "$HOME/models/qwen05b_q5_0_ours.gguf" \
+           "../models/gemma-4-E2B-it-Q4_0.gguf" "../models/qwen05b_q5_0_ours.gguf" \
+           "../../models/gemma-4-E2B-it-Q4_0.gguf" "../../models/qwen05b_q5_0_ours.gguf"; do
+    [ -f "$m" ] && MODELS="$MODELS $m"
+  done
+fi
+if [ -z "$MODELS" ]; then
+  echo "tokenizer  (no model given and no default on this machine — pass a .gguf)"
+  echo "NOTORCH_TOKENIZER_SKIPPED"
+  exit 0
+fi
+
+# Cases chosen for the ways a tokenizer breaks: a plain sentence, leading and repeated
+# spaces, punctuation runs, digits, a non-Latin script, code with indentation, and text
+# that has no whole-token spelling and must fall back to bytes.
+set -- \
+  "The capital of France is" \
+  "Hello, world!" \
+  "  leading and   repeated   spaces" \
+  "2 + 2 = 4, right?!" \
+  "Привет, как дела?" \
+  "def fibonacci(n):
+    return n if n < 2 else fibonacci(n-1) + fibonacci(n-2)" \
+  "мороженое 🍦 и ещё emoji 🚀" \
+  "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+FAILS=0
+CHECKS=0
+for M in $MODELS; do
+  NAME=$(basename "$M")
+  for P in "$@"; do
+    OURS=$(./notorch -T "$M" "$P" 2>/dev/null)
+    THEIRS=$("$REF" -m "$M" -p "$P" 2>/dev/null | awk -F" -> " 'NF>1 { gsub(/[^0-9]/, "", $1); if ($1 != "") printf "%s%s", (n++ ? "," : ""), $1 } END { print "" }')
+    CHECKS=$((CHECKS + 1))
+    SHORT=$(printf '%s' "$P" | tr '\n' ' ' | cut -c1-40)
+    if [ "$OURS" = "$THEIRS" ]; then
+      echo "tokenizer  [$NAME] \"$SHORT\"  $(printf '%s' "$OURS" | tr ',' '\n' | grep -c .) ids  identical  PASS"
+    else
+      echo "tokenizer  [$NAME] \"$SHORT\"  FAIL"
+      echo "  ours:   $OURS"
+      echo "  theirs: $THEIRS"
+      FAILS=$((FAILS + 1))
+    fi
+  done
+done
+
+if [ "$FAILS" -eq 0 ]; then
+  echo "NOTORCH_TOKENIZER_OK ($CHECKS checks)"
+else
+  echo "NOTORCH_TOKENIZER_FAIL ($FAILS of $CHECKS)"
+  exit 1
+fi


### PR DESCRIPTION
Gemma 4 is a third scheme and the file cannot tell you so. It ships a merge list AND a score per token, so the rule this tree used — merges mean byte-level BPE, scores mean SentencePiece — routes it to the wrong one, and the wrong one is quiet: nine tokens where the reference makes six, text that decodes back perfectly, and a model answering a question nobody asked. The name settles it, which is what llama.cpp reads too.

What the name means: SPM-style BPE. Spaces become U+2581, the text is split only where newlines are, merges run by rank over raw UTF-8 with no byte encoding and no word-level pre-split, unresolved pieces fall back to <0xHH>, and <bos> is prepended because the file says add_bos_token. A run of newlines that the vocabulary holds whole stays whole.

The gate is id sequences against llama-tokenize, because a tokenizer that round-trips perfectly can still split differently, and the ids are what the model reads. harness/-T prints ids and stops; harness/test_tokenizer.sh diffs eight texts — prose, repeated spaces, punctuation, digits, Cyrillic, indented code, emoji, a long repeat — across whatever models are on the machine, and skips itself where llama-tokenize is not installed. Sixteen of sixteen identical, gemma-4 and qwen.

It found two older bugs on the way, both quiet in exactly the way that matters:

utf8_dec had no four-byte arm, so every emoji was read as four separate one-byte characters, none of which is a legal token — a vocabulary holding an emoji whole emitted four byte tokens for it. The text came back right, so nothing ever complained.

The byte-level path split a run of spaces into single spaces. GPT-2 peels `\s+(?!\S)` first: four spaces before a word are three spaces and then " word". An indented line therefore came out as three separate space tokens where llama.cpp emits one, and every position after it shifted — invisible in prose, wrong in every code prompt this tree has ever run.

Also: <turn|> and <|tool_response> now end generation for this family instead of printing as text, which is the list llama.cpp carries for it.

Gemma 4 now runs end to end with no ids handed to it: "The capital of France is" -> " Paris.", and it answers in Russian about resonance in one sentence, as asked. llama parity and the whole suite are unchanged.

Quote: "It is not the things you don't know that get you, it is the things you know that ain't so." — attributed to Josh Billings
Method: the Method compares ids, because text that reads right can still be the wrong input.

By Arianna Method (Co-authored by Claude, Defender) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff