### PR TITLE
the method deleted a comment that described work it never did

### DIFF
--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,34 @@ Newest entries on top.
 
 ---
 
+## 2026-09-04 — six review points, and one of them was a comment that lied
+
+The worst of the six is the smallest. `NT_CACHELINE` carried a note saying the line size was
+"read from sysfs … rather than assumed", beside a `#define` of 64. Sysfs is where **I** read it,
+by hand, while writing the change; the code reads nothing, and alignment is a compile-time
+decision so it could not. A comment that describes behaviour the code does not have is the same
+failure as a commit message that does, and this log has spent a week saying so. It now states
+what it is: a constant, chosen because every core this has run on reports 64, wasteful rather
+than wrong if some machine reports more.
+
+The rest, all real:
+
+- `tests/bench_claim.c` took its thread count straight from `atoi` while sizing its arrays at
+  64, so `./bench_claim 128` wrote past `pthread_t th[]`, and a zero divided by zero in
+  `id % nthreads`. Both arguments now go through a parser that takes the whole string in range
+  or says why it did not, and `sched_getaffinity`'s return is checked rather than assumed.
+- The same file uses Linux affinity APIs and would not compile on macOS, which this repo
+  builds on. Guarded, with a `SKIP` main elsewhere — verified by compiling the other branch
+  with the condition forced false under `-Wall -Wextra`, not by reading it.
+- `1L << 40` as the upper bound for `NT_QMV_THREAD_MIN` is undefined where `long` is 32 bits.
+  `LONG_MAX` and `INT_MAX` say the same thing without the shift.
+- `(void)e;` left over from the plan refactor, where `e` is used three lines above.
+- Integer-to-pointer casts through `long` in the benchmark's thread argument, now `intptr_t`.
+
+Nothing here moves a number; the gates are unchanged and decode is where it was.
+
+---
+
 ## 2026-09-04 — the false sharing was real and it was not the point
 
 The pool coordinates through three counters. `offsetof` said where they sat: `shutdown` at

--- a/notorch.c
+++ b/notorch.c
@@ -5490,10 +5490,10 @@ static void nt_qmv_plan_init(void) {
      * waits. NT_QMV_SPIN=0 parks immediately, which is also the only way the condvar path
      * gets exercised. */
     p->spin = 500000;
-    if (nt_env_long("NT_QMV_SPIN", 0, 1L << 30, &v)) p->spin = (int)v;
+    if (nt_env_long("NT_QMV_SPIN", 0, INT_MAX, &v)) p->spin = (int)v;
 
     p->thread_min = NT_QMV_THREAD_MIN_DEFAULT;
-    if (nt_env_long("NT_QMV_THREAD_MIN", 1, 1L << 40, &v)) p->thread_min = v;
+    if (nt_env_long("NT_QMV_THREAD_MIN", 1, LONG_MAX, &v)) p->thread_min = v;
 
     p->threads = 0;
     if (nt_env_long("NT_QMV_THREADS", 1, NT_QMV_MAX_THREADS, &v)) p->threads = (int)v;
@@ -5509,7 +5509,6 @@ static void nt_qmv_plan_init(void) {
          * count, a mask narrower than the machine, or NT_QMV_BIG_ONLY=0. */
         const char *off = getenv("NT_QMV_BIG_ONLY");
         long online = sysconf(_SC_NPROCESSORS_ONLN);
-        (void)e;
         if (!(off && off[0] == '0') && !p->threads &&
             online > 0 && CPU_COUNT(&mine) == (int)online)
             n = nt_cpu_perf_set(&mine, &p->cpus);
@@ -5561,8 +5560,11 @@ static int nt_qmv_host_threads(int m) {
     return nt;
 }
 
-/* The coherence line, 64 bytes on every core this runs on, read from sysfs
- * (cache/index0/coherency_line_size under the cpu directory) rather than assumed. */
+/* Alignment is a compile-time decision, so this is a constant and not a reading. Sixty-four
+ * is what every core this library has run on reports in sysfs under
+ * cache/index0/coherency_line_size — checked by hand on the Exynos 1580, not detected here.
+ * Too small and the separation does not separate; too large only wastes bytes in one global,
+ * so err upward on a machine that says otherwise. */
 #define NT_CACHELINE 64
 
 typedef struct {

--- a/tests/bench_claim.c
+++ b/tests/bench_claim.c
@@ -16,17 +16,23 @@
  * stand; the layout is separated anyway because the cost of doing so is 192 bytes in one
  * global and the ratio grows with anything that claims more often.
  */
+#if defined(__linux__) && !defined(_GNU_SOURCE)
 #define _GNU_SOURCE
+#endif
 #include <stdio.h>
 #include <stdlib.h>
 #include <pthread.h>
-#include <sched.h>
 #include <time.h>
 #include <stdint.h>
+
+#if defined(__linux__)
+#include <sched.h>
 
 #define LINE 64
 
 /* The two layouts, side by side, so nothing else differs between them. */
+#define MAX_THREADS 64
+
 typedef struct { int generation; int busy; int next; } shared_layout;
 typedef struct {
     _Alignas(LINE) int generation;
@@ -36,8 +42,8 @@ typedef struct {
 
 static shared_layout g_shared;
 static split_layout  g_split;
-static int nthreads, claims, use_split;
-static int cpus[64];
+static int nthreads, claims, use_split, ncpu;
+static int cpus[MAX_THREADS];
 
 static double now(void) {
     struct timespec t;
@@ -49,10 +55,12 @@ static double now(void) {
  * what makes the sharing bite — without it a lone atomic add on a private line is just an
  * atomic add. */
 static void *worker(void *p) {
-    long id = (long)p;
-    cpu_set_t one;
-    CPU_ZERO(&one); CPU_SET(cpus[id % nthreads], &one);
-    pthread_setaffinity_np(pthread_self(), sizeof(one), &one);
+    intptr_t id = (intptr_t)p;
+    if (ncpu > 0) {
+        cpu_set_t one;
+        CPU_ZERO(&one); CPU_SET(cpus[id % ncpu], &one);
+        pthread_setaffinity_np(pthread_self(), sizeof(one), &one);
+    }
 
     int sink = 0;
     for (int i = 0; i < claims; i++) {
@@ -64,30 +72,46 @@ static void *worker(void *p) {
             __atomic_fetch_add(&g_shared.next, 1, __ATOMIC_RELAXED);
         }
     }
-    return (void *)(long)sink;
+    return (void *)(intptr_t)sink;
 }
 
 static double run(int split) {
     use_split = split;
     g_shared.next = 0; g_split.next = 0;
-    pthread_t th[64];
+    pthread_t th[MAX_THREADS];
     double t0 = now();
-    for (long i = 0; i < nthreads; i++) pthread_create(&th[i], NULL, worker, (void *)i);
+    for (intptr_t i = 0; i < nthreads; i++) pthread_create(&th[i], NULL, worker, (void *)i);
     for (int i = 0; i < nthreads; i++) pthread_join(th[i], NULL);
     return now() - t0;
 }
 
+/* Whole string, in range, or the default — an out-of-range thread count here would write past
+ * th[] rather than merely measure something odd. */
+static int arg_int(const char *s, int lo, int hi, int fallback) {
+    if (!s || !*s) return fallback;
+    char *end = NULL;
+    long v = strtol(s, &end, 10);
+    if (end == s || *end != '\0' || v < lo || v > hi) {
+        fprintf(stderr, "bench_claim: \"%s\" is not a whole number in [%d, %d]; using %d\n",
+                s, lo, hi, fallback);
+        return fallback;
+    }
+    return (int)v;
+}
+
 int main(int argc, char **argv) {
-    nthreads = argc > 1 ? atoi(argv[1]) : 4;
-    claims   = argc > 2 ? atoi(argv[2]) : 2000000;
+    nthreads = arg_int(argc > 1 ? argv[1] : NULL, 1, MAX_THREADS, 4);
+    claims   = arg_int(argc > 2 ? argv[2] : NULL, 1, 1 << 28, 2000000);
 
     cpu_set_t mask;
     CPU_ZERO(&mask);
-    sched_getaffinity(0, sizeof(mask), &mask);
-    int n = 0;
-    for (int c = 0; c < CPU_SETSIZE && n < 64; c++) if (CPU_ISSET(c, &mask)) cpus[n++] = c;
-    if (n == 0) return 1;
-    if (nthreads > n) for (int i = n; i < nthreads && i < 64; i++) cpus[i] = cpus[i % n];
+    if (sched_getaffinity(0, sizeof(mask), &mask) != 0) {
+        fprintf(stderr, "bench_claim: no affinity mask; threads land where they land\n");
+        ncpu = 0;
+    } else {
+        for (int c = 0; c < CPU_SETSIZE && ncpu < MAX_THREADS; c++)
+            if (CPU_ISSET(c, &mask)) cpus[ncpu++] = c;
+    }
 
     run(0); run(1);                                    /* warm both paths */
     double a = run(0), b = run(1);
@@ -96,3 +120,9 @@ int main(int argc, char **argv) {
            nthreads, claims, total / a / 1e6, total / b / 1e6, a / b);
     return 0;
 }
+#else
+int main(void) {
+    printf("row claim cost\n  SKIP needs Linux affinity to place threads on known cores\n");
+    return 0;
+}
+#endif


### PR DESCRIPTION
Six review points on the cacheline merge, and the worst of them is the smallest. NT_CACHELINE carried a note saying the line size was read from sysfs rather than assumed, directly above a define of 64. Sysfs is where I read it, by hand, while writing the change. The code reads nothing and could not: alignment is decided at compile time. A comment asserting behaviour the code does not have is the same failure as a commit message doing it, which this log has spent a week naming in other people's work and mine. It now says what it is — a constant, chosen because every core this has run on reports 64, and wasteful rather than wrong if some machine reports more.

The rest, each real:

tests/bench_claim.c took its thread count from atoi while sizing arrays at 64, so ./bench_claim 128 wrote past pthread_t th[], and zero threads divided by zero in id % nthreads. Both arguments now pass through a parser that takes the whole string in range or explains itself, and sched_getaffinity's return is checked instead of assumed.

The same file uses Linux affinity APIs and would not compile on macOS, which this repo builds on. Guarded now, with a SKIP main elsewhere — confirmed by compiling that branch with the condition forced false under -Wall -Wextra rather than by reading it.

1L << 40 as the upper bound for NT_QMV_THREAD_MIN is undefined where long is 32 bits; LONG_MAX and INT_MAX say the same thing without the shift. (void)e; was left over from the plan refactor, three lines below a use of e. The benchmark passed its thread argument through long casts to and from void*, now intptr_t.

Nothing here moves a number. Gates unchanged: 49, 73, 34, 3, four determinism runs, the allocation gate, four affinity modes, the race test and the sanitizer target all pass; parity identical on three prompts, tokenizer on 16.

Quote: "The map appears to us more real than the land." — D.H. Lawrence
Method: the Method deletes the sentence rather than living up to it later.

By Arianna Method (Co-authored by Claude, Defender) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff