### PR TITLE
the Method asked the same question twice and wrote down what was in m…

### DIFF
--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,51 @@ Newest entries on top.
 
 ---
 
+## 2026-09-09 — the harness can be asked twice, and says how much of the model is in memory
+
+`-r N` runs the same prompt N times in one process. The load happens once, so what is timed is
+the model running rather than the model arriving. Before each run the harness prints how much
+of itself is resident and how much the machine has free, because on a phone those two numbers
+decide the result more than anything in the arithmetic does.
+
+The reason for both is a measurement that was worthless and had already been written down.
+OLMoE is 3.66 GB on a machine with 7.6, and the same binary on the same file gave 6.7 t/s and
+18.8 t/s within one afternoon — the difference being whether 1.2 GB happened to be free. On
+that basis this log carried "16.5 t/s, 77 percent of the reference" and a decode profile
+putting 62 percent in the expert matmuls. Both are withdrawn. Three explanations were built on
+them and all three are withdrawn with them: that the gap was in 384 dispatches per token, that
+gathering the chosen experts into one call was worth 21 percent, and that scattered expert
+reads cost twice contiguous ones. The first was contradicted by a bench on the same shapes; the
+second measured adjacent experts, which routing never produces; the third was two runs, and six
+repeats of the same command gave 13.2 to 15.2 GiB/s with nothing near the 7.5 it rested on.
+
+What the mode gives instead, on a warm process with residency printed beside each line: run 1
+at 2.86 GiB resident decodes 7.9 t/s, runs 3 through 6 at 3.17 GiB decode 18.4, 18.1, 18.4,
+18.2. Two percent apart, and the line above each says why. Against `llama-bench` at `-t 4`,
+24.30 ± 0.19 on the same file, that is **75 percent** — and now both sides are warm, which the
+earlier comparison was not: `llama-bench` loads once and iterates, while a fresh harness
+process faults in 3.66 GB first.
+
+The warm profile is a different picture from the cold one: FFN 61.2 percent, `qkv+bias` 16.1,
+head 11.8. The FFN reads 453 MB per token in 29.9 ms, which is 14.8 GiB/s and matches a
+standalone bench of the same shapes — so the expert matmuls are running at the rate this
+machine gives, and there is no mystery left in them.
+
+One finding is left deliberately unused. The block holding the router took 26.7 percent of
+decode for seven percent of the bytes: `ffn_gate_inp` is the family's one f32 weight, and f32
+goes through a matvec without the integer kernel's dot instruction. Packing it to Q8_0 at load
+is worth about nine percent of decode, 18.6 to 20.5 t/s — and it breaks parity on one prompt in
+three, because routing is a discrete decision. A small numeric change reorders neighbouring
+scores, a different eight of sixty-four run, and the text stops matching the reference, which
+routes in f32. The measurement is in the source beside the code that does not use it. Trading
+correctness for nine percent is a decision to be made out loud, not a side effect.
+
+Also from review, and the same class as two before it: a check labelled "starts at the right
+row" whose predicate also tested the row count, so a slice with the right base and the wrong
+height failed under a label that did not mention height.
+
+---
+
 ## 2026-09-04 — four on the mixture, and the one that would have answered with seven eighths
 
 Review on the OLMoE merge, all four fair, and one of them a wrong answer rather than a crash.

--- a/harness/arch_olmoe.c
+++ b/harness/arch_olmoe.c
@@ -48,7 +48,7 @@ typedef struct {
         wt wq, wk, wv, wo;
         float *q_norm, *k_norm;       /* over the whole projection, not per head */
         float *ffn_norm;
-        wt gate_inp;                  /* [n_expert, embed] — the router */
+        wt gate_inp;                  /* [n_expert, embed] — the router, as the file has it */
         wt gate_exps, up_exps, down_exps;   /* stacked: n_expert slices each */
     } layers[];
 } olmoe_model;
@@ -169,7 +169,7 @@ static void olmoe_free(void *model) {
         free(m->layers[l].ffn_norm);
         free(m->layers[l].wq.f32); free(m->layers[l].wk.f32);
         free(m->layers[l].wv.f32); free(m->layers[l].wo.f32);
-        free(m->layers[l].gate_inp.f32);
+        free(m->layers[l].gate_inp.f32);   /* router_f32 borrows, it does not own */
         free(m->layers[l].gate_exps.f32); free(m->layers[l].up_exps.f32);
         free(m->layers[l].down_exps.f32);
     }
@@ -293,8 +293,17 @@ static void olmoe_forward(void *model, kv_cache *kv, const int *tokens, int n,
             rmsnorm(xn + (long)j * E, x + (long)j * E, m->layers[l].ffn_norm, E, eps);
         pf_add(PF_NORM, pft);
 
-        /* Router first, for every row at once: it is a thin matrix and the batched path
-         * costs nothing here. The experts cannot follow, because each row picks its own. */
+        /* Router: sixty-four scores over the layer's normalised input, for every row at once.
+         *
+         * This is the one f32 weight the family ships, and it is measurably expensive for its
+         * size — the block holding it took 26.7 percent of decode against seven percent of the
+         * bytes read, because f32 goes through a matvec without the integer kernel's dot
+         * instruction rather than because of its width. Packing it to Q8_0 at load was tried
+         * and is worth about nine percent of decode (18.6 -> 20.5 t/s), but routing is a
+         * discrete decision: a small numeric change reorders neighbouring scores, a different
+         * eight of sixty-four run, and the text diverges from the reference where every other
+         * prompt matches it. The reference routes in f32. Until that trade is somebody's
+         * decision rather than a side effect, so does this. */
         pft = pf_mark();
         qmm(router, &m->layers[l].gate_inp, xn, n);
         pf_add(PF_QKV, pft);

--- a/harness/main.c
+++ b/harness/main.c
@@ -84,6 +84,35 @@ static void emit(const session *s, int id) {
     fflush(stdout);
 }
 
+/* How much of this process is actually in memory, and how much the machine has left.
+ *
+ * A model larger than comfort on a phone makes every timing a statement about page residency
+ * rather than about arithmetic: the same binary on the same file measured 6.7 t/s and 18.8 on
+ * one afternoon, the difference being whether 1.2 GB happened to be free. A benchmark that
+ * does not say which of those it caught is not reporting a speed. Both numbers come from the
+ * kernel; where it does not offer them, the line is omitted rather than guessed. */
+static void residency(const char *when) {
+    long rss = -1, memfree = -1;
+    FILE *f = fopen("/proc/self/smaps_rollup", "r");
+    char line[256];
+    if (f) {
+        while (fgets(line, sizeof(line), f))
+            if (sscanf(line, "Rss: %ld kB", &rss) == 1) break;
+        fclose(f);
+    }
+    f = fopen("/proc/meminfo", "r");
+    if (f) {
+        while (fgets(line, sizeof(line), f))
+            if (sscanf(line, "MemFree: %ld kB", &memfree) == 1) break;
+        fclose(f);
+    }
+    if (rss < 0 && memfree < 0) return;
+    fprintf(stderr, "  [%s]", when);
+    if (rss >= 0) fprintf(stderr, " resident %.2f GiB", rss / 1048576.0);
+    if (memfree >= 0) fprintf(stderr, " | machine free %.2f GiB", memfree / 1048576.0);
+    fputc('\n', stderr);
+}
+
 /* Prompt in, text out, cache advanced. Returns the position after the last
  * token written, so a chat turn can hand it to the next one.
  *
@@ -166,7 +195,7 @@ static void chat(session *s, int max_tokens, float temp) {
 
 static void usage(const char *self) {
     fprintf(stderr,
-        "usage: %s [-q] [-n tokens] [-t temp] <model.gguf> [prompt] [max_tokens] [temp]\n"
+        "usage: %s [-q] [-n tokens] [-t temp] [-r runs] <model.gguf> [prompt] [max_tokens] [temp]\n"
         "  no prompt        chat in the terminal\n"
         "  -q               no banner\n"
         "  -n, -t           tokens and temperature, for chat as well as one shot\n"
@@ -200,10 +229,16 @@ int main(int argc, char **argv) {
     /* The positional form is what examples/infer_llama.c takes and what the
      * parity gate drives; the flags are for chat, which has no prompt to hang
      * positional arguments behind. */
-    int tokenize_only = 0;
+    int tokenize_only = 0, repeats = 1;
     while (ai < argc && argv[ai][0] == '-' && argv[ai][1] && !argv[ai][2]) {
         char f = argv[ai][1];
         if (f == 'q') { quiet = 1; ai++; continue; }
+        /* -r runs the same prompt N times in one process. The load happens once, so what is
+         * timed is the model running rather than the model arriving: a fresh process pays for
+         * faulting in gigabytes of weights, and the reference benchmark this is compared
+         * against does not, which made every such comparison a comparison of two different
+         * things. Later iterations are the ones to read. */
+        if (f == 'r' && ai + 1 < argc) { repeats = atoi(argv[ai + 1]); ai += 2; continue; }
         /* -T prints the ids and stops. A family arrives with two ways to be wrong and this
          * separates them: the tokenizer can be diffed against another implementation without
          * loading a single weight, and the forward can be fed ids through NT_TOKENS. */
@@ -281,9 +316,20 @@ int main(int argc, char **argv) {
             s.max_seq = n_tok + max_tokens + 1;
             s.kv = kv_new(dims.n_layers, s.max_seq, dims.kv_dim);
             fprintf(stderr, "\nprompt: \"%s\" (%d tokens, temp=%.2f)\n", prompt, n_tok, temp);
-            fputs(prompt, stdout);
-            fflush(stdout);
-            run_turn(&s, tokens, n_tok, 0, max_tokens, temp, 1);
+            if (repeats < 1) repeats = 1;
+            for (int rep = 0; rep < repeats; rep++) {
+                if (repeats > 1) {
+                    fprintf(stderr, "\n── run %d of %d ──\n", rep + 1, repeats);
+                    residency(rep == 0 ? "before the first run" : "before this run");
+                }
+                /* The cache is written from position zero every time and attention reads only
+                 * up to the current position, so what an earlier run left behind is never
+                 * looked at. Reallocating it would only add a page-fault storm to the thing
+                 * being measured. */
+                fputs(prompt, stdout);
+                fflush(stdout);
+                run_turn(&s, tokens, n_tok, 0, max_tokens, temp, 1);
+            }
         }
         free(tokens);
     } else {

--- a/tests/test_wt_expert.c
+++ b/tests/test_wt_expert.c
@@ -58,7 +58,7 @@ int main(void) {
         snprintf(detail, sizeof(detail),
                  "expert %d starts at row %d and holds %d rows, expected %d and %d",
                  e, got, slice.rows, want, rows_each);
-        check("packed slice starts at the right row", ok, ok ? NULL : detail);
+        check("packed slice has the right base and height", ok, ok ? NULL : detail);
     }
 
     /* Expanded: the same shape as floats, each row holding its own index. */
@@ -83,7 +83,7 @@ int main(void) {
         snprintf(detail, sizeof(detail),
                  "expert %d starts at row %d and holds %d rows, expected %d and %d",
                  e, got, slice.rows, want, rows_each);
-        check("f32 slice starts at the right row", ok, ok ? NULL : detail);
+        check("f32 slice has the right base and height", ok, ok ? NULL : detail);
     }
 
     /* What must be refused. A slice past the end would read somebody else's memory, and a


### PR DESCRIPTION
…emory

-r N runs one prompt N times in a single process, and before each run the harness prints how much of itself is resident and how much the machine has free. The load happens once, so what is timed is the model running rather than the model arriving; the residency line is there because on a phone those two numbers decide the result more than the arithmetic does.

Both exist because a measurement was worthless and had already been written down. OLMoE is 3.66 GB on a machine with 7.6, and the same binary on the same file gave 6.7 t/s and 18.8 within one afternoon, the difference being whether 1.2 GB happened to be free. On that basis this log carried "16.5 t/s, 77 percent of the reference" and a profile putting 62 percent of decode in the expert matmuls. Both are withdrawn, and three explanations built on them go with them: that the gap lived in 384 dispatches per token, that gathering the chosen experts into one call was worth 21 percent, and that scattered expert reads cost twice what contiguous ones do. The first was contradicted by a bench on the same shapes, the second measured adjacent experts which routing never produces, and the third rested on two runs where six repeats of the same command gave 13.2 to 15.2 GiB/s.

What replaces them, warm, with residency printed beside each line: run 1 at 2.86 GiB resident decodes 7.9 t/s; runs 3 through 6 at 3.17 GiB decode 18.4, 18.1, 18.4, 18.2. Two percent apart. Against llama-bench at -t 4 on the same file, 24.30 +/- 0.19, that is 75 percent, and now both sides are warm — the earlier comparison was not, since llama-bench loads once and iterates while a fresh harness process faults in 3.66 GB first.

The warm profile is a different picture: FFN 61.2 percent, qkv+bias 16.1, head 11.8. The FFN reads 453 MB a token in 29.9 ms, 14.8 GiB/s, which matches a standalone bench of the same shapes — the expert matmuls run at the rate this machine gives and hold no mystery.

One finding is left deliberately unused, with its number in the source beside the code that does not use it. The block holding the router took 26.7 percent of decode for seven percent of the bytes, because ffn_gate_inp is this family's one f32 weight and f32 misses the integer kernel's dot instruction. Packing it to Q8_0 at load is worth about nine percent, 18.6 to 20.5 t/s, and breaks parity on one prompt in three: routing is discrete, a small numeric change reorders neighbouring scores, a different eight of sixty-four run. The reference routes in f32. Trading that for nine percent is a decision to make out loud rather than a side effect.

Two hypotheses died on the way and are recorded for the next person who has them: the router is not slow because of a BLAS call — qmv sends an f32 weight to notorch's own pooled matvec, not to sgemm — and replacing it with a hand-rolled f32 dot loop is slower still, because that trades four threads and a vector unit for one of each.

Also from review: a check labelled "starts at the right row" whose predicate also tested the row count, so a slice with the right base and the wrong height failed under a label that never mentioned height.

Gates: 15 green, tokenizer identical on 24, llama and olmoe parity identical on three prompts each, sanitizer clean.

Quote: "Time present and time past are both perhaps present in time future." — T.S. Eliot
Method: the Method measured twice and said which time it meant.

By Arianna Method (Co-authored by Claude, Defender) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff