### PR TITLE
the method gives each thread a core instead of a promise

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -370,6 +370,7 @@ test: notorch_test test_vision test_qpool test_qmatmul test_quantize test_qmatve
 	./test_affinity
 	NT_QMV_BIG_ONLY=0 ./test_affinity off
 	./test_affinity narrowed
+	NT_QMV_PIN=0 ./test_affinity nopin
 
 test_js:
 	node js-edition/test_op_parity.mjs

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,52 @@ Newest entries on top.
 
 ---
 
+## 2026-09-02 — one thread per core, because the scheduler stacks them two to a core
+
+The core-class work left an oddity in its sweep: two cores measured slower than one. Gemma 4
+decode on `taskset -c 6,7` gave 5.1 t/s against 6.1 on `cpu7` alone, and `cpu5,6` — two cores
+of the same 2.6 GHz class — gave 4.6, 8.8, 4.6 across three runs where every other
+configuration repeated itself to the decimal.
+
+Not a spread, two plateaus, and the ratio between them is 1.9. Sampling `/proc/<pid>/task`
+through six runs said what that means: in the fast ones the two threads accumulate time on
+cpu5 and cpu6, in the slow ones both sit on cpu5 and the second collects a quarter of the
+first's cycles. One core doing the work of two. The scheduler is not being careless — a thread
+that alternates spinning with parking on a condvar reads as half idle, two halves fit on one
+core by that arithmetic, and the placement is decided once and kept for the run.
+
+So the pool pins one thread per core, in order, instead of handing every thread the same mask.
+Honouring an affinity mask somebody else set means honouring **which** cores they gave us; it
+does not mean declining to use all of them, and a mask from `taskset` or a cgroup is usually
+somebody reserving cores for exactly this. `NT_QMV_PIN=0` turns all of it off.
+
+Six runs each, cold, with an unpinned control in the same sweep on the same hardware:
+
+| | runs |
+|---|---|
+| `cpu5,6` pinned | 8.3 8.3 8.3 8.3 8.3 8.3 |
+| `cpu5,6` unpinned | 4.5 8.8 4.6 4.6 5.8 8.8 |
+| `cpu4,6` pinned | 8.3 8.3 8.3 8.3 8.3 8.3 |
+| `cpu6,7` pinned | 7.7 7.7 7.7 7.8 7.7 7.7 (was 5.1) |
+| all cores, default | 10.5 10.4 10.4 (unchanged) |
+
+The control still swings, which is what makes this a difference rather than a story. `cpu6,7`
+gains half again. Stated plainly: pinned 8.3 is about six percent below the *lucky* unpinned
+8.8, because a pinned thread cannot step aside when Android wants that core for a moment — the
+trade is six percent off the best case against eighty percent off the worst, and a number that
+repeats. The default four-core path does not move; this is for masks somebody narrowed.
+
+`tests/test_affinity.c` gains a fourth mode, `NT_QMV_PIN=0`, and its placement assertion now
+reads "one core of its own" rather than "somewhere in the plan" — the old wording passed
+whether or not the threads were stacked, which is exactly the failure this entry is about.
+
+Left open and measured, not explained: three big cores beat four. `cpu4-6` gives 10.8 / 10.8 /
+10.7 against `cpu4-7` at 10.5 / 10.5 / 10.6, so adding the *faster* prime core costs three
+percent. Either bandwidth is already saturated at three, or cpu7 is where Android puts its own
+foreground work and we are sharing it. Next.
+
+---
+
 ## 2026-09-02 — the library picks its cores, because counting them was the wrong question
 
 `nt_qmv_host_threads` asked `sched_getaffinity` how many CPUs it was allowed and used all of

--- a/notorch.c
+++ b/notorch.c
@@ -5394,15 +5394,58 @@ static int nt_qmv_fast_cpus(cpu_set_t *out) {
     return n;
 }
 
-/* Hold a thread to the fast class. Called on each pool worker as it is created and once on
- * the thread that drives them, because that thread drains a chunk alongside the pool and a
- * straggler is a straggler wherever it sits. */
-static void nt_qmv_pin(pthread_t t) {
-    cpu_set_t fast;
-    if (nt_qmv_fast_cpus(&fast) > 0) pthread_setaffinity_np(t, sizeof(fast), &fast);
+/* The cores this fan-out may use: the fast class where narrowing applies, otherwise the mask
+ * we inherited. Cached, because the first pin replaces the caller's mask and asking again
+ * afterwards would answer with that one core. */
+static int nt_qmv_target_cpus(cpu_set_t *out) {
+    static int n = -1;
+    static cpu_set_t set;
+    if (n < 0) {
+        n = nt_qmv_fast_cpus(&set);
+        if (n <= 0) {
+            CPU_ZERO(&set);
+            n = (sched_getaffinity(0, sizeof(set), &set) == 0) ? CPU_COUNT(&set) : 0;
+        }
+    }
+    if (n > 0 && out) *out = set;
+    return n;
+}
+
+/* One thread per core, in order, rather than one mask shared by all of them.
+ *
+ * Leaving placement inside the mask to the scheduler is not the neutral choice it looks like.
+ * A thread that alternates spinning with parking on a condvar reads as half idle, so two of
+ * them fit on one core by the scheduler's arithmetic, and the decision is taken once and kept
+ * for the whole run. Measured on taskset -c 5,6, six runs of Gemma 4 decode: 8.7, 5.1, 5.8,
+ * 4.6, 6.9, 8.8 t/s — two plateaus, not a spread. Sampling /proc/<pid>/task through each run
+ * showed the fast ones with the two threads accumulating time on cpu5 and cpu6, and the slow
+ * ones with both on cpu5, the second thread getting a quarter of the first one's cycles. The
+ * ratio between the plateaus is 1.9, which is what one core doing the work of two looks like.
+ *
+ * Honouring somebody else's mask means honouring which cores they gave us. It does not mean
+ * declining to use all of them. NT_QMV_PIN=0 turns this off. */
+static int nt_qmv_pin_enabled(void) {
+    static int on = -1;
+    if (on < 0) {
+        const char *e = getenv("NT_QMV_PIN");
+        on = !(e && e[0] == '0');
+    }
+    return on;
+}
+
+static void nt_qmv_pin_nth(pthread_t t, int idx) {
+    if (!nt_qmv_pin_enabled()) return;
+    cpu_set_t all, one;
+    int n = nt_qmv_target_cpus(&all);
+    if (n <= 0) return;
+    int want = idx % n, seen = 0;
+    CPU_ZERO(&one);
+    for (int c = 0; c < CPU_SETSIZE; c++)
+        if (CPU_ISSET(c, &all) && seen++ == want) { CPU_SET(c, &one); break; }
+    if (CPU_COUNT(&one)) pthread_setaffinity_np(t, sizeof(one), &one);
 }
 #else
-static void nt_qmv_pin(pthread_t t) { (void)t; }
+static void nt_qmv_pin_nth(pthread_t t, int idx) { (void)t; (void)idx; }
 #endif
 
 static int nt_qmv_host_threads(int m) {
@@ -5559,12 +5602,12 @@ static void nt_qpool_shutdown(void) {
 
 static void nt_qpool_init_once(void) {
     int nt = nt_qmv_host_threads(NT_QMV_MAX_THREADS);
-    nt_qmv_pin(pthread_self());
+    nt_qmv_pin_nth(pthread_self(), 0);
     for (int i = 0; i < nt; i++) {
         g_nt_qpool.ids[i] = i;
         if (pthread_create(&g_nt_qpool.threads[i], NULL, nt_qpool_loop, &g_nt_qpool.ids[i]) != 0)
             break;
-        nt_qmv_pin(g_nt_qpool.threads[i]);
+        nt_qmv_pin_nth(g_nt_qpool.threads[i], i + 1);
         g_nt_qpool.nthreads++;
     }
     g_nt_qpool.ready = g_nt_qpool.nthreads > 0;
@@ -6678,11 +6721,11 @@ static void nt_qpool_i8_init_once(void) {
      * a pool sized to the core count puts one thread too many on the cluster and every
      * matvec pays for the context switch. */
     int nt = nt_qmv_host_threads(NT_QMV_MAX_THREADS) - 1;
-    nt_qmv_pin(pthread_self());          /* the dispatcher takes a chunk too */
+    nt_qmv_pin_nth(pthread_self(), 0);   /* the dispatcher takes a chunk too */
     for (int i = 0; i < nt; i++) {
         if (pthread_create(&g_nt_qpool_i8.threads[i], NULL, nt_qpool_i8_loop, NULL) != 0)
             break;
-        nt_qmv_pin(g_nt_qpool_i8.threads[i]);
+        nt_qmv_pin_nth(g_nt_qpool_i8.threads[i], i + 1);
         g_nt_qpool_i8.nthreads++;
     }
     g_nt_qpool_i8.ready = g_nt_qpool_i8.nthreads > 0;

--- a/tests/test_affinity.c
+++ b/tests/test_affinity.c
@@ -11,8 +11,10 @@
  *
  * Three modes, three processes, because the decision is cached on first use:
  *   test_affinity            — the default: narrow on a mixed machine, no-op on a uniform one
- *   NT_QMV_BIG_ONLY=0 ... off — the opt-out must be honoured
- *   test_affinity narrowed    — a mask somebody already narrowed is nobody else's business
+ *   NT_QMV_BIG_ONLY=0 ... off — the class opt-out must be honoured
+ *   test_affinity narrowed    — a mask somebody already narrowed picks the cores, and we
+ *                               still spread across every core they gave us
+ *   NT_QMV_PIN=0 ... nopin    — the affinity opt-out must be honoured completely
  */
 #if defined(__linux__) && !defined(_GNU_SOURCE)
 #define _GNU_SOURCE
@@ -121,6 +123,8 @@ int main(int argc, char **argv) {
         want = start;                       /* opted out, or already somebody's decision */
         want_n = CPU_COUNT(&start);
     }
+    /* NT_QMV_PIN=0 is about affinity alone. How many threads to run is a separate question
+     * and still follows the core classes, so only the placement assertion changes below. */
 
     char a[256], b[256];
     describe(&want, a, sizeof(a));
@@ -139,8 +143,19 @@ int main(int argc, char **argv) {
         return 1;
     }
     describe(&now, b, sizeof(b));
-    snprintf(detail, sizeof(detail), "on cpus %s, expected %s", b, a);
-    check("the driving thread sits where the plan says", CPU_EQUAL(&now, &want), detail);
+    /* One thread per core, in order, so the thread that drove the matvec holds the first CPU
+     * of the plan and nothing else. A shared mask is not enough: the scheduler will put two
+     * spin-then-park threads on one core and keep them there. */
+    cpu_set_t first;
+    CPU_ZERO(&first);
+    if (!strcmp(mode, "nopin")) first = start;        /* nothing may have touched it */
+    else
+        for (int c = 0; c < CPU_SETSIZE; c++)
+            if (CPU_ISSET(c, &want)) { CPU_SET(c, &first); break; }
+    char fbuf[64];
+    describe(&first, fbuf, sizeof(fbuf));
+    snprintf(detail, sizeof(detail), "on cpus %s, expected the plan's first core %s", b, fbuf);
+    check("the driving thread holds one core of its own", CPU_EQUAL(&now, &first), detail);
 
     printf("\nResults: %s\n", fails ? "FAILED" : "all passed");
     return fails ? 1 : 0;


### PR DESCRIPTION
The core-class sweep left an oddity: two cores measured slower than one. Gemma 4 decode on taskset -c 6,7 gave 5.1 t/s against 6.1 on cpu7 alone, and cpu5,6 — two cores of the same 2.6 GHz class — gave 4.6, 8.8, 4.6 on three runs, where every other configuration repeated to the decimal.

Two plateaus rather than a spread, and the ratio between them is 1.9. Sampling /proc/<pid>/task through six runs said what that meant: in the fast runs the two threads accumulate time on cpu5 and cpu6, in the slow ones both sit on cpu5 and the second collects a quarter of the first's cycles. One core doing the work of two. The scheduler is not being careless — a thread that alternates spinning with parking reads as half idle, two halves fit on one core by that arithmetic, and the placement is taken once and kept for the whole run.

So the pool pins one thread per core, in order, instead of handing every thread the same mask. Honouring a mask somebody else set means honouring which cores they gave us; it does not mean declining to use all of them, and a mask from taskset or a cgroup is usually somebody reserving cores for exactly this work. NT_QMV_PIN=0 turns all of it off.

Six runs each, cold, with an unpinned control in the same sweep on the same hardware: cpu5,6 pinned 8.3 8.3 8.3 8.3 8.3 8.3 against unpinned 4.5 8.8 4.6 4.6 5.8 8.8; cpu4,6 pinned 8.3 six times; cpu6,7 pinned 7.7 7.7 7.7 7.8 7.7 7.7 where it had been 5.1; all cores at the default 10.5 10.4 10.4, unchanged. The control still swings, which is what makes this a difference rather than a story.

Plainly: pinned 8.3 is six percent below the lucky unpinned 8.8, because a pinned thread cannot step aside when Android wants that core for a moment. Six percent off the best case against eighty percent off the worst, and a number that repeats.

tests/test_affinity.c gains a fourth mode for NT_QMV_PIN=0, and its placement assertion now reads "one core of its own" rather than "somewhere in the plan" — the old wording passed whether or not the threads were stacked, which is the failure this commit is about.

Open and measured rather than explained: three big cores beat four. cpu4-6 gives 10.8 / 10.8 / 10.7 against cpu4-7 at 10.5 / 10.5 / 10.6, so adding the faster prime core costs three percent. Either bandwidth saturates at three, or cpu7 is where Android puts its foreground work.

Gates: 49, 73, 34, 3, the allocation gate and four affinity modes pass, parity identical on three prompts, tokenizer identical on 16.

Quote: "Order and simplification are the first steps toward the mastery of a subject." — Thomas Mann
Method: the Method does not leave its hands where somebody else decides which one moves.

By Arianna Method (Co-authored by Claude, Defender) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff