### PR TITLE
the method quantizes the one tensor the file kept in reserve

### DIFF
--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,54 @@ Newest entries on top.
 
 ---
 
+## 2026-09-01 — the quantizer learns to take quantized input, and Gemma's head halves
+
+Gemma 4's output projection is its embedding table, so the whole of `token_embd.weight` is
+read once per decoded token. `llama-quantize` deliberately keeps that tensor at a higher
+precision than the rest — in the file on this node everything is q4_0 and the head is q8_0,
+408 MiB against the 876 MiB the FFN reads. Dropping it to q4_0 was arithmetic worth testing
+and the tool could not do it: it accepted f32 and f16 sources only, and Gemma's float original
+is a 9.3 GB bf16 checkpoint that does not fit in this phone's 8 GB, since `gguf_open` reads
+the data section into memory whole.
+
+Two flags on `tools/gguf_quantize.c`. `--requantize` accepts an already-quantized source,
+which loses what the first quantization lost and then some, and is the only path left when the
+floats are gone. `--only SUBSTR` converts just the tensors whose name contains the substring
+and copies every other one byte for byte, so a single tensor can be priced on its own. Also
+bf16 (type 30) in the sizer and the type namer — without it the tool aborted on
+`per_layer_model_proj.weight`, the file's one bf16 tensor, which is copied through untouched
+rather than converted.
+
+    ./gguf_quantize gemma-4-E2B-it-Q4_0.gguf out.gguf q4_0 --requantize --only token_embd
+
+Head 408 → 216 MiB, file 2710 → 2518 MiB. Decode on the harness, three runs each, interleaved,
+from a cold phone: **8.8 / 8.5 / 8.6 t/s against 9.5 / 9.2 / 9.0, plus 7.0 percent**, prefill
+unchanged at 12.0 against 12.1. The prediction was 13 percent and it did not arrive: a q4_0
+matvec spends more on unpacking than a q8_0 one, so the head went 25.4 ms to about 16, not to
+12.7. Quality, `llama-perplexity` over 16 chunks of 512 on the same corpus: 64.8869 ± 4.234
+against 65.2808 ± 4.251 — six tenths of a percent, inside the interval. `llama.cpp` on the same
+two files moves the same way on decode, 10.83 ± 0.38 to 11.48 ± 0.02, and pays 5.5 percent of
+prefill for it, 16.61 to 15.70; we pay nothing there.
+
+Two review findings from the Gemma bring-up, both real, both in `harness/arch_gemma4.c`. The
+per-layer projection ignored the return of `nt_qmatvec_i8`, so a failure would have fed the
+residual whatever was in the scratch buffer; it now zeroes the section and says so once.
+And the loader published `ple_proj_q` before checking that its rows and columns were set,
+leaving a non-NULL pointer describing a zero-sized matrix on the allocation-failure path;
+the pointer is now published only after a probe matvec returns 0.
+
+One measurement note worth more than the patch. Decode on this file does not reproduce across
+days: 10.2 t/s on 2026-08-31, 8.9 today, from the same commit — built from `53eef56` in a
+clean tree and A/B'd against the branch, 8.9 / 8.8 / 9.0 against 8.8 / 9.1 / 8.9, no
+difference. `llama.cpp` reproduces its own number (10.92 then, 10.83 now). The asymmetry is
+`gguf.c:179` — `posix_memalign` plus `fread` of the whole data section into anonymous memory,
+which under memory pressure goes to swap and comes back decompressed, and during load holds
+the file twice: once in the page cache, once in our copy. With `Cached` at 1.9 GB against a
+2.64 GB model and 2.55 GB already swapped, part of every token streams. The reference mmaps.
+So should we — separately, with the Metal NoCopy alignment guarantee kept intact.
+
+---
+
 ## 2026-08-31 — Gemma 4 gets faster, and neither reason was in the kernels
 
 The profile refused the obvious guess. Attention was 0.9 percent of a decode, not the

--- a/harness/arch_gemma4.c
+++ b/harness/arch_gemma4.c
@@ -121,17 +121,33 @@ static void *gemma4_load(gguf_file *gf, nt_dims *dims) {
             int cols = (int)gf->tensors[pti].shape[0];
             int rows = (int)(gf->tensors[pti].n_elements / (uint64_t)cols);
             if (cols % 32 == 0) {
+                /* Either the whole thing quantizes or the pointer stays NULL. A buffer that
+                 * exists with rows and cols still zero would pass the "critical weights"
+                 * check below and then run the model against nothing — the loud failure is
+                 * the cheap one here. */
                 size_t rsz = (size_t)(cols / 32) * 34;
-                m->ple_proj_q = (uint8_t *)malloc(rsz * (size_t)rows);
+                uint8_t *packed = (uint8_t *)malloc(rsz * (size_t)rows);
                 float *row = (float *)malloc((size_t)cols * sizeof(float));
-                if (m->ple_proj_q && row) {
-                    for (int r = 0; r < rows; r++) {
-                        if (gguf_dequant_row(gf, pti, (uint64_t)r, row) != 0 ||
-                            nt_quantize_row(row, m->ple_proj_q + rsz * (size_t)r, cols, 8) != 0) {
-                            free(m->ple_proj_q); m->ple_proj_q = NULL; break;
-                        }
-                    }
-                    m->ple_proj_rows = rows; m->ple_proj_cols = cols;
+                int ok = (packed && row);
+                for (int r = 0; ok && r < rows; r++) {
+                    if (gguf_dequant_row(gf, pti, (uint64_t)r, row) != 0 ||
+                        nt_quantize_row(row, packed + rsz * (size_t)r, cols, 8) != 0)
+                        ok = 0;
+                }
+                /* The matvec has its own opinion about shapes and dtypes; ask it once here
+                 * rather than discovering the answer inside the token loop. */
+                if (ok) {
+                    float probe = 0.0f;
+                    float *zero = (float *)calloc((size_t)cols, sizeof(float));
+                    ok = zero && nt_qmatvec_i8(&probe, packed, 8, zero, 1, cols) == 0;
+                    free(zero);
+                }
+                if (ok) {
+                    m->ple_proj_q = packed;
+                    m->ple_proj_rows = rows;
+                    m->ple_proj_cols = cols;
+                } else {
+                    free(packed);
                 }
                 free(row);
             }
@@ -292,7 +308,15 @@ static void gemma4_forward(void *model, kv_cache *kv, const int *tokens, int n,
         /* per-layer input = ( norm(model_proj @ x / sqrt(E)) + table_row * sqrt(P) ) / sqrt(2) */
         if (gguf_dequant_row(m->gf, m->ple_ti, (uint64_t)tokens[j], ple_row) != 0)
             memset(ple_row, 0, (size_t)P * NL * sizeof(float));
-        nt_qmatvec_i8(proj, m->ple_proj_q, 8, xj, m->ple_proj_rows, m->ple_proj_cols);
+        /* The shape was probed at load, so a refusal here means the call failed rather than
+         * the shape being wrong — an allocation, most likely. Say so once and leave the
+         * buffer zeroed: a per-layer input of zeros degrades the answer, reading whatever
+         * the last token left there corrupts it silently. */
+        if (nt_qmatvec_i8(proj, m->ple_proj_q, 8, xj, m->ple_proj_rows, m->ple_proj_cols) != 0) {
+            static int warned = 0;
+            if (!warned) { fprintf(stderr, "gemma4: per-layer projection failed\n"); warned = 1; }
+            memset(proj, 0, (size_t)P * NL * sizeof(float));
+        }
         float inv_e = 1.0f / sqrtf((float)E), inv_sqrt2 = 1.0f / sqrtf(2.0f);
         for (int l = 0; l < NL; l++) {
             float *pl = proj + (long)l * P;

--- a/tools/gguf_quantize.c
+++ b/tools/gguf_quantize.c
@@ -43,6 +43,7 @@ static const char *type_name(uint32_t t) {
     switch (t) {
     case GGUF_TYPE_F32:  return "f32";
     case GGUF_TYPE_F16:  return "f16";
+    case GGUF_TYPE_BF16: return "bf16";
     case GGUF_TYPE_Q4_0: return "q4_0";
     case GGUF_TYPE_Q5_0: return "q5_0";
     case GGUF_TYPE_Q8_0: return "q8_0";
@@ -57,6 +58,7 @@ static uint64_t type_size(uint32_t t, uint64_t n) {
     switch (t) {
     case GGUF_TYPE_F32:  return n * 4;
     case GGUF_TYPE_F16:  return n * 2;
+    case GGUF_TYPE_BF16: return n * 2;
     case GGUF_TYPE_Q4_0: return n / 32 * 18;
     case GGUF_TYPE_Q5_0: return n / 32 * 22;
     case GGUF_TYPE_Q8_0: return n / 32 * 34;
@@ -101,11 +103,23 @@ static int pad_to(FILE *f, uint64_t target) {
 
 int main(int argc, char **argv) {
     if (argc < 3) {
-        printf("usage: %s <in.gguf> <out.gguf> [q4_0|q5_0|q8_0]\n", argv[0]);
+        printf("usage: %s <in.gguf> <out.gguf> [q4_0|q5_0|q8_0|q4_k|q6_k] [--requantize] [--only SUBSTR]\n"
+               "  --requantize   accept already-quantized tensors as input, losing what the\n"
+               "                 first quantization lost and then some. Use when the floats\n"
+               "                 are gone and the question is what a smaller format costs.\n"
+               "  --only SUBSTR  convert only tensors whose name contains SUBSTR; the rest are\n"
+               "                 copied byte for byte, so one tensor can be studied alone.\n",
+               argv[0]);
         return 1;
     }
-    int target = argc > 3 ? type_from_name(argv[3]) : GGUF_TYPE_Q4_0;
+    int target = argc > 3 && argv[3][0] != '-' ? type_from_name(argv[3]) : GGUF_TYPE_Q4_0;
     if (target < 0) { fprintf(stderr, "unknown type %s\n", argv[3]); return 1; }
+    int requantize = 0;
+    const char *only = NULL;
+    for (int i = 3; i < argc; i++) {
+        if (!strcmp(argv[i], "--requantize")) requantize = 1;
+        else if (!strcmp(argv[i], "--only") && i + 1 < argc) only = argv[++i];
+    }
 
     gguf_file *gf = gguf_open(argv[1]);
     if (!gf) return 1;
@@ -128,13 +142,22 @@ int main(int argc, char **argv) {
          * 24 as q6_K and 146 as q8_0. Same rule here, so the two tools produce files of the
          * same shape rather than merely comparable ones. */
         int is_k = (target == GGUF_TYPE_Q4_K || target == GGUF_TYPE_Q6_K);
-        int floatsrc = (t->dtype == GGUF_TYPE_F32 || t->dtype == GGUF_TYPE_F16);
-        int quantizable = (t->ndim == 2) && (t->shape[0] % 32 == 0) && floatsrc;
+        int floatsrc = (t->dtype == GGUF_TYPE_F32 || t->dtype == GGUF_TYPE_F16 ||
+                        t->dtype == GGUF_TYPE_BF16 ||
+                        (requantize && t->dtype != GGUF_TYPE_F32 && t->dtype != GGUF_TYPE_F16));
+        int named = (!only || strstr(t->name, only) != NULL);
+        int quantizable = (t->ndim == 2) && (t->shape[0] % 32 == 0) && floatsrc && named;
         uint32_t chosen = (uint32_t)target;
         if (quantizable && is_k && (t->shape[0] % 256))
             chosen = (target == GGUF_TYPE_Q4_K) ? GGUF_TYPE_Q5_0 : GGUF_TYPE_Q8_0;
         out_type[i] = quantizable ? chosen : t->dtype;
-        if (quantizable) n_quantized++;
+        if (quantizable) {
+            n_quantized++;
+            printf("  %-40s %s -> %s  %.1f MiB -> %.1f MiB\n", t->name,
+                   type_name(t->dtype), type_name(out_type[i]),
+                   (double)type_size(t->dtype, t->n_elements) / (1024.0 * 1024.0),
+                   (double)type_size(out_type[i], t->n_elements) / (1024.0 * 1024.0));
+        }
         out_off[i] = cursor;
         uint64_t sz = type_size(out_type[i], t->n_elements);
         if (!sz) {


### PR DESCRIPTION
Gemma 4 ties its output projection to token_embd, so that table is read in full for every decoded token. llama-quantize keeps it above the rest of the file on purpose: everything else here is q4_0 and the head is q8_0, 408 MiB against the 876 MiB the FFN streams. Halving it was arithmetic worth testing and this tree could not perform the test — gguf_quantize accepted f32 and f16 only, and the float original is a 9.3 GB bf16 checkpoint that will not fit in this phone's 8 GB, because gguf_open reads the data section in whole.

So the tool takes quantized input now. --requantize accepts a packed source, which loses what the first quantization lost and then some, and is the only road left once the floats are gone. --only SUBSTR converts the tensors whose name carries the substring and copies every other one byte for byte, so a single tensor can be priced alone rather than as part of a file. bf16 joins the sizer and the type namer as well: without it the tool aborted on per_layer_model_proj.weight, this file's one bf16 tensor, which is copied through rather than converted.

Head 408 to 216 MiB, file 2710 to 2518. Decode on the harness, three runs each, interleaved, from a cold phone: 8.8 / 8.5 / 8.6 t/s against 9.5 / 9.2 / 9.0 — seven percent — with prefill unmoved at 12.0 against 12.1. Thirteen was the prediction and it did not arrive, because a q4_0 matvec spends more on unpacking than a q8_0 one: the head went from 25.4 ms to about 16 rather than to 12.7. Perplexity over 16 chunks of 512 on one corpus: 64.8869 ± 4.234 against 65.2808 ± 4.251, six tenths of a percent, inside the interval. llama.cpp on the same two files moves the same way on decode, 10.83 ± 0.38 to 11.48 ± 0.02, and gives up 5.5 percent of prefill for it, 16.61 to 15.70. We give up none.

Two review findings from the bring-up travel with this, both in the family file. The per-layer projection discarded the return of nt_qmatvec_i8, so a failure would have added whatever the scratch buffer held to the residual; it zeroes the section now and says so once. And the loader published ple_proj_q before its rows and columns were set, which on the allocation failure path left a live pointer to a matrix of size zero; the pointer is published only after a probe matvec returns 0.

The measurement note outlives the patch. This file does not reproduce across days — 10.2 t/s on 2026-08-31, 8.9 today, from the same commit, checked by building 53eef56 in a clean tree and running it against the branch: 8.9 / 8.8 / 9.0 against 8.8 / 9.1 / 8.9. llama.cpp reproduces itself, 10.92 then and 10.83 now. The difference is gguf.c:179, posix_memalign and fread of the entire data section into anonymous memory, which swaps out under pressure and comes back decompressed, and at load holds the file twice — page cache and our copy both. With Cached at 1.9 GB against a 2.64 GB model and 2.55 GB already in swap, part of every token arrives from storage. The reference maps the file instead. That is the next change, and it is its own change.

Gates: 49, 73, 34 and 3 tests pass with none failing, parity with the reference identical on three prompts, tokenizer identical on 16.

Quote: "The map is not the territory, but a map that fits in the pocket is worth two that do not." — Alfred Korzybski, paraphrased
Method: the Method spends its bytes where the reading happens.

By Arianna Method (Co-authored by Claude, Defender) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff