### PR TITLE
the method stopped asking how many cores and started asking which

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ __pycache__/
 *.pyc
 test_qmatmul
 test_qmatvec_leak
+test_affinity
 
 gguf_quantize
 test_quantize

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ SIMD_LIBS  = -lpthread
 
 # ── Targets ──
 
-.PHONY: all test test_qpool test_qmatvec_leak test_js test_python test_tokenizer clean cpu gpu simd help lib shared install metal test_metal infer_gguf_metal
+.PHONY: all test test_qpool test_qmatvec_leak test_affinity test_js test_python test_tokenizer clean cpu gpu simd help lib shared install metal test_metal infer_gguf_metal
 
 all: notorch_test
 	@echo "Built with $(BLAS_NAME). Run: ./notorch_test"
@@ -356,13 +356,20 @@ test_qmatvec_leak: tests/test_qmatvec_leak.c notorch.c notorch.h
 	$(CC) $(CFLAGS) $(BLAS_FLAGS) -o test_qmatvec_leak tests/test_qmatvec_leak.c notorch.c -lm $(BLAS_LIBS)
 	@echo "Compiled: test_qmatvec_leak (packed matvec returns what it takes, $(BLAS_NAME))"
 
-test: notorch_test test_vision test_qpool test_qmatmul test_quantize test_qmatvec_leak
+test_affinity: tests/test_affinity.c notorch.c notorch.h
+	$(CC) $(CFLAGS) $(BLAS_FLAGS) -o test_affinity tests/test_affinity.c notorch.c -lm $(BLAS_LIBS)
+	@echo "Compiled: test_affinity (core selection on mixed-speed machines, $(BLAS_NAME))"
+
+test: notorch_test test_vision test_qpool test_qmatmul test_quantize test_qmatvec_leak test_affinity
 	./notorch_test
 	./test_vision
 	./test_qpool
 	./test_qmatmul
 	./test_quantize
 	./test_qmatvec_leak
+	./test_affinity
+	NT_QMV_BIG_ONLY=0 ./test_affinity off
+	./test_affinity narrowed
 
 test_js:
 	node js-edition/test_op_parity.mjs

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,49 @@ Newest entries on top.
 
 ---
 
+## 2026-09-02 — the library picks its cores, because counting them was the wrong question
+
+`nt_qmv_host_threads` asked `sched_getaffinity` how many CPUs it was allowed and used all of
+them. On a phone that is the wrong question. This SoC runs four cores at 1.95 GHz, three at
+2.6 and one at 2.91; the matvec splits into equal chunks, decode is already at the memory
+ceiling, and a chunk that lands on a small core holds up the whole operation. Which chunk that
+is changes from run to run, which is what made a benchmark disagree with itself between days —
+the earlier figures were taken under `taskset -c 4-7` and the later ones were not, and nothing
+had regressed at all.
+
+Measured by core set, Gemma 4 E2B decode: `cpu7` alone **6.0** t/s, `cpu6-7` 5.2, `cpu5-7`
+8.3, `cpu4-7` **10.2**, all eight 7.9, the four small ones 3.4. A single small core added to
+the big four costs a fifth of the throughput. More cores are not more arithmetic when the
+weights arrive at 91 percent of what the memory can deliver.
+
+The rule that survives measurement is **drop the slowest class**, not keep the fastest. The
+first version of this patch kept the fastest, which on three classes leaves the one prime core,
+and it benchmarked at 6.0 against the 8.0 it was meant to improve. Dropping only the slowest
+leaves `cpu4-7`, which is the measured optimum, and needs no threshold constant to say so.
+
+Engaged only when nobody else has decided: an explicit `NT_QMV_THREADS`, an affinity mask
+already narrower than the machine (`taskset`, a cgroup, a container), a uniform machine, no
+cpufreq, or `NT_QMV_BIG_ONLY=0` all leave the choice alone. Fewer than two surviving cores is
+treated as an unfamiliar topology rather than an opportunity. Worker threads and the thread
+that drives them are held there with `pthread_setaffinity_np` — the dispatcher drains a chunk
+alongside the pool, and a straggler is a straggler wherever it sits.
+
+Cold, three runs each, interleaved. Gemma decode **8.7 / 8.8 / 8.6 to 10.5 / 10.5 / 10.5**,
+prefill 9.4 / 9.6 / 10.1 to 13.4 / 20.9 / 20.4. Qwen 2.5 0.5B decode **33.0 / 33.1 / 34.0 to
+55.8 / 55.0 / 57.0**. Against the reference at `-t 4` on the same two files: 11.31 and 59.91,
+so decode is at 93 percent of it on both, where it had been 76 and 55. Prefill is not compared
+here — ours is an 11-token prompt and theirs is a 32-token batch, which are different
+quantities until they are measured the same way.
+
+`tests/test_affinity.c` holds it, in three processes because the decision is cached on first
+use: the default, `NT_QMV_BIG_ONLY=0`, and a mask the test narrows itself before the first
+call. It derives the expected core set from sysfs rather than asking the library, since a test
+that calls the function it is checking agrees with itself whatever that function does. Both
+ways of breaking it were tried: restoring the keep-the-fastest rule fails both assertions
+(planned 1 against 4), and removing the pinning fails exactly the one written for it.
+
+---
+
 ## 2026-09-01 — the packed matvec was keeping its scratch
 
 Review on the three merges of the day raised eight points. Six were fair and are fixed below.

--- a/notorch.c
+++ b/notorch.c
@@ -5322,6 +5322,89 @@ static long nt_qmv_thread_floor(void) {
  * the pool oversubscribed 2:1 and each matvec ended up waiting on a context switch instead
  * of on memory. The affinity mask is the honest number. NT_QMV_THREADS overrides both, which
  * is what an A/B run needs and what a caller that already owns a thread budget wants. */
+#if defined(__linux__)
+/* Reported peak kHz of one core, or 0 where cpufreq is not exported. */
+static long nt_cpu_peak_khz(int cpu) {
+    char path[128];
+    snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_max_freq", cpu);
+    FILE *f = fopen(path, "r");
+    if (!f) return 0;
+    long v = 0;
+    if (fscanf(f, "%ld", &v) != 1) v = 0;
+    fclose(f);
+    return v;
+}
+
+/* Everything in `in` except its slowest class, and how many that is. Returns 0 when the
+ * machine is uniform, when cpufreq says nothing, or when fewer than two cores would survive
+ * — all three mean there is no useful choice to make here.
+ *
+ * sched_getaffinity answers "how many cores may I use", which on a phone is the wrong
+ * question. Gemma 4 E2B on this SoC, decode, by core set: cpu7 alone 6.0 t/s, cpu6-7 5.2,
+ * cpu5-7 8.3, cpu4-7 10.2, all eight 7.9, the four small ones 3.4. Adding a single small
+ * core to the big four costs a fifth of the throughput (10.2 -> 8.3), because decode runs at
+ * the memory ceiling already and the extra core brings contention and a long tail rather
+ * than arithmetic.
+ *
+ * Note it is the slowest class that goes, not everything below the fastest. Peak clocks here
+ * are 1.95, 2.6 and 2.91 GHz across three classes; keeping only the fastest leaves the one
+ * prime core and measures 6.0, while dropping only the slowest leaves cpu4-7 and measures
+ * 10.2. Written after that mistake was built and benchmarked, not before. */
+static int nt_cpu_perf_set(const cpu_set_t *in, cpu_set_t *out) {
+    long slowest = 0, fastest = 0;
+    int seen = 0, n = 0;
+    for (int c = 0; c < CPU_SETSIZE; c++) {
+        if (!CPU_ISSET(c, in)) continue;
+        long f = nt_cpu_peak_khz(c);
+        if (f <= 0) return 0;
+        if (!seen || f < slowest) slowest = f;
+        if (f > fastest) fastest = f;
+        seen++;
+    }
+    if (!seen || slowest == fastest) return 0;
+    CPU_ZERO(out);
+    for (int c = 0; c < CPU_SETSIZE; c++)
+        if (CPU_ISSET(c, in) && nt_cpu_peak_khz(c) > slowest) { CPU_SET(c, out); n++; }
+    /* One core is not a fan-out, and on this hardware it measures worse than the whole
+     * machine. A shape that lopsided is more likely an unfamiliar topology than an
+     * opportunity, so leave it to the scheduler. */
+    return n >= 2 ? n : 0;
+}
+
+/* Computed once. Non-zero only when narrowing is both possible and nobody else's call to
+ * make: an explicit NT_QMV_THREADS, a mask already narrower than the machine (taskset, a
+ * cgroup, a container) and NT_QMV_BIG_ONLY=0 each leave it alone. */
+static int nt_qmv_fast_cpus(cpu_set_t *out) {
+    static int n = -1;
+    static cpu_set_t fast;
+    if (n < 0) {
+        n = 0;
+        const char *off = getenv("NT_QMV_BIG_ONLY");
+        const char *thr = getenv("NT_QMV_THREADS");
+        cpu_set_t mine;
+        CPU_ZERO(&mine);
+        if (!(off && off[0] == '0') && !(thr && atol(thr) > 0) &&
+            sched_getaffinity(0, sizeof(mine), &mine) == 0) {
+            long online = sysconf(_SC_NPROCESSORS_ONLN);
+            if (online > 0 && CPU_COUNT(&mine) == (int)online)
+                n = nt_cpu_perf_set(&mine, &fast);
+        }
+    }
+    if (n > 0 && out) *out = fast;
+    return n;
+}
+
+/* Hold a thread to the fast class. Called on each pool worker as it is created and once on
+ * the thread that drives them, because that thread drains a chunk alongside the pool and a
+ * straggler is a straggler wherever it sits. */
+static void nt_qmv_pin(pthread_t t) {
+    cpu_set_t fast;
+    if (nt_qmv_fast_cpus(&fast) > 0) pthread_setaffinity_np(t, sizeof(fast), &fast);
+}
+#else
+static void nt_qmv_pin(pthread_t t) { (void)t; }
+#endif
+
 static int nt_qmv_host_threads(int m) {
     static int host = -1;
     if (host < 0) {
@@ -5334,6 +5417,8 @@ static int nt_qmv_host_threads(int m) {
             cpu_set_t set;
             CPU_ZERO(&set);
             host = (sched_getaffinity(0, sizeof(set), &set) == 0) ? CPU_COUNT(&set) : 0;
+            int fast = nt_qmv_fast_cpus(NULL);
+            if (fast > 0) host = fast;
 #else
             host = 0;
 #endif
@@ -5474,10 +5559,12 @@ static void nt_qpool_shutdown(void) {
 
 static void nt_qpool_init_once(void) {
     int nt = nt_qmv_host_threads(NT_QMV_MAX_THREADS);
+    nt_qmv_pin(pthread_self());
     for (int i = 0; i < nt; i++) {
         g_nt_qpool.ids[i] = i;
         if (pthread_create(&g_nt_qpool.threads[i], NULL, nt_qpool_loop, &g_nt_qpool.ids[i]) != 0)
             break;
+        nt_qmv_pin(g_nt_qpool.threads[i]);
         g_nt_qpool.nthreads++;
     }
     g_nt_qpool.ready = g_nt_qpool.nthreads > 0;
@@ -6591,9 +6678,11 @@ static void nt_qpool_i8_init_once(void) {
      * a pool sized to the core count puts one thread too many on the cluster and every
      * matvec pays for the context switch. */
     int nt = nt_qmv_host_threads(NT_QMV_MAX_THREADS) - 1;
+    nt_qmv_pin(pthread_self());          /* the dispatcher takes a chunk too */
     for (int i = 0; i < nt; i++) {
         if (pthread_create(&g_nt_qpool_i8.threads[i], NULL, nt_qpool_i8_loop, NULL) != 0)
             break;
+        nt_qmv_pin(g_nt_qpool_i8.threads[i]);
         g_nt_qpool_i8.nthreads++;
     }
     g_nt_qpool_i8.ready = g_nt_qpool_i8.nthreads > 0;
@@ -6828,6 +6917,8 @@ int nt_qmatvec_i8_rows(float *out, const uint8_t *Wq, int dtype,
     if (r1 > r0) fn(out, Wq, qa, da, asum, r0, r1, k);
     return 0;
 }
+
+int nt_qmv_planned_threads(void) { return nt_qmv_host_threads(NT_QMV_MAX_THREADS); }
 
 int nt_qmatvec_i8(float *out, const uint8_t *Wq, int dtype,
                   const float *x, int m, int k) {

--- a/notorch.h
+++ b/notorch.h
@@ -557,6 +557,13 @@ void nt_qmv_set_thread_min(long elems);
 // code: Q4_0 (2), Q5_0 (6), Q8_0 (8), Q4_K (12), Q6_K (14). The K-quants need k
 // divisible by 256, the others by 32.
 // Returns 0 on success, -1 if no int8 kernel for the dtype yet.
+/* How many threads the packed matvec will fan out to, and on which cores. On a machine whose
+ * cores are not all the same speed notorch narrows itself to the fastest class, because the
+ * matvec splits into equal chunks and waits for the slowest one; an explicit NT_QMV_THREADS,
+ * an affinity mask already narrower than the machine, or NT_QMV_BIG_ONLY=0 all leave that
+ * decision to the caller. Exposed so a test can check the plan rather than infer it. */
+int nt_qmv_planned_threads(void);
+
 int nt_qmatvec_i8(float *out, const uint8_t *Wq, int dtype,
                   const float *x, int m, int k);
 

--- a/tests/test_affinity.c
+++ b/tests/test_affinity.c
@@ -1,0 +1,153 @@
+/* test_affinity.c — notorch must choose its cores, and must stop choosing when told.
+ *
+ * On a machine whose cores are not all the same speed, counting the affinity mask answers the
+ * wrong question: the matvec splits into equal chunks and waits for whichever chunk landed on
+ * a small core. Measured on Exynos 1580, Gemma 4 E2B decode: 10.2 t/s on the four big cores,
+ * 8.3 with one small core added, 7.9 across all eight, 6.0 on the prime core alone.
+ *
+ * The expected core set here is computed from sysfs by this file, not asked of the library.
+ * A test that calls the same function it is checking agrees with itself no matter what the
+ * function does.
+ *
+ * Three modes, three processes, because the decision is cached on first use:
+ *   test_affinity            — the default: narrow on a mixed machine, no-op on a uniform one
+ *   NT_QMV_BIG_ONLY=0 ... off — the opt-out must be honoured
+ *   test_affinity narrowed    — a mask somebody already narrowed is nobody else's business
+ */
+#if defined(__linux__) && !defined(_GNU_SOURCE)
+#define _GNU_SOURCE
+#endif
+#include "notorch.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sched.h>
+#include <pthread.h>
+
+static int fails = 0;
+
+static void check(const char *what, int ok, const char *detail) {
+    printf("  %s %s%s%s\n", ok ? "PASS" : "FAIL", what, detail ? " — " : "", detail ? detail : "");
+    if (!ok) fails++;
+}
+
+#if defined(__linux__)
+static long peak_khz(int cpu) {
+    char path[128];
+    snprintf(path, sizeof(path), "/sys/devices/system/cpu/cpu%d/cpufreq/cpuinfo_max_freq", cpu);
+    FILE *f = fopen(path, "r");
+    if (!f) return 0;
+    long v = 0;
+    if (fscanf(f, "%ld", &v) != 1) v = 0;
+    fclose(f);
+    return v;
+}
+
+/* The set this test expects notorch to settle on, derived independently: everything in `in`
+ * whose peak clock is above the slowest present, or `in` itself when that is not a choice. */
+static int expected_set(const cpu_set_t *in, cpu_set_t *out) {
+    long slow = 0, fast = 0;
+    int seen = 0, n = 0;
+    for (int c = 0; c < CPU_SETSIZE; c++) {
+        if (!CPU_ISSET(c, in)) continue;
+        long f = peak_khz(c);
+        if (f <= 0) { *out = *in; return CPU_COUNT(in); }
+        if (!seen || f < slow) slow = f;
+        if (f > fast) fast = f;
+        seen++;
+    }
+    if (!seen || slow == fast) { *out = *in; return CPU_COUNT(in); }
+    CPU_ZERO(out);
+    for (int c = 0; c < CPU_SETSIZE; c++)
+        if (CPU_ISSET(c, in) && peak_khz(c) > slow) { CPU_SET(c, out); n++; }
+    if (n < 2) { *out = *in; return CPU_COUNT(in); }
+    return n;
+}
+
+static void describe(const cpu_set_t *s, char *buf, size_t n) {
+    size_t off = 0;
+    buf[0] = 0;
+    for (int c = 0; c < CPU_SETSIZE && off + 8 < n; c++)
+        if (CPU_ISSET(c, s)) off += (size_t)snprintf(buf + off, n - off, "%d ", c);
+}
+
+/* One real matvec, big enough to take the threaded path, so the pool exists and has pinned
+ * whatever it is going to pin. */
+static int run_one_matvec(void) {
+    const int k = 1536, m = 512;
+    size_t rowsz = (size_t)(k / 32) * 18;                 /* Q4_0 */
+    uint8_t *W = (uint8_t *)malloc(rowsz * (size_t)m);
+    float *x = (float *)malloc((size_t)k * sizeof(float));
+    float *out = (float *)malloc((size_t)m * sizeof(float));
+    if (!W || !x || !out) return -1;
+    memset(W, 0x42, rowsz * (size_t)m);
+    for (int i = 0; i < k; i++) x[i] = 0.5f;
+    int rc = nt_qmatvec_i8(out, W, 2, x, m, k);
+    free(W); free(x); free(out);
+    return rc;
+}
+
+int main(int argc, char **argv) {
+    const char *mode = argc > 1 ? argv[1] : "default";
+    printf("core selection [%s]\n", mode);
+
+    cpu_set_t start;
+    CPU_ZERO(&start);
+    if (sched_getaffinity(0, sizeof(start), &start) != 0) {
+        printf("  SKIP sched_getaffinity unavailable\n");
+        return 0;
+    }
+
+    if (!strcmp(mode, "narrowed")) {
+        /* Two cores, chosen from the ones we already have, standing in for taskset or a
+         * cgroup. Nothing notorch does may widen this or narrow it further. */
+        cpu_set_t two;
+        CPU_ZERO(&two);
+        int taken = 0;
+        for (int c = 0; c < CPU_SETSIZE && taken < 2; c++)
+            if (CPU_ISSET(c, &start)) { CPU_SET(c, &two); taken++; }
+        if (taken < 2) { printf("  SKIP fewer than two CPUs to work with\n"); return 0; }
+        if (sched_setaffinity(0, sizeof(two), &two) != 0) {
+            printf("  SKIP sched_setaffinity refused\n");
+            return 0;
+        }
+        start = two;
+    }
+
+    cpu_set_t want;
+    int want_n = expected_set(&start, &want);
+    if (!strcmp(mode, "off") || !strcmp(mode, "narrowed")) {
+        want = start;                       /* opted out, or already somebody's decision */
+        want_n = CPU_COUNT(&start);
+    }
+
+    char a[256], b[256];
+    describe(&want, a, sizeof(a));
+
+    int planned = nt_qmv_planned_threads();
+    char detail[128];
+    snprintf(detail, sizeof(detail), "planned %d, expected %d over cpus %s", planned, want_n, a);
+    check("thread count matches the core plan", planned == want_n, detail);
+
+    if (run_one_matvec() != 0) { check("matvec runs", 0, "returned non-zero"); return 1; }
+
+    cpu_set_t now;
+    CPU_ZERO(&now);
+    if (sched_getaffinity(0, sizeof(now), &now) != 0) {
+        check("affinity readable after the matvec", 0, NULL);
+        return 1;
+    }
+    describe(&now, b, sizeof(b));
+    snprintf(detail, sizeof(detail), "on cpus %s, expected %s", b, a);
+    check("the driving thread sits where the plan says", CPU_EQUAL(&now, &want), detail);
+
+    printf("\nResults: %s\n", fails ? "FAILED" : "all passed");
+    return fails ? 1 : 0;
+}
+#else
+int main(void) {
+    printf("core selection\n  SKIP not Linux — nothing here selects cores\n");
+    return 0;
+}
+#endif


### PR DESCRIPTION
nt_qmv_host_threads asked sched_getaffinity how many CPUs it was allowed and used all of them. On a phone that is the wrong question. This SoC runs four cores at 1.95 GHz, three at 2.6 and one at 2.91; the matvec splits into equal chunks, decode already arrives at 91 percent of what the memory can deliver, and a chunk landing on a small core holds up the whole operation. Which chunk that is changes between runs, and that is what made a benchmark disagree with itself across two days: the earlier numbers were taken under taskset -c 4-7 and the later ones were not. Nothing had regressed. Every hypothesis chased for that — swap, page cache, temperature, prompt, generation length, BLAS threads, huge pages — was chased in the wrong place, and the mapping work those days produced stands on its own measurements rather than on the reason first given for it.

By core set, Gemma 4 E2B decode: cpu7 alone 6.0 t/s, cpu6-7 5.2, cpu5-7 8.3, cpu4-7 10.2, all eight 7.9, the four small ones 3.4. One small core added to the big four costs a fifth of the throughput. More cores are not more arithmetic at the memory ceiling; they are contention and a longer tail.

The rule is drop the slowest class, not keep the fastest. The first version of this patch kept the fastest, which across three classes leaves the single prime core, and it benchmarked 6.0 against the 8.0 it meant to improve — built, measured, thrown away. Dropping the slowest leaves cpu4-7, which is the measured optimum, and it needs no threshold constant to get there.

It engages only where nobody has already decided. An explicit NT_QMV_THREADS, a mask narrower than the machine (taskset, cgroup, container), a uniform machine, absent cpufreq, or NT_QMV_BIG_ONLY=0 each leave the choice alone; fewer than two surviving cores is read as an unfamiliar topology rather than an opportunity. Workers and the thread driving them are held with pthread_setaffinity_np, because the dispatcher drains a chunk beside the pool.

Cold, three runs each, interleaved. Gemma decode 8.7 / 8.8 / 8.6 to 10.5 / 10.5 / 10.5, prefill 9.4 / 9.6 / 10.1 to 13.4 / 20.9 / 20.4. Qwen 2.5 0.5B decode 33.0 / 33.1 / 34.0 to 55.8 / 55.0 / 57.0. The reference at -t 4 on the same two files does 11.31 and 59.91, so decode now sits at 93 percent of it on both where it had been 76 and 55. Prefill is left uncompared: ours is an 11-token prompt, theirs a 32-token batch, and those are different quantities until they are measured the same way.

tests/test_affinity.c holds it, in three processes because the decision is cached at first use — the default, NT_QMV_BIG_ONLY=0, and a mask the test narrows itself beforehand. It derives the expected set from sysfs rather than asking the library, since a test that calls the function it checks will agree with itself whatever that function does. Both breakages were tried before it was trusted: restoring keep-the-fastest fails both assertions with planned 1 against 4, and removing the pinning fails exactly the assertion written for it.

Gates: 49, 73, 34, 3, the allocation gate and three affinity modes all pass, parity identical on three prompts, tokenizer identical on 16.

Quote: "It is not enough to be busy. The question is: what are we busy about?" — Henry David Thoreau
Method: the Method asks the machine which of its hands is the fast one.

By Arianna Method (Co-authored by Claude, Defender) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff