### PR TITLE
the Method met a family that reads its weights in pieces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ llama: examples/infer_llama.c examples/bpe.c examples/bpe.h gguf.c gguf.h notorc
 # One binary, one command: ./notorch model.gguf "prompt". Architectures are a
 # table in harness/main.c; adding a family adds a file, not a branch.
 
-HARNESS_SRC = harness/main.c harness/runtime.c harness/arch_llama.c harness/arch_gemma4.c examples/bpe.c gguf.c notorch.c
+HARNESS_SRC = harness/main.c harness/runtime.c harness/arch_llama.c harness/arch_gemma4.c harness/arch_olmoe.c examples/bpe.c gguf.c notorch.c
 HARNESS_HDR = harness/arch.h harness/runtime.h harness/logo.h examples/bpe.h gguf.h notorch.h
 
 # `harness` is phony because a directory of that name sits right there, and

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,53 @@ Newest entries on top.
 
 ---
 
+## 2026-09-04 — the first mixture, and the tokens that were never in the alphabet
+
+`harness/arch_olmoe.c` runs OLMoE-1B-7B: sixteen layers, sixty-four experts each, eight used
+per token. It is the first architecture here whose weights are not read in one sweep. A dense
+model streams every byte of every layer; this one reads an eighth of its feed-forward, but
+reads it gathered — eight slices chosen per token out of a 75 MB region per tensor per layer.
+Everything this library has been tuned on assumed the sweep.
+
+Adding it needed no change to the family interface, which is what `arch.h` claims of itself.
+It needed one helper: `wt_expert`, which is arithmetic rather than a new idea. A stacked
+expert tensor is 3-D, `[n_embd, n_ff, n_expert]`, and `wt_load` already reads that as one
+matrix of `n_ff * n_expert` rows — so expert *e* is that matrix with a shorter row count and a
+shifted base, and nothing is copied. `gguf_type_size` became public to make the shift
+computable, and `tools/gguf_quantize.c` lost its private copy of it.
+
+The routing is the reference's and not the usual shape of these things: softmax over all
+sixty-four, top eight by that probability, and the weights are those probabilities as they
+stand — no renormalisation over the chosen eight (`norm_w = false` at the call site) and no
+scale (the file carries no `expert_weights_scale`). Both are common elsewhere and wrong here.
+Q and K are RMS-normalised over the whole projection before the heads are split out, with a
+weight vector of `n_embd` — gemma4 normalises per head, and the two are one reshape apart.
+
+**The tokenizer was the real find, and it was ours.** OLMoE's vocabulary carries twenty-five
+tokens the file marks USER_DEFINED, and they are runs of *real spaces* — token 50274 is four
+bytes of 0x20, not four 'Ġ'. No sequence of merges over the byte-level alphabet can ever spell
+one, so the reference matches them against the raw text before BPE runs and encodes only what
+lies between. We had no such pass, on either side: indentation was lost when encoding and lost
+again when printing, because a literal space is not in the byte-level table and got dropped.
+`gguf_read_i32_array` reads `tokenizer.ggml.token_type` to find them; CONTROL tokens are left
+out on purpose, since the reference only splits those when asked to parse specials.
+
+Why it went unseen is the part worth keeping. `harness/test_tokenizer.sh` **already** had a
+repeated-spaces text and an indented-code text, and they had passed for as long as they
+existed — on Qwen and Gemma, whose vocabularies have no such tokens, where both
+implementations happen to split the same way. The gate was not weak in its texts; it was weak
+in its corpus. OLMoE is in its default list now, 24 checks instead of 16, and removing the
+added-token pass fails exactly those two texts and only on that model.
+
+Against the reference, cold: parity is identical on all three prompts, tokenizer identical on
+24. Decode **16.1 / 16.8 t/s against llama.cpp's 21.41 ± 1.15 — 77 percent**, where the dense
+models sit at 97. The gap is not a mystery and is not a defect: the reference gathers the
+eight chosen experts into one `mul_mat_id`, while this does eight separate matvecs, twenty-four
+per layer against three, 384 dispatches per token. That is the next piece of work and it now
+has a number.
+
+---
+
 ## 2026-09-04 — six review points, and one of them was a comment that lied
 
 The worst of the six is the smallest. `NT_CACHELINE` carried a note saying the line size was

--- a/examples/bpe.c
+++ b/examples/bpe.c
@@ -93,6 +93,13 @@ struct bpe_tokenizer {
      * UTF-8 like BPE, and no word-level pre-split at all, only a break at newlines. The
      * only signal is the name in tokenizer.ggml.model, which is what llama.cpp reads too. */
     int spm_bpe;
+    /* Tokens the file marks USER_DEFINED. They are stored as literal text rather than in the
+     * byte-level encoding — a run of four real spaces, not four 'Ġ' — so the merge path can
+     * never produce them, and the reference matches them against the raw text before it runs.
+     * Skipping this step is quiet on prose and wrong on indented code: OLMoE's vocabulary
+     * carries twenty-five of these and they are all whitespace runs. */
+    int *added_id;      /* ids, longest string first */
+    int n_added;
     int add_bos, bos_id;
 };
 
@@ -137,6 +144,35 @@ bpe_tokenizer *bpe_load(const char *path) {
      * where the same two operations do not exist. Getting this wrong is quiet
      * — byte-level encode over a SentencePiece vocabulary finds no token for a
      * space and used to drop it, which reads as text with the spaces missing. */
+    /* USER_DEFINED is type 4 in tokenizer.ggml.token_type. CONTROL (3) is deliberately left
+     * out: the reference only splits on those when asked to parse specials, and a prompt that
+     * happens to spell one should not become that token by accident. */
+    int ntt = 0;
+    int32_t *ttypes = gguf_read_i32_array(path, "tokenizer.ggml.token_type", &ntt);
+    if (ttypes && ntt == nt) {
+        for (int i = 0; i < nt; i++)
+            if (ttypes[i] == 4 && toks[i] && toks[i][0]) t->n_added++;
+        if (t->n_added) {
+            t->added_id = (int*)calloc((size_t)t->n_added, sizeof(int));
+            int k = 0;
+            for (int i = 0; i < nt; i++)
+                if (ttypes[i] == 4 && toks[i] && toks[i][0]) t->added_id[k++] = i;
+            /* Longest first, so the scan takes the longest match at each position the way a
+             * longest-match scan must; insertion sort over a couple of dozen entries. */
+            for (int a = 1; a < t->n_added; a++) {
+                int v = t->added_id[a];
+                size_t vl = strlen(toks[v]);
+                int b = a - 1;
+                while (b >= 0 && strlen(toks[t->added_id[b]]) < vl) {
+                    t->added_id[b + 1] = t->added_id[b];
+                    b--;
+                }
+                t->added_id[b + 1] = v;
+            }
+        }
+    }
+    free(ttypes);
+
     int ns = 0;
     float *scores = gguf_read_f32_array(path, "tokenizer.ggml.scores", &ns);
     if (nm <= 0 && scores && ns == nt) {
@@ -180,6 +216,7 @@ void bpe_free(bpe_tokenizer *t) {
     free(t->tokens);
     smap_free(&t->vocab); smap_free(&t->merges);
     free(t->scores);
+    free(t->added_id);
     free(t);
 }
 
@@ -373,10 +410,44 @@ static int spm_bpe_encode(const bpe_tokenizer *t, const char *text, int *out, in
     return no;
 }
 
+/* Byte-level BPE over one stretch of text with no added token in it. */
+static int bpe_encode_span(const bpe_tokenizer *t, const char *text, int len, int *out, int cap);
+
 int bpe_encode(const bpe_tokenizer *t, const char *text, int *out, int cap) {
     if (t && t->spm_bpe) return spm_bpe_encode(t, text, out, cap);
     if (t && t->spm) return spm_encode(t, text, out, cap);
-    int no = 0, L = (int)strlen(text), i = 0;
+    if (!t || t->n_added <= 0) return bpe_encode_span(t, text, (int)strlen(text), out, cap);
+
+    /* Added tokens are matched against the raw text first, longest at each position, and the
+     * merge path only ever sees what lies between them. Doing it the other way round cannot
+     * work: these tokens are stored as literal bytes, so no sequence of merges over the
+     * byte-level alphabet will ever spell one. */
+    int no = 0, L = (int)strlen(text), i = 0, gap = 0;
+    while (i < L) {
+        int hit = -1, hlen = 0;
+        for (int a = 0; a < t->n_added; a++) {
+            const char *s = t->tokens[t->added_id[a]];
+            int sl = (int)strlen(s);
+            if (sl && sl <= L - i && memcmp(text + i, s, (size_t)sl) == 0) {
+                hit = t->added_id[a]; hlen = sl; break;   /* the list is longest-first */
+            }
+        }
+        if (hit < 0) { i++; continue; }
+        if (i > gap) no += bpe_encode_span(t, text + gap, i - gap, out + no, cap - no);
+        if (no < cap) out[no++] = hit;
+        i += hlen;
+        gap = i;
+    }
+    if (L > gap) no += bpe_encode_span(t, text + gap, L - gap, out + no, cap - no);
+    return no;
+}
+
+static int bpe_encode_span(const bpe_tokenizer *t, const char *span, int L, int *out, int cap) {
+    char *text = (char*)malloc((size_t)L + 1);
+    if (!text) return 0;
+    memcpy(text, span, (size_t)L);
+    text[L] = 0;
+    int no = 0, i = 0;
     while (i < L) {
         /* pre-tok piece: [i, j). One space belongs to the run that follows it, but a RUN of
          * spaces does not — GPT-2 splits `\s+(?!\S)` off first, so four spaces before a word
@@ -427,6 +498,7 @@ int bpe_encode(const bpe_tokenizer *t, const char *text, int *out, int cap) {
         free(sym);
         i = j;
     }
+    free(text);            /* the span copy this function made, not the caller's */
     return no;
 }
 
@@ -452,6 +524,20 @@ int bpe_decode_token(const bpe_tokenizer *t, int id, char *buf, int cap) {
         buf[n] = 0;
         return n;
     }
+    /* An added token is literal text and was never in the byte-level alphabet, so running it
+     * through that table drops every byte it does not recognise — a run of real spaces comes
+     * out empty, which is how indentation disappeared from generated code while the ids were
+     * right all along. Copy it as it stands. */
+    for (int a = 0; a < t->n_added; a++) {
+        if (t->added_id[a] != id) continue;
+        int len = (int)strlen(s);
+        if (len > cap - 1) len = cap - 1;
+        if (len < 0) len = 0;
+        memcpy(buf, s, (size_t)len);
+        buf[len] = 0;
+        return len;
+    }
+
     int L = (int)strlen(s), i = 0, n = 0;
     while (i < L && n < cap - 1) {
         int cp; int adv = utf8_dec(s + i, &cp); i += adv;

--- a/gguf.c
+++ b/gguf.c
@@ -258,6 +258,20 @@ gguf_file* gguf_open(const char* path) {
     return gf;
 }
 
+uint64_t gguf_type_size(uint32_t dtype, uint64_t n) {
+    switch (dtype) {
+    case GGUF_TYPE_F32:  return n * 4;
+    case GGUF_TYPE_F16:  return n * 2;
+    case GGUF_TYPE_BF16: return n * 2;
+    case GGUF_TYPE_Q4_0: return n / 32 * 18;
+    case GGUF_TYPE_Q5_0: return n / 32 * 22;
+    case GGUF_TYPE_Q8_0: return n / 32 * 34;
+    case GGUF_TYPE_Q4_K: return n / 256 * 144;
+    case GGUF_TYPE_Q6_K: return n / 256 * 210;
+    default:             return 0;
+    }
+}
+
 void gguf_close(gguf_file* gf) {
     if (!gf) return;
 #if NOTORCH_GGUF_MMAP
@@ -377,6 +391,42 @@ char** gguf_read_str_array(const char* path, const char* key, int* out_n) {
                 if (!result[j]) break;
             }
             if (out_n) *out_n = (int)j;   // actually-read count, not claimed alen
+            break;
+        }
+        if (!skip_value(f, vtype)) break;
+    }
+    fclose(f);
+    return result;
+}
+
+/* Same walk for an INT32 array. tokenizer.ggml.token_type is one, and without it there is
+ * no way to tell an added token — a literal run of spaces, say — from an ordinary merge. */
+int32_t* gguf_read_i32_array(const char* path, const char* key, int* out_n) {
+    if (out_n) *out_n = 0;
+    FILE* f = fopen(path, "rb");
+    if (!f) return NULL;
+    uint32_t magic;
+    if (!read_u32(f, &magic) || magic != GGUF_MAGIC) { fclose(f); return NULL; }
+    uint32_t version; uint64_t n_tensors, n_kv;
+    read_u32(f, &version); read_u64(f, &n_tensors); read_u64(f, &n_kv);
+    int32_t* result = NULL;
+    for (uint64_t i = 0; i < n_kv; i++) {
+        char k[512] = {0};
+        uint32_t vtype;
+        if (!read_string(f, k, sizeof(k)) || !read_u32(f, &vtype)) break;
+        if (strcmp(k, key) == 0 && vtype == 9) {
+            uint32_t atype; uint64_t alen;
+            if (!read_u32(f, &atype) || !read_u64(f, &alen)) break;
+            if (atype != 5 && atype != 4) break;          /* INT32 or UINT32 */
+            if (alen > GGUF_MAX_STR_ARRAY) {
+                fprintf(stderr, "gguf: i32-array '%s' len %llu exceeds GGUF_MAX_STR_ARRAY=%u; refusing\n",
+                        key, (unsigned long long)alen, (unsigned)GGUF_MAX_STR_ARRAY);
+                break;
+            }
+            result = (int32_t*)calloc(alen ? alen : 1, sizeof(int32_t));
+            if (!result) break;
+            uint64_t got = fread(result, sizeof(int32_t), alen, f);
+            if (out_n) *out_n = (int)got;
             break;
         }
         if (!skip_value(f, vtype)) break;

--- a/gguf.h
+++ b/gguf.h
@@ -93,6 +93,11 @@ int gguf_find_tensor(const gguf_file* gf, const char* name);
 
 // Dequantize tensor to float32 array. Caller must free returned pointer.
 // Handles: F32 (copy), F16 (convert), Q8_0 (dequant), Q4_0 (dequant).
+/* Packed bytes for n elements of a dtype, or 0 for a dtype this reader cannot size.
+ * A 3-D expert tensor is stored as one matrix, so slicing an expert out of it needs to
+ * know how far a row is — the only reason this is public. */
+uint64_t gguf_type_size(uint32_t dtype, uint64_t n_elements);
+
 float* gguf_dequant(const gguf_file* gf, int tensor_idx);
 
 // One row of a packed tensor, decoded in place of the whole thing. dst needs shape[0]
@@ -115,6 +120,9 @@ int gguf_read_str_kv(const char* path, const char* key, char* out, int cap);
 
 // One integer metadata value by key (u32, i32, bool or u64). Returns 0 on success.
 int gguf_read_uint_kv(const char* path, const char* key, uint64_t* out);
+
+// Same for a type-9 INT32/UINT32 array (e.g. "tokenizer.ggml.token_type").
+int32_t* gguf_read_i32_array(const char* path, const char* key, int* out_n);
 
 // Same for a type-9 FLOAT32 array (e.g. "tokenizer.ggml.scores"). Returns a
 // malloc'd float* of *out_n values, or NULL if the key is absent or not f32.

--- a/harness/arch.h
+++ b/harness/arch.h
@@ -33,5 +33,6 @@ typedef struct {
 
 extern const nt_arch nt_arch_llama;
 extern const nt_arch nt_arch_gemma4;
+extern const nt_arch nt_arch_olmoe;
 
 #endif

--- a/harness/arch_olmoe.c
+++ b/harness/arch_olmoe.c
@@ -1,0 +1,359 @@
+/* arch_olmoe.c — OLMoE, and the first mixture this tree has run.
+ *
+ * Everything before the feed-forward is llama with two additions: Q and K are RMS-normalised
+ * after their projections and before the heads are split out, with a weight vector as long as
+ * the whole projection rather than one per head. Read that from the file rather than from a
+ * family resemblance — gemma4 normalises per head, this one does not, and the two are one
+ * reshape apart.
+ *
+ * The feed-forward is the new part and it changes how weights are read. A dense model streams
+ * every byte of every layer for every token; this one has sixty-four experts per layer and
+ * uses eight, so it reads an eighth of the feed-forward — but reads it *gathered*, eight
+ * slices chosen per token out of a 75 MB region, instead of one sweep. Everything this
+ * library has been tuned on assumed the sweep.
+ *
+ * Routing, from the reference and not from the usual shape of these things: softmax over all
+ * sixty-four, top eight by that probability, and the weights are those probabilities taken as
+ * they are. No renormalisation over the chosen eight (llama.cpp passes norm_w = false here)
+ * and no scale (the file carries no expert_weights_scale). Both are common in other mixtures
+ * and wrong for this one.
+ *
+ * Prints go to stderr: stdout belongs to the model. */
+#include "harness/arch.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+#define OLMOE_MAX_USED 32
+
+typedef struct {
+    int n_layers, n_heads, n_kv_heads, embed, ffn, vocab, head_dim, kv_dim, q_dim;
+    int n_expert, n_expert_used;
+    float rope_base, rms_eps;
+
+    gguf_file *gf;
+    int emb_ti;
+
+    wt tok_emb;
+    float *out_norm;
+    wt out_weight;
+
+    struct {
+        float *attn_norm;
+        wt wq, wk, wv, wo;
+        float *q_norm, *k_norm;       /* over the whole projection, not per head */
+        float *ffn_norm;
+        wt gate_inp;                  /* [n_expert, embed] — the router */
+        wt gate_exps, up_exps, down_exps;   /* stacked: n_expert slices each */
+    } layers[];
+} olmoe_model;
+
+static float *load_f32(gguf_file *gf, const char *name) {
+    int ti = gguf_find_tensor(gf, name);
+    return ti < 0 ? NULL : gguf_dequant(gf, ti);
+}
+
+static void *olmoe_load(gguf_file *gf, nt_dims *dims) {
+    int nl = gf->n_layers;
+    olmoe_model *m = (olmoe_model*)calloc(1, sizeof(olmoe_model) + nl * sizeof(m->layers[0]));
+    if (!m) return NULL;
+
+    m->n_layers = nl;
+    m->n_heads = gf->n_heads;
+    m->n_kv_heads = gf->n_kv_heads;
+    m->embed = gf->embed_dim;
+    m->ffn = gf->ffn_dim;
+    m->rope_base = gf->rope_freq_base;
+    m->rms_eps = gf->rms_eps;
+    m->gf = gf;
+
+    /* Expert counts have no home in gguf_file's convenience fields, and a mixture without
+     * them is not a mixture. Exact keys, because this family's names are not suffixes of
+     * anything else. */
+    const gguf_kv *kv = gguf_get_kv(gf, "olmoe.expert_count");
+    m->n_expert = kv ? (int)kv->val.u32 : 0;
+    kv = gguf_get_kv(gf, "olmoe.expert_used_count");
+    m->n_expert_used = kv ? (int)kv->val.u32 : 0;
+    if (m->n_expert <= 0 || m->n_expert_used <= 0 || m->n_expert_used > OLMOE_MAX_USED ||
+        m->n_expert_used > m->n_expert) {
+        fprintf(stderr, "olmoe: expert counts missing or unusable (%d of %d)\n",
+                m->n_expert_used, m->n_expert);
+        free(m);
+        return NULL;
+    }
+
+    int ti = gguf_find_tensor(gf, "blk.0.attn_q.weight");
+    if (ti >= 0) {
+        m->q_dim = (int)gf->tensors[ti].shape[1];
+        m->head_dim = m->q_dim / m->n_heads;
+    } else {
+        m->q_dim = m->embed;
+        m->head_dim = m->embed / m->n_heads;
+    }
+    m->kv_dim = m->n_kv_heads * m->head_dim;
+
+    m->emb_ti = gguf_find_tensor(gf, "token_embd.weight");
+    if (!wt_load(&m->tok_emb, gf, "token_embd.weight") || m->emb_ti < 0) {
+        fprintf(stderr, "olmoe: no token_embd\n");
+        free(m);
+        return NULL;
+    }
+    m->vocab = m->tok_emb.rows;
+    m->out_norm = load_f32(gf, "output_norm.weight");
+    /* Not tied: this family ships a separate head, and in this checkpoint at a different
+     * quantisation from the embedding table. */
+    if (!wt_load(&m->out_weight, gf, "output.weight")) {
+        fprintf(stderr, "olmoe: no output.weight\n");
+        free(m);
+        return NULL;
+    }
+
+    int ok = m->out_norm != NULL;
+    for (int l = 0; l < nl && ok; l++) {
+        char nm[128];
+        #define T(dst, fmt) (snprintf(nm, sizeof(nm), fmt, l), wt_load(&m->layers[l].dst, gf, nm))
+        #define F(dst, fmt) (snprintf(nm, sizeof(nm), fmt, l), m->layers[l].dst = load_f32(gf, nm), \
+                             m->layers[l].dst != NULL)
+        ok = F(attn_norm, "blk.%d.attn_norm.weight")
+          && T(wq, "blk.%d.attn_q.weight")   && T(wk, "blk.%d.attn_k.weight")
+          && T(wv, "blk.%d.attn_v.weight")   && T(wo, "blk.%d.attn_output.weight")
+          && F(q_norm, "blk.%d.attn_q_norm.weight")
+          && F(k_norm, "blk.%d.attn_k_norm.weight")
+          && F(ffn_norm, "blk.%d.ffn_norm.weight")
+          && T(gate_inp, "blk.%d.ffn_gate_inp.weight")
+          && T(gate_exps, "blk.%d.ffn_gate_exps.weight")
+          && T(up_exps, "blk.%d.ffn_up_exps.weight")
+          && T(down_exps, "blk.%d.ffn_down_exps.weight");
+        #undef T
+        #undef F
+        /* The stacked tensors must divide into the experts the metadata promised, or a slice
+         * would silently start mid-expert and the model would answer with somebody else's
+         * arithmetic. */
+        if (ok && (m->layers[l].gate_exps.rows != m->ffn * m->n_expert ||
+                   m->layers[l].up_exps.rows   != m->ffn * m->n_expert ||
+                   m->layers[l].down_exps.rows != m->embed * m->n_expert)) {
+            fprintf(stderr, "olmoe: layer %d expert stack does not match %d experts\n",
+                    l, m->n_expert);
+            ok = 0;
+        }
+    }
+    if (!ok) {
+        fprintf(stderr, "olmoe: missing or mismatched weights\n");
+        free(m);
+        return NULL;
+    }
+
+    fprintf(stderr, "olmoe: E=%d H=%d KV=%d HD=%d FFN=%d V=%d L=%d experts=%d/%d\n",
+            m->embed, m->n_heads, m->n_kv_heads, m->head_dim, m->ffn, m->vocab,
+            m->n_layers, m->n_expert_used, m->n_expert);
+
+    dims->n_layers = m->n_layers;
+    dims->kv_dim = m->kv_dim;
+    dims->vocab = m->vocab;
+    return m;
+}
+
+static void olmoe_free(void *model) {
+    olmoe_model *m = (olmoe_model*)model;
+    if (!m) return;
+    free(m->tok_emb.f32); free(m->out_norm); free(m->out_weight.f32);
+    for (int l = 0; l < m->n_layers; l++) {
+        free(m->layers[l].attn_norm);
+        free(m->layers[l].q_norm); free(m->layers[l].k_norm);
+        free(m->layers[l].ffn_norm);
+        free(m->layers[l].wq.f32); free(m->layers[l].wk.f32);
+        free(m->layers[l].wv.f32); free(m->layers[l].wo.f32);
+        free(m->layers[l].gate_inp.f32);
+        free(m->layers[l].gate_exps.f32); free(m->layers[l].up_exps.f32);
+        free(m->layers[l].down_exps.f32);
+    }
+    free(m);
+}
+
+/* Top-k by value, k small and n sixty-four, so k passes of argmax beat sorting and beat
+ * being clever. Returns the indices; the caller reads the weights out of the untouched
+ * probability vector. */
+static void top_k(const float *p, int n, int k, int *idx) {
+    char taken[1024];
+    memset(taken, 0, (size_t)n);
+    for (int i = 0; i < k; i++) {
+        int best = -1;
+        float bv = -INFINITY;
+        for (int e = 0; e < n; e++)
+            if (!taken[e] && p[e] > bv) { bv = p[e]; best = e; }
+        idx[i] = best < 0 ? 0 : best;
+        taken[idx[i]] = 1;
+    }
+}
+
+static void olmoe_forward(void *model, kv_cache *kv, const int *tokens, int n,
+                          int pos0, float *logits) {
+    olmoe_model *m = (olmoe_model*)model;
+    int E = m->embed, H = m->n_heads, KV = m->n_kv_heads;
+    int HD = m->head_dim, KVD = m->kv_dim, FFN = m->ffn, Q_DIM = m->q_dim;
+    int NE = m->n_expert, NU = m->n_expert_used;
+    float eps = m->rms_eps;
+    int gqa = H / KV;
+
+    double pft = pf_mark();
+    float *x = (float*)calloc((size_t)n * E, sizeof(float));
+    for (int j = 0; j < n; j++) {
+        float *xj = x + (long)j * E;
+        if (m->tok_emb.f32) memcpy(xj, m->tok_emb.f32 + (long)tokens[j] * E, E * sizeof(float));
+        else if (gguf_dequant_row(m->gf, m->emb_ti, (uint64_t)tokens[j], xj) != 0)
+            memset(xj, 0, E * sizeof(float));
+    }
+    pf_add(PF_EMBED, pft);
+
+    float *xn = (float*)calloc((size_t)n * E, sizeof(float));
+    float *q_all = (float*)calloc((size_t)n * Q_DIM, sizeof(float));
+    float *k_new = (float*)calloc((size_t)n * KVD, sizeof(float));
+    float *v_new = (float*)calloc((size_t)n * KVD, sizeof(float));
+    float *attn_out = (float*)calloc((size_t)n * Q_DIM, sizeof(float));
+    float *ffn_out = (float*)calloc((size_t)n * E, sizeof(float));
+    float *router = (float*)calloc((size_t)n * NE, sizeof(float));
+    float *eg = (float*)calloc((size_t)FFN, sizeof(float));
+    float *eu = (float*)calloc((size_t)FFN, sizeof(float));
+    float *eo = (float*)calloc((size_t)E, sizeof(float));
+
+    for (int l = 0; l < m->n_layers; l++) {
+        pft = pf_mark();
+        for (int j = 0; j < n; j++)
+            rmsnorm(xn + (long)j * E, x + (long)j * E, m->layers[l].attn_norm, E, eps);
+        pf_add(PF_NORM, pft);
+
+        pft = pf_mark();
+        qmm(q_all, &m->layers[l].wq, xn, n);
+        qmm(k_new, &m->layers[l].wk, xn, n);
+        qmm(v_new, &m->layers[l].wv, xn, n);
+        pf_add(PF_QKV, pft);
+
+        /* The projection is normalised whole, then split into heads. Doing it after the
+         * split would divide by a different scale per head and is a different model. */
+        pft = pf_mark();
+        for (int j = 0; j < n; j++) {
+            rmsnorm(q_all + (long)j * Q_DIM, q_all + (long)j * Q_DIM,
+                    m->layers[l].q_norm, Q_DIM, eps);
+            rmsnorm(k_new + (long)j * KVD, k_new + (long)j * KVD,
+                    m->layers[l].k_norm, KVD, eps);
+        }
+        pf_add(PF_NORM, pft);
+
+        pft = pf_mark();
+        long base = (long)l * kv->max_seq * KVD;
+        for (int j = 0; j < n; j++) {
+            int pos = pos0 + j;
+            float *qj = q_all + (long)j * Q_DIM, *kj = k_new + (long)j * KVD;
+            for (int h = 0; h < H; h++) rope(qj + h*HD, pos, HD, m->rope_base, 1);
+            for (int h = 0; h < KV; h++) rope(kj + h*HD, pos, HD, m->rope_base, 1);
+            memcpy(kv->k + base + (long)pos * KVD, kj, KVD * sizeof(float));
+            memcpy(kv->v + base + (long)pos * KVD, v_new + (long)j * KVD, KVD * sizeof(float));
+        }
+        pf_add(PF_ROPE, pft);
+
+        pft = pf_mark();
+        float scale = 1.0f / sqrtf((float)HD);
+        memset(attn_out, 0, (size_t)n * Q_DIM * sizeof(float));
+        for (int j = 0; j < n; j++) {
+            int pos = pos0 + j;
+            for (int h = 0; h < H; h++) {
+                int kv_h = h / gqa;
+                float *q = q_all + (long)j * Q_DIM + h * HD;
+                float *scores = (float*)calloc(pos + 1, sizeof(float));
+                for (int t = 0; t <= pos; t++) {
+                    const float *kt = kv->k + base + (long)t * KVD + kv_h * HD;
+                    scores[t] = dot_f32(q, kt, HD) * scale;
+                }
+                softmax(scores, pos + 1);
+                float *out_h = attn_out + (long)j * Q_DIM + h * HD;
+                for (int t = 0; t <= pos; t++) {
+                    const float *vt = kv->v + base + (long)t * KVD + kv_h * HD;
+                    axpy_f32(out_h, scores[t], vt, HD);
+                }
+                free(scores);
+            }
+        }
+        pf_add(PF_ATTN, pft);
+
+        pft = pf_mark();
+        qmm(ffn_out, &m->layers[l].wo, attn_out, n);
+        pf_add(PF_PROJ, pft);
+        pft = pf_mark();
+        for (long i = 0; i < (long)n * E; i++) x[i] += ffn_out[i];
+        pf_add(PF_RESID, pft);
+
+        pft = pf_mark();
+        for (int j = 0; j < n; j++)
+            rmsnorm(xn + (long)j * E, x + (long)j * E, m->layers[l].ffn_norm, E, eps);
+        pf_add(PF_NORM, pft);
+
+        /* Router first, for every row at once: it is a thin matrix and the batched path
+         * costs nothing here. The experts cannot follow, because each row picks its own. */
+        pft = pf_mark();
+        qmm(router, &m->layers[l].gate_inp, xn, n);
+        pf_add(PF_QKV, pft);
+
+        memset(ffn_out, 0, (size_t)n * E * sizeof(float));
+        for (int j = 0; j < n; j++) {
+            float *probs = router + (long)j * NE;
+            const float *xj = xn + (long)j * E;
+            float *dst = ffn_out + (long)j * E;
+            int idx[OLMOE_MAX_USED];
+
+            pft = pf_mark();
+            softmax(probs, NE);
+            top_k(probs, NE, NU, idx);
+            pf_add(PF_SILU, pft);
+
+            for (int e = 0; e < NU; e++) {
+                wt ge, ue, de;
+                if (!wt_expert(&ge, &m->layers[l].gate_exps, idx[e], FFN) ||
+                    !wt_expert(&ue, &m->layers[l].up_exps,   idx[e], FFN) ||
+                    !wt_expert(&de, &m->layers[l].down_exps, idx[e], E)) {
+                    static int warned = 0;
+                    if (!warned) { fprintf(stderr, "olmoe: expert slice failed\n"); warned = 1; }
+                    continue;
+                }
+                pft = pf_mark();
+                qmv(eg, &ge, xj);
+                qmv(eu, &ue, xj);
+                pf_add(PF_FFN, pft);
+                pft = pf_mark();
+                for (int i = 0; i < FFN; i++) {
+                    float g = eg[i];
+                    eg[i] = (g / (1.0f + expf(-g))) * eu[i];
+                }
+                pf_add(PF_SILU, pft);
+                pft = pf_mark();
+                qmv(eo, &de, eg);
+                pf_add(PF_FFN, pft);
+                /* The weight is the softmax probability as it stands: this family neither
+                 * renormalises over the chosen eight nor scales them. */
+                axpy_f32(dst, probs[idx[e]], eo, E);
+            }
+        }
+        pft = pf_mark();
+        for (long i = 0; i < (long)n * E; i++) x[i] += ffn_out[i];
+        pf_add(PF_RESID, pft);
+    }
+
+    if (logits) {
+        pft = pf_mark();
+        rmsnorm(xn, x + (long)(n - 1) * E, m->out_norm, E, eps);
+        qmv(logits, &m->out_weight, xn);
+        pf_add(PF_HEAD, pft);
+    }
+
+    free(x); free(xn); free(q_all); free(k_new); free(v_new);
+    free(attn_out); free(ffn_out); free(router); free(eg); free(eu); free(eo);
+}
+
+static const char *const olmoe_names[] = { "olmoe", NULL };
+
+const nt_arch nt_arch_olmoe = {
+    .names = olmoe_names,
+    .load = olmoe_load,
+    .free = olmoe_free,
+    .forward = olmoe_forward,
+};

--- a/harness/main.c
+++ b/harness/main.c
@@ -20,6 +20,7 @@
 
 static const nt_arch *const ARCHS[] = {
     &nt_arch_gemma4,
+    &nt_arch_olmoe,
     &nt_arch_llama,
 };
 

--- a/harness/runtime.c
+++ b/harness/runtime.c
@@ -49,6 +49,17 @@ int wt_load(wt *w, gguf_file *gf, const char *name) {
     return (w->q || w->f32) ? 1 : 0;
 }
 
+int wt_expert(wt *dst, const wt *src, int index, int rows_each) {
+    if (!src->q || index < 0 || rows_each <= 0) return 0;      /* the f32 fallback cannot slice */
+    if ((long)(index + 1) * rows_each > src->rows) return 0;
+    uint64_t row_bytes = gguf_type_size((uint32_t)src->dtype, (uint64_t)src->cols);
+    if (!row_bytes) return 0;
+    *dst = *src;
+    dst->rows = rows_each;
+    dst->q    = src->q + row_bytes * (uint64_t)index * (uint64_t)rows_each;
+    return 1;
+}
+
 kv_cache *kv_new(int nl, int max_seq, int kv_dim) {
     kv_cache *kv = (kv_cache*)calloc(1, sizeof(kv_cache));
     if (!kv) return NULL;

--- a/harness/runtime.h
+++ b/harness/runtime.h
@@ -39,6 +39,12 @@ typedef struct {
 
 int  wt_load(wt *w, gguf_file *gf, const char *name);
 
+/* One expert out of a stacked expert tensor. A mixture stores its experts as one 3-D tensor,
+ * which wt_load already reads as a single matrix of n_expert * rows_each rows — so an expert
+ * is that matrix with a shorter row count and a shifted base, and nothing is copied. Returns
+ * 0 if the slice does not fit or the dtype has no packed row size. */
+int  wt_expert(wt *dst, const wt *src, int index, int rows_each);
+
 typedef struct {
     float *k, *v;
     int max_seq, n_layers, kv_dim;

--- a/harness/test_tokenizer.sh
+++ b/harness/test_tokenizer.sh
@@ -31,9 +31,16 @@ MODELS="$*"
 if [ -z "$MODELS" ]; then
   # $HOME is not always where the models are — this tree is often run from a chroot whose
   # home is elsewhere than the one holding the files, so look beside the repo as well.
+  # olmoe earns its place here rather than for variety: its vocabulary carries USER_DEFINED
+  # tokens — runs of real spaces, stored as literal text — and no other model in this list
+  # does. The indented-code and repeated-space texts below were already here and passed for
+  # years, because on a vocabulary without such tokens both implementations split the same way.
   for m in "$HOME/models/gemma-4-E2B-it-Q4_0.gguf" "$HOME/models/qwen05b_q5_0_ours.gguf" \
+           "$HOME/models/olmoe-1b-7b-q4_0.gguf" \
            "../models/gemma-4-E2B-it-Q4_0.gguf" "../models/qwen05b_q5_0_ours.gguf" \
-           "../../models/gemma-4-E2B-it-Q4_0.gguf" "../../models/qwen05b_q5_0_ours.gguf"; do
+           "../models/olmoe-1b-7b-q4_0.gguf" \
+           "../../models/gemma-4-E2B-it-Q4_0.gguf" "../../models/qwen05b_q5_0_ours.gguf" \
+           "../../models/olmoe-1b-7b-q4_0.gguf"; do
     [ -f "$m" ] && MODELS="$MODELS $m"
   done
 fi

--- a/tools/gguf_quantize.c
+++ b/tools/gguf_quantize.c
@@ -53,20 +53,9 @@ static const char *type_name(uint32_t t) {
     }
 }
 
-/* Packed size of n elements. Only the formats this tool emits plus the ones it may copy. */
-static uint64_t type_size(uint32_t t, uint64_t n) {
-    switch (t) {
-    case GGUF_TYPE_F32:  return n * 4;
-    case GGUF_TYPE_F16:  return n * 2;
-    case GGUF_TYPE_BF16: return n * 2;
-    case GGUF_TYPE_Q4_0: return n / 32 * 18;
-    case GGUF_TYPE_Q5_0: return n / 32 * 22;
-    case GGUF_TYPE_Q8_0: return n / 32 * 34;
-    case GGUF_TYPE_Q4_K: return n / 256 * 144;
-    case GGUF_TYPE_Q6_K: return n / 256 * 210;
-    default:             return 0;
-    }
-}
+/* Packed size of n elements — gguf_type_size, kept under the old name so the code below
+ * reads the same. It used to be a copy of that function living here. */
+#define type_size gguf_type_size
 
 static int copy_range(FILE *in, FILE *out, uint64_t off, uint64_t len) {
     if (fseek(in, (long)off, SEEK_SET) != 0) return -1;


### PR DESCRIPTION
harness/arch_olmoe.c runs OLMoE-1B-7B: sixteen layers, sixty-four experts each, eight used per token. It is the first architecture here whose weights are not read in one sweep. A dense model streams every byte of every layer; this reads an eighth of its feed-forward and reads it gathered, eight slices chosen per token out of a 75 MB region per tensor per layer. Everything this library has been tuned on assumed the sweep.

It needed no change to the family interface, which is what arch.h claims of itself, and one helper that is arithmetic rather than an idea. A stacked expert tensor is 3-D and wt_load already reads it as one matrix of n_ff * n_expert rows, so expert e is that matrix with a shorter row count and a shifted base — wt_expert copies nothing. gguf_type_size became public to make the shift computable and tools/gguf_quantize.c lost its private copy of it.

Routing is the reference's rather than the usual shape: softmax over all sixty-four, top eight by that probability, weights taken as those probabilities stand — no renormalisation over the chosen eight, no scale, because the call site passes norm_w = false and the file carries no expert_weights_scale. Q and K are RMS-normalised across the whole projection before the heads are split out, with a weight vector of n_embd; gemma4 does it per head and the two are one reshape apart.

The tokenizer was the real find and it was ours. This vocabulary carries twenty-five tokens marked USER_DEFINED and they are runs of real spaces — token 50274 is four bytes of 0x20, not four of the byte-level space glyph. No sequence of merges over that alphabet can spell one, so the reference matches them against the raw text before BPE and encodes only the gaps. We had no such pass on either side: indentation was lost encoding and lost again printing, since a literal space is not in the byte-level table and was dropped. gguf_read_i32_array reads tokenizer.ggml.token_type to find them. CONTROL tokens are left out deliberately — the reference splits those only when asked to parse specials.

Why it went unseen is worth keeping. test_tokenizer.sh already had a repeated-spaces text and an indented-code text and both had always passed, on Qwen and Gemma, whose vocabularies have no such tokens and where the two implementations happen to split alike. The gate was not weak in its texts, it was weak in its corpus. OLMoE is in its default list now, 24 checks against 16, and removing the added-token pass fails exactly those two texts and only on that model.

Cold, against the reference: parity identical on three prompts, tokenizer identical on 24, decode 16.1 / 16.8 t/s against llama.cpp's 21.41 +/- 1.15 — 77 percent, where the dense models sit at 97. The gap is neither a mystery nor a defect: the reference gathers the eight chosen experts into one mul_mat_id while this runs eight separate matvecs, twenty-four per layer against three, 384 dispatches a token. Next piece of work, now with a number on it.

Gates: 49, 73, 34, 3, four determinism runs, the allocation gate, four affinity modes, the race test and the sanitizer target all pass; llama parity identical on three prompts, olmoe parity identical on three, tokenizer identical on 24.

Quote: "The whole is other than the sum of the parts." — Kurt Koffka
Method: the Method learned to read only the part it was sent for.

By Arianna Method (Co-authored by Claude, Defender) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff