### PR TITLE
the method stopped copying the model to look at it

### DIFF
--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,51 @@ Newest entries on top.
 
 ---
 
+## 2026-09-01 — the model is mapped, not read
+
+`gguf_open` allocated the whole tensor block and read the file into it. On a workstation that
+is merely wasteful; on a phone it is the reason a benchmark does not repeat. The copy is
+anonymous memory, so under pressure the kernel compresses 2.6 GB of weights into swap and
+decompresses them again on the next token, and during load the file exists twice — page cache
+and our copy both. Decode on one Gemma file measured 10.2 t/s one day and 8.9 the next from an
+unchanged commit, checked by building the same revision in a clean tree and running it against
+the branch; the reference, which maps its files, repeated itself across the same two days.
+
+The tensor block is now a read-only `MAP_PRIVATE` view. The data section is 32-byte aligned
+and a mapping must start on a page, so it maps from the page below and hands out the offset
+view; `data_size` on this path is the exact byte count rather than the page-rounded one, which
+makes the bounds checks in `gguf_dequant_row` stricter, not looser. `map_base` and `map_len`
+carry what `munmap` needs. Any refusal from the kernel falls back to the read path, which is
+kept whole.
+
+Populating is the default, and that took a measurement to settle. Faulted lazily the model
+arrives one page at a time inside the first forward pass, which is prefill: 7.5 t/s against
+12.3 on an 11-token prompt. `MADV_WILLNEED` did not move it — 7.4 / 7.5 / 8.2 with the call
+against 7.0 / 7.1 / 8.3 without — so the call is not in the tree. `MAP_POPULATE` pays the same
+cost at load as one sequential stream and removes it from prefill entirely, 12.5 / 12.3, while
+still reaching first output faster than reading did because nothing is copied: **1.90 s
+against 4.13**. The cost is fixed rather than per token, which is why all three variants are
+indistinguishable on a 577-token prompt — 10.0, 10.0, 10.1 — and why the short prompt is the
+only place the choice shows. `NT_GGUF_MMAP=lazy` skips populating for a model larger than RAM:
+peak RSS **1 557 448 kB against 2 851 072**, at the price named above.
+
+Decode moved nowhere, which is the expected result and worth stating: 8.6 to 8.9 t/s across
+all eight runs of a cold-start A/B, mapped and read alike. Prefill with the file already in
+cache favours the mapping, 12.5 / 12.9 against 12.2 / 8.5, because mapping is free there and
+`fread` still copies 2.6 GB. Whether the day-to-day variance is gone is a claim for another
+day's measurement; what can be said now is that the mechanism behind it was removed.
+
+Metal keeps the read path unchanged. `nt_metal_register_base` wraps `data` as a NoCopy
+MTLBuffer and needs a page-aligned pointer with a page-rounded length, which an offset view
+into a file does not provide, so the mapping does not compile under `USE_METAL` at all.
+`NT_GGUF_MMAP=0` forces the read path anywhere else.
+
+The gate was checked by breaking it: shifting the mapped view four bytes makes the same model
+answer `!!!!!!!!` where it answered ` Paris.`, and parity catches it. Suites 49, 73, 34 and 3
+pass, parity is identical on three prompts, tokenizer on 16.
+
+---
+
 ## 2026-09-01 — the quantizer learns to take quantized input, and Gemma's head halves
 
 Gemma 4's output projection is its embedding table, so the whole of `token_embd.weight` is

--- a/gguf.c
+++ b/gguf.c
@@ -8,6 +8,29 @@
 #include <math.h>
 #include <unistd.h>
 
+/* Mapping the tensor block instead of reading it. A model is the largest thing
+ * this library ever holds, and holding it as anonymous memory costs three ways:
+ * during load the file exists twice, once in the page cache and once in our
+ * copy; afterwards the copy is the kernel's first candidate for swap, which on
+ * a phone means compressing weights and decompressing them again on the next
+ * token; and two processes running the same model pay for it twice. File-backed
+ * pages have none of those properties — they are dropped clean and re-read, and
+ * they are shared. The measurable symptom of not doing this was decode speed
+ * that did not reproduce between days on an unchanged commit.
+ *
+ * Metal keeps the read path. `nt_metal_register_base` wraps `data` as a NoCopy
+ * MTLBuffer, which requires a page-aligned pointer and a page-rounded length,
+ * and a mapped view starts wherever the file's 32-byte-aligned data section
+ * starts. `NT_GGUF_MMAP=0` forces the read path anywhere else, and
+ * `NT_GGUF_MMAP=lazy` maps without populating — half the resident memory, at
+ * the cost of faulting the model in during the first forward pass. */
+#if !defined(USE_METAL) && !defined(_WIN32) && !defined(__EMSCRIPTEN__)
+#define NOTORCH_GGUF_MMAP 1
+#include <sys/mman.h>
+#else
+#define NOTORCH_GGUF_MMAP 0
+#endif
+
 // ── Reading primitives ───────────────────────────────────────────────────────
 
 static int read_u32(FILE* f, uint32_t* v) { return fread(v, 4, 1, f) == 1; }
@@ -171,11 +194,50 @@ gguf_file* gguf_open(const char* path) {
         fclose(f); free(gf); return NULL;
     }
     long data_size = fsize - (long)gf->data_offset;
-    // Page-align the tensor block so the Metal backend can wrap it as one
-    // zero-copy NoCopy MTLBuffer (resident weights). free() stays valid.
     size_t pg = (size_t)getpagesize();
-    size_t alloc = ((size_t)data_size + pg - 1) & ~(pg - 1);
     gf->data = NULL;
+    gf->map_base = NULL;
+    gf->map_len = 0;
+
+#if NOTORCH_GGUF_MMAP
+    {
+        const char* mode = getenv("NT_GGUF_MMAP");
+        if (!(mode && mode[0] == '0')) {
+            // The mapping has to start on a page boundary; the data section is
+            // only 32-byte aligned, so map from the page below it and hand out
+            // the offset view. Everything readable through `data` stays inside
+            // the mapping because the kernel rounds `map_len` up, never down.
+            size_t delta = (size_t)(gf->data_offset & (uint64_t)(pg - 1));
+            size_t len   = delta + (size_t)data_size;
+            int    flags = MAP_PRIVATE;
+#ifdef MAP_POPULATE
+            // Faulted lazily, the whole model arrives a page at a time inside the
+            // first forward pass, and on a 2.6 GB file that costs half a second of
+            // prefill — measured, 7.5 t/s against 12.3 on an 11-token prompt, and
+            // invisible on a 577-token one because the cost is fixed rather than
+            // per token. Populating pays it at load as one sequential stream, which
+            // is what the read path did, and beats the read path on wall clock
+            // anyway (2.09 s against 3.62) because nothing is copied. NT_GGUF_MMAP=lazy
+            // skips it and halves resident memory, for a model larger than RAM.
+            if (!(mode && strcmp(mode, "lazy") == 0)) flags |= MAP_POPULATE;
+#endif
+            void*  base  = mmap(NULL, len, PROT_READ, flags, fileno(f), (off_t)(gf->data_offset - delta));
+            if (base != MAP_FAILED) {
+                gf->map_base  = base;
+                gf->map_len   = (uint64_t)len;
+                gf->data      = (uint8_t*)base + delta;
+                gf->data_size = (uint64_t)data_size;
+                fclose(f);
+                return gf;
+            }
+        }
+    }
+#endif
+
+    // Read path: mapping is off, or the kernel refused. Page-align the tensor
+    // block so the Metal backend can wrap it as one zero-copy NoCopy MTLBuffer
+    // (resident weights). free() stays valid.
+    size_t alloc = ((size_t)data_size + pg - 1) & ~(pg - 1);
     if (posix_memalign((void**)&gf->data, pg, alloc) != 0 || !gf->data) { fclose(f); free(gf); return NULL; }
     gf->data_size = (uint64_t)alloc;
     fseek(f, gf->data_offset, SEEK_SET);
@@ -190,6 +252,10 @@ gguf_file* gguf_open(const char* path) {
 
 void gguf_close(gguf_file* gf) {
     if (!gf) return;
+#if NOTORCH_GGUF_MMAP
+    if (gf->map_base) munmap(gf->map_base, (size_t)gf->map_len);
+    else
+#endif
     free(gf->data);
     free(gf);
 }

--- a/gguf.h
+++ b/gguf.h
@@ -61,9 +61,13 @@ typedef struct {
 
     // Data section
     uint64_t       kv_end;        // file offset just past the metadata section
-    uint8_t*       data;          // page-aligned (posix_memalign) raw tensor bytes
+    uint8_t*       data;          // raw tensor bytes: a read-only mapped view of the
+                                  // file, or a posix_memalign copy when mapping is off
     uint64_t       data_offset;   // file offset where tensor data starts
-    uint64_t       data_size;     // page-rounded byte size of `data` (for Metal NoCopy)
+    uint64_t       data_size;     // bytes readable through `data`; page-rounded on the
+                                  // copy path, where Metal NoCopy needs the rounding
+    void*          map_base;      // mmap base, NULL when `data` is a heap copy
+    uint64_t       map_len;       // length to hand back to munmap
 
     // Architecture params (extracted from metadata)
     int  n_layers;


### PR DESCRIPTION
gguf_open allocated the tensor block and read the file into it. On a workstation that is merely wasteful. On a phone it is why a benchmark does not repeat: the copy is anonymous memory, so under pressure the kernel compresses 2.6 GB of weights into swap and decompresses them again on the next token, and during load the file exists twice, page cache and our copy both. Decode on one Gemma file measured 10.2 t/s on one day and 8.9 on the next from an unchanged commit — checked by building that revision in a clean tree and running it against the branch, 8.9 / 8.8 / 9.0 against 8.8 / 9.1 / 8.9. The reference maps its files and repeated itself across the same two days, 10.92 and 10.83.

The block is a read-only MAP_PRIVATE view now. A mapping starts on a page and the data section is aligned to 32, so it maps from the page below and hands out the offset view; data_size here is the exact count rather than the page-rounded one, which makes the bounds checks stricter rather than looser. map_base and map_len carry what munmap wants. Any refusal from the kernel falls back to the read path, which is kept whole.

Populating is the default and that took measuring. Faulted lazily the model arrives a page at a time inside the first forward pass, which is prefill: 7.5 t/s against 12.3 on an 11-token prompt. MADV_WILLNEED did not move it, 7.4 / 7.5 / 8.2 with the call against 7.0 / 7.1 / 8.3 without, so the call is not in the tree. MAP_POPULATE pays the same cost at load as one sequential stream, takes it out of prefill entirely at 12.5 / 12.3, and still reaches first output faster than reading because nothing is copied: 1.90 s against 4.13. The cost is fixed rather than per token, which is why all three are indistinguishable on a 577-token prompt — 10.0, 10.0, 10.1 — and why the short prompt is the only place the choice is visible. NT_GGUF_MMAP=lazy skips populating for a model larger than RAM: peak RSS 1557448 kB against 2851072, at the price named above.

Decode moved nowhere, which is the expected result and is worth saying: 8.6 to 8.9 t/s across all eight runs of a cold-start A/B, mapped and read alike. With the file already in cache prefill favours the mapping, 12.5 / 12.9 against 12.2 / 8.5, because mapping is free there and fread copies 2.6 GB regardless. Whether the day-scale variance is gone belongs to another day's measurement; what is established is that the mechanism behind it is no longer there.

Metal keeps the read path untouched. nt_metal_register_base wraps data as a NoCopy MTLBuffer and wants a page-aligned pointer with a page-rounded length, which an offset view into a file does not give, so the mapping does not compile under USE_METAL at all. NT_GGUF_MMAP=0 forces the read path anywhere else.

The gate was checked by breaking it: shift the mapped view four bytes and the model answers !!!!!!!! where it answered " Paris.", and parity fails on it. Suites of 49, 73, 34 and 3 pass with none failing, parity identical on three prompts, tokenizer identical on 16.

Quote: "He who has a why to live can bear almost any how." — Friedrich Nietzsche
Method: the Method reads the file where the file already is.

By Arianna Method (Co-authored by Claude, Defender) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff