### PR TITLE
the method separated the counters and reports that nothing got faster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ test_qmatmul
 test_qmatvec_leak
 test_affinity
 test_plan_race
+bench_claim
 test_plan_race_tsan
 
 gguf_quantize

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ SIMD_LIBS  = -lpthread
 
 # ── Targets ──
 
-.PHONY: all test test_qpool test_qmatvec_leak test_affinity test_plan_race test_tsan test_js test_python test_tokenizer clean cpu gpu simd help lib shared install metal test_metal infer_gguf_metal
+.PHONY: all test test_qpool test_qmatvec_leak test_affinity test_plan_race test_tsan bench_claim test_js test_python test_tokenizer clean cpu gpu simd help lib shared install metal test_metal infer_gguf_metal
 
 all: notorch_test
 	@echo "Built with $(BLAS_NAME). Run: ./notorch_test"
@@ -352,6 +352,10 @@ test_qmatmul: tests/test_qmatmul.c notorch.c notorch.h
 	$(CC) $(CFLAGS) $(BLAS_FLAGS) -o test_qmatmul tests/test_qmatmul.c notorch.c -lm $(BLAS_LIBS)
 	@echo "Compiled: test_qmatmul (batched packed matmul vs per-token, $(BLAS_NAME))"
 
+bench_claim: tests/bench_claim.c
+	$(CC) $(CFLAGS) -o bench_claim tests/bench_claim.c
+	@echo "Compiled: bench_claim (row-claim cost, shared line against separated)"
+
 test_plan_race: tests/test_plan_race.c notorch.c notorch.h
 	$(CC) $(CFLAGS) $(BLAS_FLAGS) -o test_plan_race tests/test_plan_race.c notorch.c -lm $(BLAS_LIBS)
 	@echo "Compiled: test_plan_race (both pools settling the plan at once, $(BLAS_NAME))"
@@ -360,8 +364,8 @@ test_plan_race: tests/test_plan_race.c notorch.c notorch.h
 # five races on the version before it was one pthread_once, none after. Android's ASLR is
 # wider than ThreadSanitizer's shadow mapping expects, hence setarch.
 test_tsan: tests/test_plan_race.c notorch.c notorch.h
-	$(CC) -fsanitize=thread -O1 -pthread -I. -o test_plan_race_tsan \
-	  tests/test_plan_race.c notorch.c -lm
+	$(CC) $(CFLAGS) $(BLAS_FLAGS) -fsanitize=thread -O1 -o test_plan_race_tsan \
+	  tests/test_plan_race.c notorch.c -lm $(BLAS_LIBS)
 	@echo "Running under ThreadSanitizer — expect no warnings"
 	setarch -R ./test_plan_race_tsan 2>&1 | tee /dev/stderr | grep -q 'WARNING: ThreadSanitizer' \
 	  && { echo "RACE REPORTED"; exit 1; } || echo "clean"

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,50 @@ Newest entries on top.
 
 ---
 
+## 2026-09-04 — the false sharing was real and it was not the point
+
+The pool coordinates through three counters. `offsetof` said where they sat: `shutdown` at
+232, `generation` 236, `busy` 240, `next` 244 — one 64-byte line, with the job description
+starting at 248 in the same line. Every one of the sixty-four row claims a matvec makes wrote
+that line while the other workers were reading it.
+
+Separating them changes nothing measurable in decode. Four runs each, cold: Gemma
+11.2 / 11.1 / 11.1 / 11.1 against 11.1 four times, Qwen 56.4 / 56.5 / 56.9 against
+56.2 / 57.2 / 56.3 / 56.3, and at `NT_QMV_CHUNKS=64`, where claims are four times as frequent,
+53.0 against 53.3. That is a null result and it is reported as one.
+
+But "no effect in decode" and "no effect" are different claims, and four workers cannot settle
+the second. `tests/bench_claim.c` measures the claim alone — a worker reads `generation` the
+way the spin loop does, then claims a row — and the sharing costs plenty: **51.9 Mclaims/s in
+one line against 121.3 separated at four threads, 2.34x**; 1.25x at one thread, 2.31x at three,
+1.95x at eight.
+
+Both facts fit together in arithmetic. A matvec makes 68 claims: 1.3 us shared, 0.6 separated.
+A token runs a few hundred matvecs and takes about ninety milliseconds. The saving is a
+fraction of a millisecond, which is exactly the nothing the decode measurement found.
+
+The layout is separated anyway, and the reason is the ratio rather than the milliseconds: it
+costs 192 bytes in one global, the operation genuinely runs twice as fast, and anything that
+claims more often — more cores, finer chunks, smaller matrices — moves the arithmetic. Both
+pools get the same treatment. What this entry does not claim is a speedup, because there
+isn't one here.
+
+Three review points on the merges, all fair. `NT_QMV_SPIN` was parsed with `atoi`, which maps
+junk to zero — and zero is a valid setting meaning park on every wait, the worst one there is.
+`NT_QMV_SPIN=off`, written by analogy with `NT_QMV_POOL` where "off" is accepted, would have
+silently chosen it. Every knob now goes through one parser that takes the whole string or
+prints why it did not. `tests/test_plan_race.c` used `pthread_barrier_t`, which POSIX makes
+optional and macOS does not have, and that test is in the default `make test` — replaced with a
+mutex and a condition variable. The `test_tsan` target compiled without `$(CFLAGS)` and
+`$(BLAS_FLAGS)`, so it sanitized a different configuration than the one that ships.
+
+One part of that review did not hold up: the concern that `A && { …; exit 1; } || C` lets a
+detected race exit zero. Checked against a genuinely racy build — 3215ed0, before the plan was
+made once — and the recipe prints RACE REPORTED and exits 1. `exit` inside the group ends the
+shell before `||` is reached.
+
+---
+
 ## 2026-09-03 — the workers were going to sleep between matvecs
 
 A worker looks for its next job for a while before parking on a condvar, and the budget for

--- a/notorch.c
+++ b/notorch.c
@@ -12,6 +12,7 @@
 #include "notorch.h"
 #include <stdio.h>
 #include <string.h>
+#include <errno.h>
 #include <float.h>
 #include <limits.h>
 #include <sys/time.h>
@@ -5427,9 +5428,29 @@ static pthread_once_t g_nt_qmv_plan_once = PTHREAD_ONCE_INIT;
  * costs nothing and the ordering is what makes it safe rather than merely fast. */
 static const nt_qmv_plan *g_nt_qmv_plan_ready = NULL;
 
+/* Whole string or nothing. atoi maps junk to zero, and for a spin budget zero is both valid
+ * and the worst setting there is — park on every wait — so NT_QMV_SPIN=off, written by
+ * analogy with NT_QMV_POOL where "off" is accepted, would quietly choose it. A typo should
+ * cost a line on stderr, not six percent of decode. */
+static int nt_env_long(const char *name, long lo, long hi, long *out) {
+    const char *e = getenv(name);
+    if (!e || !*e) return 0;
+    char *end = NULL;
+    errno = 0;
+    long v = strtol(e, &end, 10);
+    if (errno != 0 || end == e || *end != '\0' || v < lo || v > hi) {
+        fprintf(stderr, "notorch: %s=\"%s\" is not a whole number in [%ld, %ld]; "
+                        "keeping the default\n", name, e, lo, hi);
+        return 0;
+    }
+    *out = v;
+    return 1;
+}
+
 static void nt_qmv_plan_init(void) {
     nt_qmv_plan *p = &g_nt_qmv_plan;
     const char *e;
+    long v;
 
     e = getenv("NT_QMV_PIN");
     p->pin = !(e && e[0] == '0');
@@ -5445,9 +5466,8 @@ static void nt_qmv_plan_init(void) {
      * 52.9, 54.4, 55.1, 55.9, 55.3. Sixteen is best or tied on both, and at sixteen four cores
      * match the three that exclude the prime core, so the fix is granularity rather than
      * discarding a core. The float pool reached sixteen independently. */
-    e = getenv("NT_QMV_CHUNKS");
-    long v = e ? atol(e) : 0;
-    p->chunks = (v >= 1 && v <= 64) ? (int)v : 16;
+    p->chunks = 16;
+    if (nt_env_long("NT_QMV_CHUNKS", 1, 64, &v)) p->chunks = (int)v;
 
     e = getenv("NT_QMV_POOL");
     p->pool = !(e && (!strcmp(e, "0") || !strcmp(e, "false") ||
@@ -5469,15 +5489,14 @@ static void nt_qmv_plan_init(void) {
      * free for continuous decoding, a small drain for a process that runs one matvec and
      * waits. NT_QMV_SPIN=0 parks immediately, which is also the only way the condvar path
      * gets exercised. */
-    e = getenv("NT_QMV_SPIN");
-    p->spin = (e && atoi(e) >= 0) ? atoi(e) : 500000;
+    p->spin = 500000;
+    if (nt_env_long("NT_QMV_SPIN", 0, 1L << 30, &v)) p->spin = (int)v;
 
-    e = getenv("NT_QMV_THREAD_MIN");
-    p->thread_min = (e && atol(e) > 0) ? atol(e) : NT_QMV_THREAD_MIN_DEFAULT;
+    p->thread_min = NT_QMV_THREAD_MIN_DEFAULT;
+    if (nt_env_long("NT_QMV_THREAD_MIN", 1, 1L << 40, &v)) p->thread_min = v;
 
-    e = getenv("NT_QMV_THREADS");
-    long want = e ? atol(e) : 0;
-    p->threads = want > 0 ? (int)want : 0;
+    p->threads = 0;
+    if (nt_env_long("NT_QMV_THREADS", 1, NT_QMV_MAX_THREADS, &v)) p->threads = (int)v;
 
 #if defined(__linux__)
     p->ncpu = 0;
@@ -5490,6 +5509,7 @@ static void nt_qmv_plan_init(void) {
          * count, a mask narrower than the machine, or NT_QMV_BIG_ONLY=0. */
         const char *off = getenv("NT_QMV_BIG_ONLY");
         long online = sysconf(_SC_NPROCESSORS_ONLN);
+        (void)e;
         if (!(off && off[0] == '0') && !p->threads &&
             online > 0 && CPU_COUNT(&mine) == (int)online)
             n = nt_cpu_perf_set(&mine, &p->cpus);
@@ -5541,6 +5561,10 @@ static int nt_qmv_host_threads(int m) {
     return nt;
 }
 
+/* The coherence line, 64 bytes on every core this runs on, read from sysfs
+ * (cache/index0/coherency_line_size under the cpu directory) rather than assumed. */
+#define NT_CACHELINE 64
+
 typedef struct {
     nt_qrows_fn fn; float *out; const uint8_t *Wq; const float *x;
     int r0, r1, k;
@@ -5557,6 +5581,9 @@ static void *nt_qworker(void *p) {
 
 // Persistent qmatvec workers remove pthread_create/join from every decode matvec.
 // The caller computes the last shard inline; workers handle the earlier shards.
+/* Same separation as the integer pool below, for the same measured reason: the claim counter
+ * shares its line with the fields every worker reads, and an atomic add on a shared line runs
+ * 2.3 times slower than on one of its own. */
 typedef struct {
     pthread_mutex_t mu;
     pthread_cond_t cv_work;
@@ -5566,29 +5593,19 @@ typedef struct {
     int nthreads;
     int ready;
     int shutdown;
-    long generation;
     int active;
     int done;
     nt_qjob jobs[NT_QMV_MAX_THREADS];
     nt_qjob shared;              /* fn/out/Wq/x/k common to every chunk */
-    int lo, hi, chunk, next;     /* the range the workers drain */
+    int lo, hi, chunk;           /* the range the workers drain, fixed for the dispatch */
+    _Alignas(NT_CACHELINE) long generation;   /* bumped per dispatch, read by every worker */
+    _Alignas(NT_CACHELINE) int next;          /* one atomic add per row claim */
 } nt_qpool;
 
 static nt_qpool g_nt_qpool = {
-    PTHREAD_MUTEX_INITIALIZER,
-    PTHREAD_COND_INITIALIZER,
-    PTHREAD_COND_INITIALIZER,
-    {0},
-    {0},
-    0,
-    0,
-    0,
-    0,
-    0,
-    0,
-    {{0}},
-    {0},              /* shared           */
-    0, 0, 0, 0,       /* lo hi chunk next */
+    .mu = PTHREAD_MUTEX_INITIALIZER,
+    .cv_work = PTHREAD_COND_INITIALIZER,
+    .cv_done = PTHREAD_COND_INITIALIZER,
 };
 static pthread_once_t g_nt_qpool_once = PTHREAD_ONCE_INIT;
 static pthread_mutex_t g_nt_qpool_dispatch_mu = PTHREAD_MUTEX_INITIALIZER;
@@ -6684,27 +6701,29 @@ static void *nt_qworker_i8(void *p) {
 // counter before sleeping — between two matvecs of the same token the gap is microseconds,
 // so the spin almost always catches the next job, and the condvar remains underneath so an
 // idle phone is not held awake. NT_QMV_SPIN overrides the budget for measurement.
+/* Three counters written at three different rates by different threads. Left adjacent they
+ * sat in one line — measured with offsetof, shutdown at 232, generation 236, busy 240, next
+ * 244, all of line 3 — so each of the sixty-four row claims per matvec invalidated the line
+ * the other workers were spinning on and reading the job description from. Separated here,
+ * with the job itself kept beside the fields that are published before the generation bump
+ * and read-only afterwards. */
 typedef struct {
     pthread_mutex_t mu;
     pthread_cond_t cv_work;
     pthread_t threads[NT_QMV_MAX_THREADS];
     int nthreads;
     int ready;
-    int shutdown;          /* atomic */
-    int generation;        /* atomic: bumped once per dispatch */
-    int busy;              /* atomic: workers still draining */
-    int next;              /* atomic: next unclaimed row */
-    nt_qjob_i8 shared;
+    nt_qjob_i8 shared;     /* published before the bump; read-only for the dispatch */
     int hi, chunk;
+    _Alignas(NT_CACHELINE) int generation;  /* bumped once per dispatch, spun on by everyone */
+    int shutdown;                           /* written once ever, read beside generation */
+    _Alignas(NT_CACHELINE) int busy;        /* one decrement per worker per dispatch */
+    _Alignas(NT_CACHELINE) int next;        /* one atomic add per row claim, the hot one */
 } nt_qpool_i8;
 
 static nt_qpool_i8 g_nt_qpool_i8 = {
-    PTHREAD_MUTEX_INITIALIZER,
-    PTHREAD_COND_INITIALIZER,
-    {0},
-    0, 0, 0, 0, 0, 0,
-    {0},              /* shared    */
-    0, 0,             /* hi chunk  */
+    .mu = PTHREAD_MUTEX_INITIALIZER,
+    .cv_work = PTHREAD_COND_INITIALIZER,
 };
 
 #if defined(__aarch64__) || defined(__arm__)

--- a/tests/bench_claim.c
+++ b/tests/bench_claim.c
@@ -1,0 +1,98 @@
+/* claimbench.c — what the row claim costs when its counter shares a line, and when it does not.
+ *
+ * The pool coordinates through three counters: workers spin reading `generation`, claim rows
+ * with an atomic add on `next`, and report completion by decrementing `busy`. Adjacent, those
+ * three sit in one 64-byte line, so every claim invalidates the line the others are reading.
+ * Decode did not measurably care on four cores; this asks whether the effect exists at all and
+ * how it grows with thread count, which is the part four cores cannot answer.
+ *
+ * Build: make bench_claim
+ * Run:   taskset -c 4-7 ./bench_claim [threads] [claims-per-thread]
+ *
+ * Exynos 1580, four big cores, 2M claims per thread: one line 51.9 Mclaims/s against 121.3
+ * separated at four threads, 2.34x; 1.25x at one thread, 1.95x at eight. Decode does not
+ * move, because a matvec makes 68 claims — 1.3 us shared against 0.6 — and a token runs a
+ * few hundred matvecs against ninety milliseconds of arithmetic. Real, and small where we
+ * stand; the layout is separated anyway because the cost of doing so is 192 bytes in one
+ * global and the ratio grows with anything that claims more often.
+ */
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <pthread.h>
+#include <sched.h>
+#include <time.h>
+#include <stdint.h>
+
+#define LINE 64
+
+/* The two layouts, side by side, so nothing else differs between them. */
+typedef struct { int generation; int busy; int next; } shared_layout;
+typedef struct {
+    _Alignas(LINE) int generation;
+    _Alignas(LINE) int busy;
+    _Alignas(LINE) int next;
+} split_layout;
+
+static shared_layout g_shared;
+static split_layout  g_split;
+static int nthreads, claims, use_split;
+static int cpus[64];
+
+static double now(void) {
+    struct timespec t;
+    clock_gettime(CLOCK_MONOTONIC, &t);
+    return (double)t.tv_sec + (double)t.tv_nsec * 1e-9;
+}
+
+/* One worker: read the generation the way the spin loop does, then claim a row. The read is
+ * what makes the sharing bite — without it a lone atomic add on a private line is just an
+ * atomic add. */
+static void *worker(void *p) {
+    long id = (long)p;
+    cpu_set_t one;
+    CPU_ZERO(&one); CPU_SET(cpus[id % nthreads], &one);
+    pthread_setaffinity_np(pthread_self(), sizeof(one), &one);
+
+    int sink = 0;
+    for (int i = 0; i < claims; i++) {
+        if (use_split) {
+            sink += __atomic_load_n(&g_split.generation, __ATOMIC_ACQUIRE);
+            __atomic_fetch_add(&g_split.next, 1, __ATOMIC_RELAXED);
+        } else {
+            sink += __atomic_load_n(&g_shared.generation, __ATOMIC_ACQUIRE);
+            __atomic_fetch_add(&g_shared.next, 1, __ATOMIC_RELAXED);
+        }
+    }
+    return (void *)(long)sink;
+}
+
+static double run(int split) {
+    use_split = split;
+    g_shared.next = 0; g_split.next = 0;
+    pthread_t th[64];
+    double t0 = now();
+    for (long i = 0; i < nthreads; i++) pthread_create(&th[i], NULL, worker, (void *)i);
+    for (int i = 0; i < nthreads; i++) pthread_join(th[i], NULL);
+    return now() - t0;
+}
+
+int main(int argc, char **argv) {
+    nthreads = argc > 1 ? atoi(argv[1]) : 4;
+    claims   = argc > 2 ? atoi(argv[2]) : 2000000;
+
+    cpu_set_t mask;
+    CPU_ZERO(&mask);
+    sched_getaffinity(0, sizeof(mask), &mask);
+    int n = 0;
+    for (int c = 0; c < CPU_SETSIZE && n < 64; c++) if (CPU_ISSET(c, &mask)) cpus[n++] = c;
+    if (n == 0) return 1;
+    if (nthreads > n) for (int i = n; i < nthreads && i < 64; i++) cpus[i] = cpus[i % n];
+
+    run(0); run(1);                                    /* warm both paths */
+    double a = run(0), b = run(1);
+    double total = (double)nthreads * (double)claims;
+    printf("%d threads x %d claims: one line %.2f Mclaims/s, separated %.2f  (%.2fx)\n",
+           nthreads, claims, total / a / 1e6, total / b / 1e6, a / b);
+    return 0;
+}

--- a/tests/test_plan_race.c
+++ b/tests/test_plan_race.c
@@ -7,8 +7,10 @@
  * from one thread and the integer matvec from another runs both initialisers at the same
  * moment and both of them reach into those statics.
  *
- * Nothing here is a timing trick. The two calls are released together by a barrier so the
- * initialisers overlap, and the run is meant to be read by ThreadSanitizer:
+ * Nothing here is a timing trick. The two calls are released together so the initialisers
+ * overlap, through a mutex and a condition variable rather than pthread_barrier — the barrier
+ * API is optional in POSIX and absent on macOS, which this repo builds on. The run is meant to
+ * be read by ThreadSanitizer:
  *
  *     cc -fsanitize=thread -O1 -pthread -I. -o test_plan_race tests/test_plan_race.c notorch.c -lm
  *     setarch -R ./test_plan_race          # Android's ASLR is wider than TSan expects
@@ -28,12 +30,22 @@
 static uint8_t *W;            /* Q4_0 rows, shared by both callers */
 static float *x;
 static float *out_f, *out_i;
-static pthread_barrier_t start;
+/* The starting gate: both callers wait until the second one arrives, then go together. */
+static pthread_mutex_t gate_mu = PTHREAD_MUTEX_INITIALIZER;
+static pthread_cond_t gate_cv = PTHREAD_COND_INITIALIZER;
+static int gate_arrived = 0;
 static int seen_threads_f, seen_threads_i;
+
+static void gate_wait(void) {
+    pthread_mutex_lock(&gate_mu);
+    if (++gate_arrived == 2) pthread_cond_broadcast(&gate_cv);
+    else while (gate_arrived < 2) pthread_cond_wait(&gate_cv, &gate_mu);
+    pthread_mutex_unlock(&gate_mu);
+}
 
 static void *call_float(void *p) {
     (void)p;
-    pthread_barrier_wait(&start);
+    gate_wait();
     nt_qmatvec(out_f, W, 2, x, M_ROWS, K_COLS);
     seen_threads_f = nt_qmv_planned_threads();
     return NULL;
@@ -41,7 +53,7 @@ static void *call_float(void *p) {
 
 static void *call_int(void *p) {
     (void)p;
-    pthread_barrier_wait(&start);
+    gate_wait();
     nt_qmatvec_i8(out_i, W, 2, x, M_ROWS, K_COLS);
     seen_threads_i = nt_qmv_planned_threads();
     return NULL;
@@ -59,13 +71,11 @@ int main(void) {
     for (size_t i = 0; i < rowsz * (size_t)M_ROWS; i++) W[i] = (uint8_t)(i * 37u + 11u);
     for (int i = 0; i < K_COLS; i++) x[i] = (float)((i % 23) - 11) * 0.0625f;
 
-    pthread_barrier_init(&start, NULL, 2);
     pthread_t a, b;
     pthread_create(&a, NULL, call_float, NULL);
     pthread_create(&b, NULL, call_int, NULL);
     pthread_join(a, NULL);
     pthread_join(b, NULL);
-    pthread_barrier_destroy(&start);
 
     int fails = 0;
     if (seen_threads_f != seen_threads_i) {


### PR DESCRIPTION
The pool coordinates through three counters and offsetof said where they sat: shutdown at 232, generation 236, busy 240, next 244, one 64-byte line, with the job description starting at 248 in the same line. Each of the sixty-four row claims a matvec makes wrote that line while the other workers read it.

Separating them changes nothing measurable in decode. Four cold runs each: Gemma 11.2 / 11.1 / 11.1 / 11.1 against 11.1 four times; Qwen 56.4 / 56.5 / 56.9 against 56.2 / 57.2 / 56.3 / 56.3; and at NT_QMV_CHUNKS=64, where claims come four times as often, 53.0 against 53.3. A null result, reported as one.

"No effect in decode" and "no effect" are different claims and four workers cannot settle the second, so tests/bench_claim.c measures the claim alone — read generation the way the spin loop does, then claim a row. The sharing costs plenty there: 51.9 Mclaims/s in one line against 121.3 separated at four threads, 2.34x, with 1.25x at one thread and 1.95x at eight.

The two fit in arithmetic. A matvec makes 68 claims: 1.3 us shared against 0.6 separated. A token runs a few hundred matvecs and takes about ninety milliseconds, so the saving is a fraction of one. That is precisely the nothing the decode measurement found.

The layout is separated anyway, for the ratio rather than the milliseconds: 192 bytes in one global, an operation that genuinely runs twice as fast, and a cost that grows with anything claiming more often — more cores, finer chunks, smaller matrices. Both pools get it. This commit claims no speedup, because there is none here.

Three review points, all fair. NT_QMV_SPIN was parsed with atoi, which maps junk to zero, and zero is a valid setting meaning park on every wait — the worst one available. NT_QMV_SPIN=off, written by analogy with NT_QMV_POOL where off is accepted, would have chosen it in silence. Every knob now goes through one parser that takes the whole string or says why it did not. tests/test_plan_race.c used pthread_barrier_t, optional in POSIX and absent on macOS, and that test runs in the default make test — now a mutex and a condition variable. The test_tsan target compiled without CFLAGS and BLAS_FLAGS, sanitizing a configuration that does not ship.

One point did not hold: the concern that A && { ...; exit 1; } || C lets a detected race exit zero. Checked against a genuinely racy build, 3215ed0, before the plan was made once — the recipe prints RACE REPORTED and exits 1, because exit inside the group ends the shell before || is reached.

Gates: 49, 73, 34, 3, four determinism runs, the allocation gate, four affinity modes, the race test and the sanitizer target all pass; parity identical on three prompts, tokenizer on 16.

Quote: "Not everything that can be counted counts, and not everything that counts can be counted." — William Bruce Cameron
Method: the Method measured the thing in isolation before deciding what its silence meant.

By Arianna Method (Co-authored by Claude, Defender) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff