### PR TITLE
the method stopped answering with seven of its eight experts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ test_qmatvec_leak
 test_affinity
 test_plan_race
 bench_claim
+test_wt_expert
 test_plan_race_tsan
 
 gguf_quantize

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ SIMD_LIBS  = -lpthread
 
 # ── Targets ──
 
-.PHONY: all test test_qpool test_qmatvec_leak test_affinity test_plan_race test_tsan bench_claim test_js test_python test_tokenizer clean cpu gpu simd help lib shared install metal test_metal infer_gguf_metal
+.PHONY: all test test_qpool test_qmatvec_leak test_affinity test_plan_race test_tsan bench_claim test_wt_expert test_js test_python test_tokenizer clean cpu gpu simd help lib shared install metal test_metal infer_gguf_metal
 
 all: notorch_test
 	@echo "Built with $(BLAS_NAME). Run: ./notorch_test"
@@ -352,6 +352,11 @@ test_qmatmul: tests/test_qmatmul.c notorch.c notorch.h
 	$(CC) $(CFLAGS) $(BLAS_FLAGS) -o test_qmatmul tests/test_qmatmul.c notorch.c -lm $(BLAS_LIBS)
 	@echo "Compiled: test_qmatmul (batched packed matmul vs per-token, $(BLAS_NAME))"
 
+test_wt_expert: tests/test_wt_expert.c harness/runtime.c gguf.c notorch.c harness/runtime.h
+	$(CC) $(CFLAGS) $(BLAS_FLAGS) -I. -o test_wt_expert tests/test_wt_expert.c \
+	  harness/runtime.c gguf.c notorch.c -lm $(BLAS_LIBS)
+	@echo "Compiled: test_wt_expert (one expert out of a stacked tensor, $(BLAS_NAME))"
+
 bench_claim: tests/bench_claim.c
 	$(CC) $(CFLAGS) -o bench_claim tests/bench_claim.c
 	@echo "Compiled: bench_claim (row-claim cost, shared line against separated)"
@@ -378,7 +383,7 @@ test_affinity: tests/test_affinity.c notorch.c notorch.h
 	$(CC) $(CFLAGS) $(BLAS_FLAGS) -o test_affinity tests/test_affinity.c notorch.c -lm $(BLAS_LIBS)
 	@echo "Compiled: test_affinity (core selection on mixed-speed machines, $(BLAS_NAME))"
 
-test: notorch_test test_vision test_qpool test_qmatmul test_quantize test_qmatvec_leak test_affinity test_plan_race
+test: notorch_test test_vision test_qpool test_qmatmul test_quantize test_qmatvec_leak test_affinity test_plan_race test_wt_expert
 	./notorch_test
 	./test_vision
 	./test_qpool
@@ -393,6 +398,7 @@ test: notorch_test test_vision test_qpool test_qmatmul test_quantize test_qmatve
 	./test_affinity narrowed
 	NT_QMV_PIN=0 ./test_affinity nopin
 	./test_plan_race
+	./test_wt_expert
 
 test_js:
 	node js-edition/test_op_parity.mjs

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,35 @@ Newest entries on top.
 
 ---
 
+## 2026-09-04 — four on the mixture, and the one that would have answered with seven eighths
+
+Review on the OLMoE merge, all four fair, and one of them a wrong answer rather than a crash.
+
+`wt_expert` refused to slice a weight held as expanded f32, taking only the packed form. That
+did not fail loudly: the caller logged once and skipped that expert, so a model whose expert
+tensors fell back to f32 — which is exactly what happens to a dtype with no packed kernel —
+would have run with seven of its eight and said nothing. The expanded form is a contiguous
+`[rows, cols]` and slices by the same arithmetic; refusing it was refusing the case the
+fallback exists for. The docstring said so too and now does not.
+
+`tests/test_wt_expert.c` gates both forms without a model: rows are filled with their own
+index, so a slice that lands wrong reads a number naming where it landed. Thirteen checks,
+including the three refusals that must stay refusals — past the end, negative, and a weight
+with no data at all. Restoring the old `!src->q` condition fails the five f32 cases and
+nothing else, which is how the gate was shown to bite.
+
+The rest: `olmoe.expert_count` came out of the file and went unbounded into a `taken[1024]` on
+the stack, so a header claiming more experts than that would have written past it — the count
+is now checked against the buffer it indexes. `bpe_encode` handed a NULL tokenizer to the span
+path, which reads `t->byte_cp` on its first line. And the expert loop's failure branch dropped
+one expert of eight; it now drops the whole feed-forward for that token, because a missing
+contribution shows in the output and a quietly missing expert does not.
+
+Gates: 15 green including the new one, tokenizer identical on 24, llama parity identical on
+three prompts, olmoe parity identical on three.
+
+---
+
 ## 2026-09-04 — the first mixture, and the tokens that were never in the alphabet
 
 `harness/arch_olmoe.c` runs OLMoE-1B-7B: sixteen layers, sixty-four experts each, eight used

--- a/examples/bpe.c
+++ b/examples/bpe.c
@@ -416,7 +416,8 @@ static int bpe_encode_span(const bpe_tokenizer *t, const char *text, int len, in
 int bpe_encode(const bpe_tokenizer *t, const char *text, int *out, int cap) {
     if (t && t->spm_bpe) return spm_bpe_encode(t, text, out, cap);
     if (t && t->spm) return spm_encode(t, text, out, cap);
-    if (!t || t->n_added <= 0) return bpe_encode_span(t, text, (int)strlen(text), out, cap);
+    if (!t) return 0;               /* the span path reads t->byte_cp on its first line */
+    if (t->n_added <= 0) return bpe_encode_span(t, text, (int)strlen(text), out, cap);
 
     /* Added tokens are matched against the raw text first, longest at each position, and the
      * merge path only ever sees what lies between them. Doing it the other way round cannot

--- a/harness/arch_olmoe.c
+++ b/harness/arch_olmoe.c
@@ -26,6 +26,10 @@
 #include <math.h>
 
 #define OLMOE_MAX_USED 32
+/* top_k marks the experts it has taken in a buffer this wide. The count comes out of the file,
+ * so it is checked against this rather than trusted: a header claiming more experts than the
+ * buffer holds would write past it. */
+#define OLMOE_MAX_EXPERTS 1024
 
 typedef struct {
     int n_layers, n_heads, n_kv_heads, embed, ffn, vocab, head_dim, kv_dim, q_dim;
@@ -75,7 +79,8 @@ static void *olmoe_load(gguf_file *gf, nt_dims *dims) {
     m->n_expert = kv ? (int)kv->val.u32 : 0;
     kv = gguf_get_kv(gf, "olmoe.expert_used_count");
     m->n_expert_used = kv ? (int)kv->val.u32 : 0;
-    if (m->n_expert <= 0 || m->n_expert_used <= 0 || m->n_expert_used > OLMOE_MAX_USED ||
+    if (m->n_expert <= 0 || m->n_expert > OLMOE_MAX_EXPERTS ||
+        m->n_expert_used <= 0 || m->n_expert_used > OLMOE_MAX_USED ||
         m->n_expert_used > m->n_expert) {
         fprintf(stderr, "olmoe: expert counts missing or unusable (%d of %d)\n",
                 m->n_expert_used, m->n_expert);
@@ -175,7 +180,7 @@ static void olmoe_free(void *model) {
  * being clever. Returns the indices; the caller reads the weights out of the untouched
  * probability vector. */
 static void top_k(const float *p, int n, int k, int *idx) {
-    char taken[1024];
+    char taken[OLMOE_MAX_EXPERTS];
     memset(taken, 0, (size_t)n);
     for (int i = 0; i < k; i++) {
         int best = -1;
@@ -308,12 +313,22 @@ static void olmoe_forward(void *model, kv_cache *kv, const int *tokens, int n,
 
             for (int e = 0; e < NU; e++) {
                 wt ge, ue, de;
+                /* Load has already checked that every stack divides into n_expert slices of
+                 * the right height, so this cannot fire on a file that loaded. If it ever
+                 * does, the token gets no feed-forward at all rather than seven eighths of
+                 * one: a missing contribution is visible in the output, a quietly missing
+                 * expert is not. */
                 if (!wt_expert(&ge, &m->layers[l].gate_exps, idx[e], FFN) ||
                     !wt_expert(&ue, &m->layers[l].up_exps,   idx[e], FFN) ||
                     !wt_expert(&de, &m->layers[l].down_exps, idx[e], E)) {
                     static int warned = 0;
-                    if (!warned) { fprintf(stderr, "olmoe: expert slice failed\n"); warned = 1; }
-                    continue;
+                    if (!warned) {
+                        fprintf(stderr, "olmoe: expert %d of layer %d would not slice; "
+                                        "this token's feed-forward is dropped\n", idx[e], l);
+                        warned = 1;
+                    }
+                    memset(dst, 0, (size_t)E * sizeof(float));
+                    break;
                 }
                 pft = pf_mark();
                 qmv(eg, &ge, xj);

--- a/harness/runtime.c
+++ b/harness/runtime.c
@@ -50,14 +50,27 @@ int wt_load(wt *w, gguf_file *gf, const char *name) {
 }
 
 int wt_expert(wt *dst, const wt *src, int index, int rows_each) {
-    if (!src->q || index < 0 || rows_each <= 0) return 0;      /* the f32 fallback cannot slice */
+    if (!src || index < 0 || rows_each <= 0) return 0;
     if ((long)(index + 1) * rows_each > src->rows) return 0;
-    uint64_t row_bytes = gguf_type_size((uint32_t)src->dtype, (uint64_t)src->cols);
-    if (!row_bytes) return 0;
-    *dst = *src;
-    dst->rows = rows_each;
-    dst->q    = src->q + row_bytes * (uint64_t)index * (uint64_t)rows_each;
-    return 1;
+    if (src->q) {
+        uint64_t row_bytes = gguf_type_size((uint32_t)src->dtype, (uint64_t)src->cols);
+        if (!row_bytes) return 0;
+        *dst = *src;
+        dst->rows = rows_each;
+        dst->q    = src->q + row_bytes * (uint64_t)index * (uint64_t)rows_each;
+        return 1;
+    }
+    /* The expanded copy is a contiguous [rows, cols] of floats and slices the same way. It
+     * used to be refused here, which did not fail — the caller skipped that expert and
+     * answered with seven of its eight, quietly. A dtype with no packed kernel is exactly
+     * when this path is taken, so refusing it is refusing the case it exists for. */
+    if (src->f32) {
+        *dst = *src;
+        dst->rows = rows_each;
+        dst->f32  = src->f32 + (long)index * rows_each * src->cols;
+        return 1;
+    }
+    return 0;
 }
 
 kv_cache *kv_new(int nl, int max_seq, int kv_dim) {

--- a/harness/runtime.h
+++ b/harness/runtime.h
@@ -41,8 +41,10 @@ int  wt_load(wt *w, gguf_file *gf, const char *name);
 
 /* One expert out of a stacked expert tensor. A mixture stores its experts as one 3-D tensor,
  * which wt_load already reads as a single matrix of n_expert * rows_each rows — so an expert
- * is that matrix with a shorter row count and a shifted base, and nothing is copied. Returns
- * 0 if the slice does not fit or the dtype has no packed row size. */
+ * is that matrix with a shorter row count and a shifted base, and nothing is copied. Works on
+ * both forms a weight can take here: the packed bytes, and the expanded f32 a dtype without a
+ * kernel falls back to. Returns 0 only when the slice does not fit, the weight is absent, or
+ * the packed dtype has no known row size. */
 int  wt_expert(wt *dst, const wt *src, int index, int rows_each);
 
 typedef struct {

--- a/tests/test_wt_expert.c
+++ b/tests/test_wt_expert.c
@@ -1,0 +1,91 @@
+/* test_wt_expert.c — slicing one expert out of a stacked tensor, in both forms a weight takes.
+ *
+ * A mixture keeps its experts in one 3-D tensor and wt_load reads that as a single matrix, so
+ * an expert is a row range: a shifted base and a shorter row count, nothing copied. Two things
+ * make that worth a test rather than a reading. The packed form has to advance by the dtype's
+ * row size, which differs per dtype and is easy to get right for Q4_0 and wrong for Q6_K. And
+ * the f32 form has to advance at all — it was refused at first, and refusing it did not fail
+ * loudly: the caller skipped that expert and answered with seven of its eight.
+ *
+ * No model is needed. The weights here are counted bytes and counted floats, so a wrong offset
+ * is a wrong number rather than a wrong sentence.
+ */
+#include "harness/runtime.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int fails = 0;
+
+static void check(const char *what, int ok, const char *detail) {
+    printf("  %s %s%s%s\n", ok ? "PASS" : "FAIL", what, detail ? " — " : "", detail ? detail : "");
+    if (!ok) fails++;
+}
+
+int main(void) {
+    printf("expert slice out of a stacked tensor\n");
+
+    const int cols = 256, rows_each = 4, n_expert = 5;
+    const int rows = rows_each * n_expert;
+    char detail[160];
+
+    /* Packed: Q4_0 is 18 bytes per 32 values, so a row is cols/32*18. Fill each row with its
+     * own index so a slice that lands wrong reads a number that names where it landed. */
+    size_t rb = (size_t)(cols / 32) * 18;
+    uint8_t *packed = (uint8_t *)malloc(rb * (size_t)rows);
+    if (!packed) { printf("  FAIL out of memory\n"); return 1; }
+    for (int r = 0; r < rows; r++) memset(packed + rb * (size_t)r, r, rb);
+
+    wt stacked = { .q = packed, .f32 = NULL, .dtype = 2 /* Q4_0 */,
+                   .rows = rows, .cols = cols, .use_i8 = 0 };
+
+    for (int e = 0; e < n_expert; e++) {
+        wt slice;
+        if (!wt_expert(&slice, &stacked, e, rows_each)) {
+            snprintf(detail, sizeof(detail), "expert %d refused", e);
+            check("packed slice returns a weight", 0, detail);
+            continue;
+        }
+        int want = e * rows_each;
+        int got = slice.q[0];
+        snprintf(detail, sizeof(detail), "expert %d starts at row %d, expected %d", e, got, want);
+        check("packed slice starts at the right row", got == want && slice.rows == rows_each,
+              got == want ? NULL : detail);
+    }
+
+    /* Expanded: the same shape as floats, each row holding its own index. */
+    float *flat = (float *)malloc((size_t)rows * cols * sizeof(float));
+    if (!flat) { printf("  FAIL out of memory\n"); return 1; }
+    for (int r = 0; r < rows; r++)
+        for (int c = 0; c < cols; c++) flat[(size_t)r * cols + c] = (float)r;
+
+    wt expanded = { .q = NULL, .f32 = flat, .dtype = 0 /* F32 */,
+                    .rows = rows, .cols = cols, .use_i8 = 0 };
+
+    for (int e = 0; e < n_expert; e++) {
+        wt slice;
+        if (!wt_expert(&slice, &expanded, e, rows_each)) {
+            snprintf(detail, sizeof(detail), "expert %d refused", e);
+            check("f32 slice returns a weight", 0, detail);
+            continue;
+        }
+        int want = e * rows_each;
+        int got = (int)slice.f32[0];
+        snprintf(detail, sizeof(detail), "expert %d starts at row %d, expected %d", e, got, want);
+        check("f32 slice starts at the right row", got == want && slice.rows == rows_each,
+              got == want ? NULL : detail);
+    }
+
+    /* What must be refused. A slice past the end would read somebody else's memory, and a
+     * weight that is neither packed nor expanded has nothing to slice. */
+    wt slice;
+    check("a slice past the end is refused",
+          !wt_expert(&slice, &stacked, n_expert, rows_each), NULL);
+    check("a negative index is refused", !wt_expert(&slice, &stacked, -1, rows_each), NULL);
+    wt empty = { .q = NULL, .f32 = NULL, .dtype = 2, .rows = rows, .cols = cols, .use_i8 = 0 };
+    check("a weight with no data is refused", !wt_expert(&slice, &empty, 0, rows_each), NULL);
+
+    free(packed); free(flat);
+    printf("\nResults: %s\n", fails ? "FAILED" : "all passed");
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
Four review points on the mixture, all fair, and one of them a wrong answer rather than a crash. wt_expert refused to slice a weight held as expanded f32 and took only the packed form. That did not fail loudly: the caller warned once and skipped the expert, so a model whose expert tensors fell back to f32 — which is what happens to any dtype without a packed kernel — would have run on seven of its eight and said nothing about it. The expanded form is a contiguous [rows, cols] and slices by the same arithmetic. Refusing it was refusing the case the fallback exists for, and the docstring that said so is corrected with it.

tests/test_wt_expert.c gates both forms and needs no model: every row is filled with its own index, so a slice that lands wrong reads a number that names where it landed. Thirteen checks, including three refusals that must stay refusals — past the end, negative, and a weight holding neither packed bytes nor floats. Restoring the old !src->q condition fails the five f32 cases and nothing else.

The rest. olmoe.expert_count came out of the file unbounded and indexed a taken[1024] on the stack, so a header claiming more experts than that would have written past it; the count is checked against the buffer it indexes now. bpe_encode could hand a NULL tokenizer to the span path, which reads t->byte_cp on its first line. And the expert loop's failure branch dropped one expert of eight — it drops the whole feed-forward for that token now, because a missing contribution is visible in the output and a quietly missing expert is not.

Gates: 15 green including the new one, tokenizer identical on 24, llama parity identical on three prompts, olmoe parity identical on three.

Quote: "It is the mark of an educated mind to rest satisfied with the degree of precision which the nature of the subject admits." — Aristotle
Method: the Method would rather be visibly wrong than quietly incomplete.

By Arianna Method (Co-authored by Claude, Defender) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff