### PR TITLE
the Method stopped putting its workers to sleep mid-token

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -380,6 +380,7 @@ test: notorch_test test_vision test_qpool test_qmatmul test_quantize test_qmatve
 	./test_qpool
 	NT_QMV_CHUNKS=1 ./test_qpool
 	NT_QMV_CHUNKS=64 ./test_qpool
+	NT_QMV_SPIN=0 ./test_qpool
 	./test_qmatmul
 	./test_quantize
 	./test_qmatvec_leak

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,50 @@ Newest entries on top.
 
 ---
 
+## 2026-09-03 — the workers were going to sleep between matvecs
+
+A worker looks for its next job for a while before parking on a condvar, and the budget for
+that looking was 20000 iterations. Between two matvecs of one token the gap is the scalar work
+— norms, rope, softmax, quantizing the activation — and some of those gaps are longer than
+20000 iterations covers. Every one of them parked three workers and woke them again through a
+futex.
+
+Raising the budget, four cores, decode t/s on Gemma 4 E2B and Qwen 2.5 0.5B: 20000 -> 10.5 /
+52.7, 200000 -> 10.9 / 56.1, **500000 -> 11.1 / 56.5**, 1000000 -> 11.1 / 56.1, 4000000 ->
+11.1 / 57.6. Flat past the knee at half a million, which is the new default.
+
+Spinning does not cost what it looks like it costs, and the CPU seconds beside the wall clock
+say so: 11.6 cpu-s at 20000 against 11.3 at 500000 for the same 24 tokens, wall 5.53 s against
+4.98. Parking and waking spends more cycles than looking does. What it does cost is a core held
+for about ten milliseconds after the last dispatch before the worker gives up — free for
+continuous decoding, a small drain for a process that runs one matvec and waits.
+
+Cold, three runs each, against the previous default and the reference at `-t 4` on the same
+files: Gemma **10.6 / 10.0 / 10.6 -> 11.0 / 11.0 / 11.1** against llama.cpp's 11.33, Qwen
+**52.3 / 52.1 / 52.5 -> 56.4 / 56.0 / 55.7** against 57.98. Decode is at 97 percent of the
+reference on both, from 93 after the core work and 76 and 55 before it.
+
+An old note in this log said the opposite — that a long spin halved throughput on two cores,
+2.8 t/s against 5.1. That measurement was taken before the pool pinned one thread per core,
+and it was measuring two threads sharing one core, where a spinner starves the thread doing the
+arithmetic. With placement settled the sign reverses: on two cores now, 8.1 at zero budget
+against 8.95 at 200000. The old number was about placement, not about spinning.
+
+One guess died on the way. The three counters the pool coordinates through — `generation`,
+`busy`, `next` — are consecutive ints in one cache line, so every chunk claim invalidates the
+line the others spin on, and false sharing predicts that more spinning hurts. It helps, all the
+way to four million. Worth separating those fields anyway, but that is a different change with
+its own measurement, not the explanation for this one.
+
+`test_qpool` now also runs at `NT_QMV_SPIN=0`, which is the only way the park-and-wake path
+executes at all — at the default budget a worker essentially never reaches the condvar. Said
+exactly, because it was tried: that run caught nothing the default run missed. A lost wakeup is
+a race and no bit comparison finds it; corrupting the busy count, the hazard the dispatch
+comment warns about, fails both runs. It is coverage before the next refactor touches that
+path, not a second detector.
+
+---
+
 ## 2026-09-03 — one plan behind one guard, and the five races a review only half saw
 
 Review on the pinning merge pointed at `nt_qmv_target_cpus`: a `cpu_set_t` cached in a

--- a/notorch.c
+++ b/notorch.c
@@ -5453,8 +5453,24 @@ static void nt_qmv_plan_init(void) {
     p->pool = !(e && (!strcmp(e, "0") || !strcmp(e, "false") ||
                       !strcmp(e, "off") || !strcmp(e, "no")));
 
+    /* How long a worker keeps looking before it parks on the condvar. Between two matvecs of
+     * one token the gap is the scalar work — norms, rope, softmax, quantizing the activation
+     * — and some of those gaps are longer than a short budget covers, so the worker parks and
+     * has to be woken through a futex, once per worker per gap. Raising the budget past the
+     * long gaps removes those wakes. Gemma 4 E2B and Qwen 2.5 0.5B decode, four cores:
+     * 20000 -> 10.5 / 52.7 t/s, 200000 -> 10.9 / 56.1, 500000 -> 11.1 / 56.5,
+     * 1000000 -> 11.1 / 56.1, 4000000 -> 11.1 / 57.6. Five to seven percent, flat past the
+     * knee at half a million.
+     *
+     * Spinning does not cost what it looks like it costs. Measured with the CPU seconds beside
+     * the wall clock: 11.6 cpu-s at 20000 against 11.3 at 500000 for the same work, because
+     * parking and waking spends more of them than looking does. What it does cost is a core
+     * held for roughly ten milliseconds after the last dispatch before the worker gives up —
+     * free for continuous decoding, a small drain for a process that runs one matvec and
+     * waits. NT_QMV_SPIN=0 parks immediately, which is also the only way the condvar path
+     * gets exercised. */
     e = getenv("NT_QMV_SPIN");
-    p->spin = (e && atoi(e) >= 0) ? atoi(e) : 20000;
+    p->spin = (e && atoi(e) >= 0) ? atoi(e) : 500000;
 
     e = getenv("NT_QMV_THREAD_MIN");
     p->thread_min = (e && atol(e) > 0) ? atol(e) : NT_QMV_THREAD_MIN_DEFAULT;

--- a/tests/test_qpool.c
+++ b/tests/test_qpool.c
@@ -11,7 +11,13 @@
  * m is deliberately not a multiple of any plausible core count, to exercise the tail.
  * How finely the rows are divided is read once per process, so the Makefile runs this
  * under several NT_QMV_CHUNKS values: coarse and fine must agree to the bit with each
- * other and with the single-threaded reference.
+ * other and with the single-threaded reference. It also runs once at NT_QMV_SPIN=0, which
+ * is the only way the park-and-wake path is exercised at all: at the default budget a worker
+ * almost never reaches the condvar, so that code would otherwise go years without executing.
+ * Stated exactly, because it was tried: that run caught nothing the default run missed. A
+ * lost wakeup is a race and no bit comparison finds it, and corrupting the busy count — the
+ * hazard the dispatch comment warns about — fails both runs. It is coverage before the next
+ * refactor touches that path, not a second detector.
  *
  * Two failure modes were injected while writing this to confirm it can fail: a cursor
  * that skips a row per chunk, and a range one row short. Both were caught. An overlapping


### PR DESCRIPTION
A worker looks for its next job before parking on a condvar, and the budget for looking was 20000 iterations. Between two matvecs of one token the gap is the scalar work — norms, rope, softmax, quantizing the activation — and some of those gaps outlast 20000 iterations. Each one parked three workers and woke them again through a futex.

Four cores, decode t/s on Gemma 4 E2B and Qwen 2.5 0.5B: 20000 -> 10.5 / 52.7, 200000 -> 10.9 / 56.1, 500000 -> 11.1 / 56.5, 1000000 -> 11.1 / 56.1, 4000000 -> 11.1 / 57.6. Flat past the knee at half a million, which is the new default.

Spinning does not cost what it appears to, and the CPU seconds beside the wall clock say so: 11.6 cpu-s at 20000 against 11.3 at 500000 for the same 24 tokens, wall 5.53 s against 4.98. Parking and waking spends more cycles than looking does. It does cost a core held about ten milliseconds after the last dispatch before the worker gives up: free for continuous decoding, a small drain for a process that runs one matvec and waits.

Cold, three runs each, against the previous default and the reference at -t 4 on the same files: Gemma 10.6 / 10.0 / 10.6 to 11.0 / 11.0 / 11.1 against llama.cpp's 11.33; Qwen 52.3 / 52.1 / 52.5 to 56.4 / 56.0 / 55.7 against 57.98. Decode sits at 97 percent of the reference on both, from 93 after the core work and 76 and 55 before it.

An older note in this log said the opposite: that a long spin halved throughput on two cores, 2.8 against 5.1. That was measured before the pool pinned one thread per core, so it was measuring two threads sharing a core, where a spinner starves the one doing arithmetic. With placement settled the sign reverses — two cores now give 8.1 at zero budget against 8.95 at
200000. The old number was about placement.

A guess died here too. generation, busy and next are consecutive ints in one cache line, so every chunk claim invalidates the line the others spin on, and false sharing predicts that more spinning hurts. It helps, out to four million. Those fields deserve separating regardless, but that is its own change with its own measurement, not the explanation for this one.

test_qpool also runs at NT_QMV_SPIN=0 now, the only way the park-and-wake path executes at all — at the default budget a worker essentially never reaches the condvar. Exactly, because it was tried: that run caught nothing the default run missed. A lost wakeup is a race and no bit comparison finds it; corrupting the busy count, which is the hazard the dispatch comment warns about, fails both runs. Coverage before the next refactor touches that path, not a second detector.

Gates: 49, 73, 34, 3, four determinism runs, the allocation gate, four affinity modes, the race test and the sanitizer target all pass; parity identical on three prompts, tokenizer on 16.

Quote: "Rest is not idleness, and to lie sometimes on the grass is by no means a waste of time." — John Lubbock
Method: the Method keeps its hands open between two pieces of work.

By Arianna Method (Co-authored by Claude, Defender) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff