### PR TITLE
the method gave back the scratch it had been keeping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ libnotorch.dylib
 __pycache__/
 *.pyc
 test_qmatmul
+test_qmatvec_leak
 
 gguf_quantize
 test_quantize

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ SIMD_LIBS  = -lpthread
 
 # ── Targets ──
 
-.PHONY: all test test_qpool test_js test_python test_tokenizer clean cpu gpu simd help lib shared install metal test_metal infer_gguf_metal
+.PHONY: all test test_qpool test_qmatvec_leak test_js test_python test_tokenizer clean cpu gpu simd help lib shared install metal test_metal infer_gguf_metal
 
 all: notorch_test
 	@echo "Built with $(BLAS_NAME). Run: ./notorch_test"
@@ -352,12 +352,17 @@ test_qmatmul: tests/test_qmatmul.c notorch.c notorch.h
 	$(CC) $(CFLAGS) $(BLAS_FLAGS) -o test_qmatmul tests/test_qmatmul.c notorch.c -lm $(BLAS_LIBS)
 	@echo "Compiled: test_qmatmul (batched packed matmul vs per-token, $(BLAS_NAME))"
 
-test: notorch_test test_vision test_qpool test_qmatmul test_quantize
+test_qmatvec_leak: tests/test_qmatvec_leak.c notorch.c notorch.h
+	$(CC) $(CFLAGS) $(BLAS_FLAGS) -o test_qmatvec_leak tests/test_qmatvec_leak.c notorch.c -lm $(BLAS_LIBS)
+	@echo "Compiled: test_qmatvec_leak (packed matvec returns what it takes, $(BLAS_NAME))"
+
+test: notorch_test test_vision test_qpool test_qmatmul test_quantize test_qmatvec_leak
 	./notorch_test
 	./test_vision
 	./test_qpool
 	./test_qmatmul
 	./test_quantize
+	./test_qmatvec_leak
 
 test_js:
 	node js-edition/test_op_parity.mjs

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,49 @@ Newest entries on top.
 
 ---
 
+## 2026-09-01 — the packed matvec was keeping its scratch
+
+Review on the three merges of the day raised eight points. Six were fair and are fixed below.
+Reading the code to answer one of them turned up something nobody had flagged: `nt_qmatvec_i8`
+takes three buffers per call — the quantized activation, its scales, and the per-block sums —
+and frees two of them on every exit path. `asum` is freed on the allocation-failure path and
+nowhere else: not on the unsupported-kernel return, not on the single-threaded shortcut, not
+on the pool return, not at the end. That is the hottest function in the library, and it leaked
+`k/32 × 4` bytes every time it ran. Watched on a 0.5B model, resident memory climbed
+380228 → 387180 → 394976 kB across ten seconds of decode; with the frees in place the same
+window gives 380560 → 384068 → 387412, and what is left is the KV cache becoming resident as
+the context fills — 24 layers × 2 KV heads × 64 × 2 × 4 bytes is 24 kB per token of context,
+which is the slope that remains.
+
+`tests/test_qmatvec_leak.c` is the gate, and it is `mallinfo2` rather than RSS: RSS moves for
+reasons that have nothing to do with the caller, `uordblks` is exactly the sum of live
+allocations. Two thousand calls now retain **0 bytes**; with the frees removed again the same
+test reports **416000**, which is 208 per call against the 192 the arithmetic predicts plus
+the allocator's header. Where `mallinfo2` is absent the test says so and skips, because a gate
+that cannot measure must not claim to.
+
+The same review was right that `nt_qmatvec_i8` validated dtype and shape but never the
+pointers, so a caller whose weight failed to load reached the kernel and died there instead of
+receiving the `-1` it was testing for — `harness/arch_gemma4.c` tests for exactly that. Guard
+added; removing it again turns the new test into a segfault rather than a failed assertion,
+which is its own kind of proof.
+
+Also from the review, all confirmed before changing anything: the Python ctypes binding had
+drifted from `gguf_file` by two additions, `kv_end` from the quantizer work and `map_base` /
+`map_len` from the mapping, and a `Structure` with a gap does not fail loudly — every field
+past the gap reads its neighbour. `tests/gguf_layout.c` puts `data` at 443432 and `n_layers`
+at 443472 on this platform, and only the corrected field list reproduces both. (The Python
+gate itself was not executed here; this node does not run Python. It needs a run where it is
+allowed.) `tools/gguf_quantize.c` ignored unknown flags and accepted `--only` with no value,
+which made a typo look like a successful conversion — both are errors now; and `--requantize`
+read as "any dtype that is not float", which let types `gguf_dequant_row` has no reader for
+past the shape test, so it names the five it can decode. Wording in the previous entry was
+loose in three places and now says: populating is the default *where the platform has*
+`MAP_POPULATE`, `USE_METAL` compiles the mapping out rather than failing to build, and the
+two load timings come from two different runs rather than being one disputed number.
+
+---
+
 ## 2026-09-01 — the model is mapped, not read
 
 `gguf_open` allocated the whole tensor block and read the file into it. The file passes through
@@ -35,13 +78,15 @@ makes the bounds checks in `gguf_dequant_row` stricter, not looser. `map_base` a
 carry what `munmap` needs. Any refusal from the kernel falls back to the read path, which is
 kept whole.
 
-Populating is the default, and that took a measurement to settle. Faulted lazily the model
+Populating is the default where the platform has `MAP_POPULATE`; where it does not, the
+mapping is lazy and the paragraph below describes what that costs. Which to prefer took a
+measurement to settle. Faulted lazily the model
 arrives one page at a time inside the first forward pass, which is prefill: 7.5 t/s against
 12.3 on an 11-token prompt. `MADV_WILLNEED` did not move it — 7.4 / 7.5 / 8.2 with the call
 against 7.0 / 7.1 / 8.3 without — so the call is not in the tree. `MAP_POPULATE` pays the same
 cost at load as one sequential stream and removes it from prefill entirely, 12.5 / 12.3, while
 still reaching first output faster than reading did because nothing is copied: **1.90 s
-against 4.13**. The cost is fixed rather than per token, which is why all three variants are
+against 4.13** in one run and 2.09 against 3.62 in another. The cost is fixed rather than per token, which is why all three variants are
 indistinguishable on a 577-token prompt — 10.0, 10.0, 10.1 — and why the short prompt is the
 only place the choice shows. `NT_GGUF_MMAP=lazy` skips populating for a model larger than RAM:
 peak RSS **1 557 448 kB against 2 851 072**, at the price named above.
@@ -65,7 +110,8 @@ wrong. It is recorded as open rather than explained.
 
 Metal keeps the read path unchanged. `nt_metal_register_base` wraps `data` as a NoCopy
 MTLBuffer and needs a page-aligned pointer with a page-rounded length, which an offset view
-into a file does not provide, so the mapping does not compile under `USE_METAL` at all.
+into a file does not provide, so `USE_METAL` compiles the mapping out — `gguf.c` itself builds
+as it always did, with `NOTORCH_GGUF_MMAP` set to 0.
 `NT_GGUF_MMAP=0` forces the read path anywhere else.
 
 The gate was checked by breaking it: shifting the mapped view four bytes makes the same model

--- a/gguf.c
+++ b/gguf.c
@@ -13,12 +13,12 @@
  * passes through the page cache on its way into our copy, so a 2.6 GB model
  * occupies 5.2 GB at the moment of load, and two processes running the same
  * model repeat all of it. A mapping is the page cache, so neither happens —
- * measured on this phone as 1.90 s to first output against 4.13.
+ * measured on this phone as 1.9-2.1 s to first output against 3.6-4.1, two runs of each.
  *
  * What this does NOT fix, stated because the first version of this comment
  * claimed it did: decode speed on one Gemma file measured 10.2 t/s on one day
  * and 8.6-9.0 the next from an unchanged commit, and mapping does not move it.
- * The swap explanation was checked and refused — under 3 GiB of deliberate
+ * The swap explanation was checked and refuted — under 3 GiB of deliberate
  * pressure the process reported no swapped pages on either path, because
  * weights touched every token stay hot enough that the kernel evicts something
  * else. Generation length, prompt, temperature, BLAS threads and huge pages
@@ -222,9 +222,11 @@ gguf_file* gguf_open(const char* path) {
             // prefill — measured, 7.5 t/s against 12.3 on an 11-token prompt, and
             // invisible on a 577-token one because the cost is fixed rather than
             // per token. Populating pays it at load as one sequential stream, which
-            // is what the read path did, and beats the read path on wall clock
-            // anyway (2.09 s against 3.62) because nothing is copied. NT_GGUF_MMAP=lazy
-            // skips it and halves resident memory, for a model larger than RAM.
+            // is what the read path did, and beats the read path on wall clock anyway
+            // because nothing is copied — see the header comment for the timings. Where
+            // MAP_POPULATE does not exist the mapping is lazy and prefill pays the faults.
+            // NT_GGUF_MMAP=lazy asks for that deliberately, to halve resident memory when
+            // the model is larger than RAM.
             if (!(mode && strcmp(mode, "lazy") == 0)) flags |= MAP_POPULATE;
 #endif
             void*  base  = mmap(NULL, len, PROT_READ, flags, fileno(f), (off_t)(gf->data_offset - delta));

--- a/notorch.c
+++ b/notorch.c
@@ -6831,6 +6831,11 @@ int nt_qmatvec_i8_rows(float *out, const uint8_t *Wq, int dtype,
 
 int nt_qmatvec_i8(float *out, const uint8_t *Wq, int dtype,
                   const float *x, int m, int k) {
+    /* The dtype and shape were checked here from the start and the pointers were not, so a
+     * caller whose weight failed to load reached the kernel and crashed there instead of
+     * getting the -1 it was testing for. Callers do test for it: harness/arch_gemma4.c
+     * zeroes its per-layer section on a non-zero return. */
+    if (!out || !Wq || !x || m <= 0 || k <= 0) return -1;
     if (dtype != 2 && dtype != 6 && dtype != 8 && dtype != 12 && dtype != 14)
         return -1;                                       /* Q4_0/Q5_0/Q8_0/Q4_K/Q6_K */
     if (k % 32) return -1;
@@ -6853,11 +6858,11 @@ int nt_qmatvec_i8(float *out, const uint8_t *Wq, int dtype,
      * is why widening the guard above without touching this line sent Q5_0 into the Q6_K
      * kernel and read 210-byte blocks out of a 22-byte-block buffer. */
     nt_qrows_i8_fn fn = nt_qrows_i8_for(dtype, k);
-    if (!fn) { free(qa); free(da); return -1; }
+    if (!fn) { free(qa); free(da); free(asum); return -1; }
     int nt = nt_qmv_host_threads(m);
     if (nt <= 1 || (long)m * k < nt_qmv_thread_floor()) {
         fn(out, Wq, qa, da, asum, 0, m, k);
-        free(qa); free(da);
+        free(qa); free(da); free(asum);
         return 0;
     }
 #ifdef _OPENMP
@@ -6883,6 +6888,7 @@ int nt_qmatvec_i8(float *out, const uint8_t *Wq, int dtype,
     if (nt_qpool_i8_run(jobs, launched) == 0) {
         free(qa);
         free(da);
+        free(asum);
         return 0;
     }
 
@@ -6898,7 +6904,7 @@ int nt_qmatvec_i8(float *out, const uint8_t *Wq, int dtype,
     }
     for (int t = 0; t < launched; t++) pthread_join(th[t], NULL);
 #endif
-    free(qa); free(da);
+    free(qa); free(da); free(asum);
     return 0;
 }
 

--- a/python/notorch.py
+++ b/python/notorch.py
@@ -58,9 +58,16 @@ class _GGUFFile(Structure):
                 ("kv", _KV * GGUF_MAX_KV),
                 ("n_kv_parsed", c_int),
                 ("tensors", _TensorInfo * GGUF_MAX_TENSORS),
+                # kv_end, map_base and map_len were added to gguf_file on the C side and
+                # not here, which does not fail loudly: every field after the gap simply
+                # reads its neighbour. The C compiler puts data at 443432 and n_layers at
+                # 443472 on this platform, and only this field list reproduces both.
+                ("kv_end", c_uint64),
                 ("data", POINTER(c_uint8)),
                 ("data_offset", c_uint64),
                 ("data_size", c_uint64),
+                ("map_base", c_void_p),
+                ("map_len", c_uint64),
                 ("n_layers", c_int), ("n_heads", c_int), ("n_kv_heads", c_int),
                 ("embed_dim", c_int), ("ffn_dim", c_int), ("vocab_size", c_int),
                 ("ctx_len", c_int),

--- a/tests/test_qmatvec_leak.c
+++ b/tests/test_qmatvec_leak.c
@@ -1,0 +1,79 @@
+/* test_qmatvec_leak.c — the packed matvec must return every byte it took.
+ *
+ * nt_qmatvec_i8 allocated three buffers per call and freed two of them on every exit path
+ * but one, so the hottest function in the library leaked its block-sum scratch on every
+ * invocation: about 1.4 MB per second of decode on a 0.5B model, unbounded in a server.
+ * Reading the code says it; this says it in bytes, and goes red if the free is removed.
+ *
+ * The gate is glibc's mallinfo2, not RSS. RSS is a measure of what the allocator has asked
+ * the kernel for and it moves for reasons that have nothing to do with the caller, while
+ * uordblks is exactly the sum of live allocations. Where mallinfo2 is unavailable the test
+ * says so and passes, because a gate that cannot measure must not pretend to.
+ */
+#include "notorch.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#if defined(__GLIBC__)
+#include <malloc.h>
+#define HAVE_MALLINFO2 (__GLIBC__ > 2 || (__GLIBC__ == 2 && __GLIBC_MINOR__ >= 33))
+#else
+#define HAVE_MALLINFO2 0
+#endif
+
+static int fails = 0;
+
+static void check(const char *what, int ok, const char *detail) {
+    printf("  %s %s%s%s\n", ok ? "PASS" : "FAIL", what, detail ? " — " : "", detail ? detail : "");
+    if (!ok) fails++;
+}
+
+int main(void) {
+    printf("packed matvec — allocation balance\n");
+
+    /* Q4_0: 18 bytes per block of 32. One row of k weights, m rows. Shapes are the ones a
+     * decode actually asks for, so the threaded path is exercised rather than only the
+     * single-threaded shortcut. */
+    const int k = 1536, m = 512;
+    size_t rowsz = (size_t)(k / 32) * 18;
+    uint8_t *W = (uint8_t *)malloc(rowsz * (size_t)m);
+    float *x = (float *)malloc((size_t)k * sizeof(float));
+    float *out = (float *)malloc((size_t)m * sizeof(float));
+    if (!W || !x || !out) { printf("  FAIL out of memory\n"); return 1; }
+    for (size_t i = 0; i < rowsz * (size_t)m; i++) W[i] = (uint8_t)(i * 31u + 7u);
+    for (int i = 0; i < k; i++) x[i] = (float)((i % 17) - 8) * 0.125f;
+
+    /* A NULL weight must come back as -1 rather than as a signal. This is the contract the
+     * callers test against, and it did not hold until the guard was added. */
+    check("NULL weight returns -1", nt_qmatvec_i8(out, NULL, 2, x, m, k) == -1, NULL);
+    check("NULL activation returns -1", nt_qmatvec_i8(out, W, 2, NULL, m, k) == -1, NULL);
+    check("NULL output returns -1", nt_qmatvec_i8(NULL, W, 2, x, m, k) == -1, NULL);
+
+    if (nt_qmatvec_i8(out, W, 2, x, m, k) != 0) {
+        check("matvec runs", 0, "returned non-zero on a valid call");
+        return 1;
+    }
+
+#if HAVE_MALLINFO2
+    /* Warm first: the allocator grows its arenas on the early calls and that growth is not
+     * a leak. Measure only the steady state. */
+    for (int i = 0; i < 64; i++) nt_qmatvec_i8(out, W, 2, x, m, k);
+    size_t before = mallinfo2().uordblks;
+    const int reps = 2000;
+    for (int i = 0; i < reps; i++) nt_qmatvec_i8(out, W, 2, x, m, k);
+    size_t after = mallinfo2().uordblks;
+    long delta = (long)after - (long)before;
+    /* Each leaked scratch would be k/32 int32 = 192 bytes, so 2000 calls would show about
+     * 384 kB. Anything under 64 kB is allocator bookkeeping, not per-call retention. */
+    char detail[128];
+    snprintf(detail, sizeof(detail), "%ld bytes held after %d calls", delta, reps);
+    check("nothing retained per call", delta < 65536, detail);
+#else
+    printf("  SKIP mallinfo2 unavailable — allocation balance not measured here\n");
+#endif
+
+    free(W); free(x); free(out);
+    printf("\nResults: %s\n", fails ? "FAILED" : "all passed");
+    return fails ? 1 : 0;
+}

--- a/tools/gguf_quantize.c
+++ b/tools/gguf_quantize.c
@@ -116,9 +116,18 @@ int main(int argc, char **argv) {
     if (target < 0) { fprintf(stderr, "unknown type %s\n", argv[3]); return 1; }
     int requantize = 0;
     const char *only = NULL;
+    /* A typo in a flag used to be silence, and silence here reads as success: the tool would
+     * copy the file through and report a conversion that never happened. */
     for (int i = 3; i < argc; i++) {
+        if (argv[i][0] != '-') {
+            if (i == 3) continue;                       /* the type name, already parsed */
+            fprintf(stderr, "unexpected argument %s\n", argv[i]); return 1;
+        }
         if (!strcmp(argv[i], "--requantize")) requantize = 1;
-        else if (!strcmp(argv[i], "--only") && i + 1 < argc) only = argv[++i];
+        else if (!strcmp(argv[i], "--only")) {
+            if (i + 1 >= argc) { fprintf(stderr, "--only needs a substring\n"); return 1; }
+            only = argv[++i];
+        } else { fprintf(stderr, "unknown option %s\n", argv[i]); return 1; }
     }
 
     gguf_file *gf = gguf_open(argv[1]);
@@ -142,9 +151,14 @@ int main(int argc, char **argv) {
          * 24 as q6_K and 146 as q8_0. Same rule here, so the two tools produce files of the
          * same shape rather than merely comparable ones. */
         int is_k = (target == GGUF_TYPE_Q4_K || target == GGUF_TYPE_Q6_K);
+        /* Only the dtypes this file can both decode and size. Letting --requantize mean
+         * "anything not float" put dtypes gguf_dequant_row has no reader for through the
+         * shape test, and the failure landed mid-write rather than at the decision. */
         int floatsrc = (t->dtype == GGUF_TYPE_F32 || t->dtype == GGUF_TYPE_F16 ||
                         t->dtype == GGUF_TYPE_BF16 ||
-                        (requantize && t->dtype != GGUF_TYPE_F32 && t->dtype != GGUF_TYPE_F16));
+                        (requantize && (t->dtype == GGUF_TYPE_Q4_0 || t->dtype == GGUF_TYPE_Q5_0 ||
+                                        t->dtype == GGUF_TYPE_Q8_0 || t->dtype == GGUF_TYPE_Q4_K ||
+                                        t->dtype == GGUF_TYPE_Q6_K)));
         int named = (!only || strstr(t->name, only) != NULL);
         int quantizable = (t->ndim == 2) && (t->shape[0] % 32 == 0) && floatsrc && named;
         uint32_t chosen = (uint32_t)target;


### PR DESCRIPTION
Review on the day's three merges raised eight points. Six were fair. Reading the code to answer one of them found what none of them had: nt_qmatvec_i8 takes three buffers per call — the quantized activation, its scales, and the per-block sums — and frees two on every exit path. asum is freed when an allocation fails and nowhere else: not on the unsupported-kernel return, not on the single-threaded shortcut, not on the pool return, not at the end of the function. That is the hottest entry in this library and it leaked k/32 times four bytes every call. Resident memory on a 0.5B model climbed 380228 to 387180 to 394976 kB across ten seconds of decode; with the frees in place the same window gives 380560 to 384068 to 387412, and the slope that remains is the KV cache becoming resident as the context fills — 24 layers by 2 KV heads by 64, times two, times four bytes, is 24 kB per token of context.

tests/test_qmatvec_leak.c holds it, on mallinfo2 rather than RSS: RSS moves for reasons that have nothing to do with the caller, uordblks is the sum of live allocations and nothing else. Two thousand calls retain 0 bytes. Removing the frees again and rerunning reports 416000, which is 208 a call against the 192 the arithmetic predicts plus the allocator's header — the gate was watched failing before it was trusted. Where mallinfo2 is absent it says so and skips, because a gate that cannot measure must not claim to.

The review was also right that this function validated dtype and shape and never the pointers, so a caller whose weight failed to load reached the kernel and died there instead of getting the -1 it was testing for. harness/arch_gemma4.c tests for exactly that. With the guard removed again the new test segfaults rather than failing an assertion, which is its own proof.

The rest, each confirmed before it was touched. The Python ctypes binding had drifted from gguf_file by two additions, kv_end from the quantizer work and map_base/map_len from the mapping, and a Structure with a gap does not fail loudly — every field past it reads its neighbour. tests/gguf_layout.c puts data at 443432 and n_layers at 443472 here, and only the corrected field list reproduces both; the Python gate itself was not run, this node does not run Python, and it wants a run on one that does. gguf_quantize ignored unknown flags and took --only with no value, so a typo looked like a conversion; both are errors now. --requantize meant "any dtype that is not float", which let types gguf_dequant_row cannot decode past the shape test, and now names the five it can. Three loose sentences in yesterday's entry are corrected: populating is the default where the platform has MAP_POPULATE, USE_METAL compiles the mapping out rather than failing to build, and the two load timings are two runs rather than one disputed number.

Gates: 49, 73, 34, 3 and the new one pass with none failing, parity identical on three prompts, tokenizer identical on 16.

Quote: "A man should look for what is, and not for what he thinks should be." — Albert Einstein
Method: the Method counts what it borrowed.

By Arianna Method (Co-authored by Claude, Defender) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff