### PR TITLE
arch-resonance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,12 +203,12 @@ llama: examples/infer_llama.c examples/bpe.c examples/bpe.h gguf.c gguf.h notorc
 # One binary, one command: ./notorch model.gguf "prompt". Architectures are a
 # table in harness/main.c; adding a family adds a file, not a branch.
 
-HARNESS_SRC = harness/main.c harness/runtime.c harness/arch_llama.c harness/arch_gemma4.c harness/arch_olmoe.c examples/bpe.c gguf.c notorch.c
+HARNESS_SRC = harness/main.c harness/runtime.c harness/arch_llama.c harness/arch_gemma4.c harness/arch_olmoe.c harness/arch_resonance.c examples/bpe.c gguf.c notorch.c
 HARNESS_HDR = harness/arch.h harness/runtime.h harness/logo.h examples/bpe.h gguf.h notorch.h
 
 # `harness` is phony because a directory of that name sits right there, and
 # make would otherwise call it up to date and build nothing.
-.PHONY: harness test_harness
+.PHONY: harness test_harness test_resonance
 
 harness: notorch
 
@@ -220,6 +220,11 @@ notorch: $(HARNESS_SRC) $(HARNESS_HDR)
 # nothing. MODEL= to point it at one file, otherwise it looks for its defaults.
 test_harness: notorch llama
 	./harness/test_parity.sh $(MODEL)
+
+# Resonance against the forward it was ported from. The reference stays in
+# arianna.c; what lives here is its answer, frozen in tests/resonance_golden_v3.txt.
+test_resonance:
+	./harness/test_resonance.sh $(MODEL)
 
 # Tokenizer ids against llama.cpp's, which is the only definition of a tokenizer being
 # right. Skips itself where llama-tokenize is not installed. MODEL= to aim it.

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,74 @@ Newest entries on top.
 
 ---
 
+## 2026-09-10 — Resonance comes home, and the file's shapes are written backwards
+
+`harness/arch_resonance.c` runs Resonance 200M — E=768, H=12, D=64, FFN=2048,
+V=16384, 20 blocks, ctx 2048, rrpram_rank 48. It is the Method's own
+architecture and the first one here that was already running somewhere else:
+the forward has lived in `arianna.c/tools/resonance_forward.h`, behind an AML
+program, since long before this harness existed.
+
+A block runs two attentions over one set of values. The first is the ordinary
+content attention. The second, RRPRAM, never looks at a key: it maps the
+normalised input through a learned low-rank basis, `temp[r] = Σ_e xn[e]·wr_a[h,e,r]`,
+and scores position *j* against a second learned basis, `Σ_r temp[r]·wr_b[h,r,j]`.
+One is addressed by content and the other by position, over the same V, and a
+per-head sigmoid decides the mix. The second basis carries the context length
+in its shape — `wr_b` is [H, R, T] — so past T the model has no basis at all.
+
+**The port was wrong and the gate said where.** Not the architecture: the
+shapes. This file writes `ne` outer dimension first, the reverse of the ggml
+convention `wt_load` reads. `mlp.w_gate.weight` is `ne=[2048,768]` where a
+llama-family file would write `ne=[768,2048]`, and `wr_a` is `ne=[12,768,48]`,
+which only reads as [H,E,R] outer-first. Square matrices hide it completely —
+`wq/wk/wv/wo` come out identical either way — and every other tensor comes out
+transposed, which is fluent, confident, wrong text. The shapes now come from
+the architecture's own config, the way the reference always took them; the
+dtype still comes from the file.
+
+Finding it took a bisection rather than a reading. Position 0 was the lever:
+there the softmax is over one score, so both attentions reduce to V exactly and
+the blend is V whatever the gate says, and RoPE at pos 0 is the identity. That
+left embedding, norms, projections and MLP — and the residual stream matched
+bit for bit at the entry to block 0 and differed by 4.39 at block 1, so the
+fault was inside one block with two thirds of it already excluded. Dumping the
+blend narrowed it to what came after.
+
+**What the comparison measures now.** Logits, not text, against the reference
+forward built standalone against this tree: at one position the two agree bit
+for bit, 0.000e+00 across all 16384; from two positions on, 1.3e-05 to 1.8e-05
+absolute against a mean |logit| of 1.589. That residue is named rather than
+tolerated — rebuilding the port with `-U__ARM_NEON` gives 0.000e+00 at two,
+three and twelve positions, so it is exactly the four-lane accumulation in
+`dot_f32`/`axpy_f32` against the reference's scalar loops. Twenty greedy tokens
+are identical: "The field is not a fixed point, but a living field where every
+wave is a wave in the air, a".
+
+Red hand on both halves of the block, and the second one is why this gate reads
+logits. Swapping content and rrpram inside the per-head gate moves the argmax
+from 432 to 262 and the logits by 4.8. Transposing `wr_a` **leaves the argmax at
+432** and moves the logits by 5.6 — a text comparison would have called that a
+pass. `harness/test_resonance.sh` holds the reference's eight largest logits in
+`tests/resonance_golden_v3.txt` at a 1e-3 tolerance, and reads 4.29e-06.
+
+Adding the family needed no change to `harness/runtime.c` or to the interface —
+one file, one line in the table, and one local loader that overrides the shape
+convention for this file.
+
+Still open, and it is what stops this being finished: **the GGUF carries no
+tokenizer.** No `tokenizer.ggml.tokens`, no merges, no scores — 243 tensors and
+eleven architecture keys. The vocabulary lives in `arianna.c`'s source as 16128
+integer merge pairs, so neither this harness nor llama.cpp can read the file on
+its own, and the gate above had to be driven by ids. The canonical tokenizer on
+the Hub confirms what those integers mean: all 16128 merge pairs match its
+string pairs exactly, and its `idmap` shows the model's id space is byte-order
+— id *i* is byte *i*, id 256+*k* is merge *k* — while the Hub's JSON is in
+`tokenizers`' own codepoint-rank order. Baking the vocabulary into a copy of
+the file, in byte-order, is the next piece.
+
+---
+
 ## 2026-09-09 — Q4_K keeps four running sums, and stops being the slow format
 
 Q4_K read 13.0 GiB/s where Q4_0 read 17.3 on identical byte counts — 144 bytes per 256 values

--- a/harness/arch.h
+++ b/harness/arch.h
@@ -34,5 +34,6 @@ typedef struct {
 extern const nt_arch nt_arch_llama;
 extern const nt_arch nt_arch_gemma4;
 extern const nt_arch nt_arch_olmoe;
+extern const nt_arch nt_arch_resonance;
 
 #endif

--- a/harness/arch_resonance.c
+++ b/harness/arch_resonance.c
@@ -1,0 +1,366 @@
+/* arch_resonance.c — Resonance, the Method's own architecture.
+ *
+ * A block runs two attentions over one set of values. The first is the usual
+ * content attention, Q·Kᵀ/√D. The second — RRPRAM — does not look at keys at
+ * all: it maps the normalised input through a learned low-rank basis,
+ * temp[r] = Σ_e xn[e]·wr_a[h,e,r], and scores position j by that against a
+ * second learned basis, Σ_r temp[r]·wr_b[h,r,j]. One is addressed by content,
+ * the other by position, and a per-head sigmoid decides how much of each:
+ * g·content + (1−g)·rrpram.
+ *
+ * That second basis carries the context length in its shape — wr_b is
+ * [H, R, T] — so the model has no basis at all past T positions. T is read off
+ * the file and announced; it is not a soft limit.
+ *
+ * Ported from ~/arianna-shared/arianna.c/tools/resonance_forward.h. Equality
+ * with that forward is the goal and not an assumption: nothing in this file
+ * establishes it, and the gate that does is separate from it.
+ *
+ * Tensor names are the training graph's own (transformer.h.N.attn.wq.weight),
+ * not the llama convention, which is what an architecture table is for. */
+#include "harness/arch.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+typedef struct {
+    int vocab, embed, heads, head_dim, blocks, ffn, ctx, rank;
+
+    gguf_file *gf;
+    float *tok_emb;          /* [vocab, embed] — dense, one row per token */
+    float *norm_f;
+    wt out_head;
+
+    struct {
+        float *norm1, *norm2;
+        float *wr_a;         /* [H, E, R] */
+        float *wr_b;         /* [H, R, T] */
+        float *gate;         /* [H] */
+        wt wq, wk, wv, wo;
+        wt mlp_gate, mlp_up, mlp_down;
+    } b[64];
+} resonance_model;
+
+/* eps and rope base are constants of this architecture rather than metadata:
+ * the training graph hard-codes both, and the file carries neither. */
+#define RES_EPS       1e-5f
+#define RES_ROPE_BASE 10000.0f
+
+static void rmsnorm_p(float *o, const float *x, const float *w, int n) {
+    float ss = 0;
+    for (int i = 0; i < n; i++) ss += x[i] * x[i];
+    float inv = 1.0f / sqrtf(ss / n + RES_EPS);
+    for (int i = 0; i < n; i++) o[i] = x[i] * inv * w[i];
+}
+
+/* Pairs (2i, 2i+1) rotate together — the older of the two conventions, and the
+ * one the training graph applies. */
+static void rope_even_odd(float *q, float *k, int pos, int dim) {
+    int n_pairs = dim / 2;
+    for (int i = 0; i < n_pairs; i++) {
+        float freq = 1.0f / powf(RES_ROPE_BASE, (float)(2 * i) / (float)dim);
+        float val = pos * freq;
+        float cs = cosf(val), sn = sinf(val);
+        float qe = q[2*i], qo = q[2*i + 1];
+        float ke = k[2*i], ko = k[2*i + 1];
+        q[2*i]     = qe * cs - qo * sn;
+        q[2*i + 1] = qe * sn + qo * cs;
+        k[2*i]     = ke * cs - ko * sn;
+        k[2*i + 1] = ke * sn + ko * cs;
+    }
+}
+
+static float siluf(float x) { return x > -20 ? x / (1 + expf(-x)) : 0; }
+static float sigmoidf_(float x) { return 1.0f / (1.0f + expf(-x)); }
+
+/* This file writes its tensor shapes outer dimension first, which is the
+ * reverse of the ggml convention wt_load reads: mlp.w_gate.weight is
+ * ne=[2048,768] where a llama-family file would write ne=[768,2048], and
+ * wr_a is ne=[12,768,48] which only reads as [H,E,R] outer-first. Square
+ * matrices hide it — wq/wk/wv/wo come out identical either way — and every
+ * other one comes out transposed, which is fluent, wrong text.
+ *
+ * So the shape comes from the architecture here and not from the file. The
+ * dtype probe is still the file's answer: ask the two entry points whether
+ * they take this tensor rather than assuming F16 forever. */
+static int packed(wt *w, gguf_file *gf, const char *name, int rows, int cols) {
+    int ti = gguf_find_tensor(gf, name);
+    if (ti < 0) { fprintf(stderr, "resonance: tensor '%s' missing\n", name); return 0; }
+    const gguf_tensor_info *t = &gf->tensors[ti];
+    if (t->n_elements != (uint64_t)rows * (uint64_t)cols) {
+        fprintf(stderr, "resonance: '%s' has %llu elements, arch says %dx%d\n",
+                name, (unsigned long long)t->n_elements, rows, cols);
+        return 0;
+    }
+    w->rows = rows;
+    w->cols = cols;
+    w->dtype = (int)t->dtype;
+    w->q = gf->data + t->offset;
+    w->f32 = NULL;
+    float *probe = (float*)calloc(cols, sizeof(float));
+    float out = 0.0f;
+    if (probe) {
+        w->use_i8 = (nt_qmatvec_i8(&out, w->q, w->dtype, probe, 1, cols) == 0);
+        if (!w->use_i8 && nt_qmatvec(&out, w->q, w->dtype, probe, 1, cols) != 0) {
+            w->q = NULL;
+            w->f32 = gguf_dequant(gf, ti);
+        }
+        free(probe);
+    }
+    return (w->q || w->f32) ? 1 : 0;
+}
+
+static float *dense(gguf_file *gf, const char *name) {
+    int ti = gguf_find_tensor(gf, name);
+    if (ti < 0) { fprintf(stderr, "resonance: tensor '%s' missing\n", name); return NULL; }
+    float *p = gguf_dequant(gf, ti);
+    if (!p) fprintf(stderr, "resonance: dequant '%s' failed\n", name);
+    return p;
+}
+
+static void *resonance_load(gguf_file *gf, nt_dims *dims) {
+    resonance_model *m = (resonance_model*)calloc(1, sizeof(resonance_model));
+    if (!m) return NULL;
+
+    int ok = 1;
+#define KV(key, tgt) do { \
+        const gguf_kv *kv = gguf_get_kv(gf, key); \
+        if (!kv) { fprintf(stderr, "resonance: missing kv '%s'\n", key); ok = 0; } \
+        else tgt = (int)kv->val.u32; \
+    } while (0)
+    KV("resonance.vocab_size",           m->vocab);
+    KV("resonance.embedding_length",     m->embed);
+    KV("resonance.attention.head_count", m->heads);
+    KV("resonance.attention.head_dim",   m->head_dim);
+    KV("resonance.block_count",          m->blocks);
+    KV("resonance.feed_forward_length",  m->ffn);
+    KV("resonance.context_length",       m->ctx);
+    KV("resonance.rrpram_rank",          m->rank);
+#undef KV
+    if (!ok) { free(m); return NULL; }
+
+    /* H*D == E is not a convention here but an assumption the forward rests on:
+     * the KV rows are E wide and the blend runs over E, so a head layout that
+     * does not fill E would read past its own head. */
+    if (m->heads * m->head_dim != m->embed || m->blocks < 1 ||
+        m->blocks > (int)(sizeof(m->b) / sizeof(m->b[0]))) {
+        fprintf(stderr, "resonance: arch refused — V=%d E=%d H=%d D=%d B=%d M=%d T=%d R=%d\n",
+                m->vocab, m->embed, m->heads, m->head_dim, m->blocks, m->ffn, m->ctx, m->rank);
+        free(m);
+        return NULL;
+    }
+    fprintf(stderr, "resonance: E=%d H=%d D=%d FFN=%d V=%d B=%d ctx=%d rrpram_rank=%d\n",
+            m->embed, m->heads, m->head_dim, m->ffn, m->vocab, m->blocks, m->ctx, m->rank);
+
+    const int E = m->embed, FFN = m->ffn;
+    m->gf = gf;
+    m->tok_emb = dense(gf, "tok_emb");
+    m->norm_f  = dense(gf, "norm_f.weight");
+    if (!packed(&m->out_head, gf, "out_head.weight", m->vocab, E)) ok = 0;
+
+    char nm[128];
+    for (int l = 0; l < m->blocks && ok; l++) {
+        #define L(field, suffix) do { \
+            snprintf(nm, sizeof(nm), "transformer.h.%d." suffix, l); \
+            m->b[l].field = dense(gf, nm); \
+            if (!m->b[l].field) ok = 0; \
+        } while (0)
+        #define W(field, suffix, r, c) do { \
+            snprintf(nm, sizeof(nm), "transformer.h.%d." suffix, l); \
+            if (!packed(&m->b[l].field, gf, nm, (r), (c))) ok = 0; \
+        } while (0)
+        L(wr_a,     "attn.wr_a");
+        L(wr_b,     "attn.wr_b");
+        L(gate,     "attn.gate");
+        L(norm1,    "norm1.weight");
+        W(wq,       "attn.wq.weight",     E,   E);
+        W(wk,       "attn.wk.weight",     E,   E);
+        W(wv,       "attn.wv.weight",     E,   E);
+        W(wo,       "attn.wo.weight",     E,   E);
+        L(norm2,    "norm2.weight");
+        W(mlp_gate, "mlp.w_gate.weight",  FFN, E);
+        W(mlp_up,   "mlp.w_up.weight",    FFN, E);
+        W(mlp_down, "mlp.w_down.weight",  E,   FFN);
+        #undef L
+        #undef W
+    }
+
+    if (!ok || !m->tok_emb || !m->norm_f) {
+        fprintf(stderr, "resonance: missing critical weights\n");
+        free(m);
+        return NULL;
+    }
+
+    dims->n_layers = m->blocks;
+    dims->kv_dim   = m->embed;      /* K and V are stored whole, no GQA here */
+    dims->vocab    = m->vocab;
+    return m;
+}
+
+static void resonance_free(void *model) {
+    resonance_model *m = (resonance_model*)model;
+    if (!m) return;
+    free(m->tok_emb); free(m->norm_f); free(m->out_head.f32);
+    for (int l = 0; l < m->blocks; l++) {
+        free(m->b[l].norm1); free(m->b[l].norm2);
+        free(m->b[l].wr_a); free(m->b[l].wr_b); free(m->b[l].gate);
+        free(m->b[l].wq.f32); free(m->b[l].wk.f32);
+        free(m->b[l].wv.f32); free(m->b[l].wo.f32);
+        free(m->b[l].mlp_gate.f32); free(m->b[l].mlp_up.f32); free(m->b[l].mlp_down.f32);
+    }
+    free(m);
+}
+
+/* One position. Prefill calls this per row rather than in a batch: the two
+ * attentions read the cache row by row and the source forward is per-token, so
+ * a batched form would be a different summation order for no weight traffic
+ * saved — every matrix here is already read once per position. */
+static void resonance_step(resonance_model *m, kv_cache *kv, int tok, int pos,
+                           float *logits, float *scratch) {
+    const int E = m->embed, H = m->heads, D = m->head_dim;
+    const int FFN = m->ffn, R = m->rank, T = m->ctx;
+    const float sc = 1.0f / sqrtf((float)D);
+
+    float *x   = scratch;                 /* E       */
+    float *xn  = x + E;                   /* E       */
+    float *qa  = xn + E;                  /* E       */
+    float *ka  = qa + E;                  /* E       */
+    float *va  = ka + E;                  /* E       */
+    float *cot = va + E;                  /* E       */
+    float *rot = cot + E;                 /* E       */
+    float *bl_ = rot + E;                 /* E       */
+    float *ao  = bl_ + E;                 /* E       */
+    float *mg  = ao + E;                  /* FFN     */
+    float *mu  = mg + FFN;                /* FFN     */
+    float *mo  = mu + FFN;                /* E       */
+    float *att = mo + E;                  /* max_seq */
+    float *tmp = att + kv->max_seq;       /* R       */
+
+    double pft = pf_mark();
+    memcpy(x, m->tok_emb + (long)tok * E, E * sizeof(float));
+    pf_add(PF_EMBED, pft);
+
+    for (int l = 0; l < m->blocks; l++) {
+        pft = pf_mark();
+        rmsnorm_p(xn, x, m->b[l].norm1, E);
+        pf_add(PF_NORM, pft);
+
+        pft = pf_mark();
+        qmv(qa, &m->b[l].wq, xn);
+        qmv(ka, &m->b[l].wk, xn);
+        qmv(va, &m->b[l].wv, xn);
+        pf_add(PF_QKV, pft);
+
+        pft = pf_mark();
+        for (int h = 0; h < H; h++)
+            rope_even_odd(qa + h * D, ka + h * D, pos, D);
+        long base = (long)l * kv->max_seq * E;
+        memcpy(kv->k + base + (long)pos * E, ka, E * sizeof(float));
+        memcpy(kv->v + base + (long)pos * E, va, E * sizeof(float));
+        pf_add(PF_ROPE, pft);
+
+        pft = pf_mark();
+        /* content attention */
+        for (int h = 0; h < H; h++) {
+            const float *q_h = qa + h * D;
+            for (int j = 0; j <= pos; j++) {
+                const float *kj = kv->k + base + (long)j * E + h * D;
+                att[j] = dot_f32(q_h, kj, D) * sc;
+            }
+            softmax(att, pos + 1);
+            float *oh = cot + h * D;
+            memset(oh, 0, D * sizeof(float));
+            for (int j = 0; j <= pos; j++)
+                axpy_f32(oh, att[j], kv->v + base + (long)j * E + h * D, D);
+        }
+
+        /* RRPRAM: scored by position through a learned basis, over the same V */
+        for (int h = 0; h < H; h++) {
+            const float *wr_a_h = m->b[l].wr_a + (long)h * E * R;
+            const float *wr_b_h = m->b[l].wr_b + (long)h * R * T;
+            for (int r = 0; r < R; r++) {
+                float s = 0;
+                for (int e = 0; e < E; e++) s += xn[e] * wr_a_h[e * R + r];
+                tmp[r] = s;
+            }
+            for (int j = 0; j <= pos; j++) {
+                float s = 0;
+                for (int r = 0; r < R; r++) s += tmp[r] * wr_b_h[r * T + j];
+                att[j] = s * sc;
+            }
+            softmax(att, pos + 1);
+            float *oh = rot + h * D;
+            memset(oh, 0, D * sizeof(float));
+            for (int j = 0; j <= pos; j++)
+                axpy_f32(oh, att[j], kv->v + base + (long)j * E + h * D, D);
+        }
+
+        for (int h = 0; h < H; h++) {
+            float g = sigmoidf_(m->b[l].gate[h]);
+            for (int d = 0; d < D; d++)
+                bl_[h * D + d] = g * cot[h * D + d] + (1.0f - g) * rot[h * D + d];
+        }
+        pf_add(PF_ATTN, pft);
+
+        pft = pf_mark();
+        qmv(ao, &m->b[l].wo, bl_);
+        pf_add(PF_PROJ, pft);
+        pft = pf_mark();
+        for (int e = 0; e < E; e++) x[e] += ao[e];
+        pf_add(PF_RESID, pft);
+
+        pft = pf_mark();
+        rmsnorm_p(xn, x, m->b[l].norm2, E);
+        pf_add(PF_NORM, pft);
+        pft = pf_mark();
+        qmv(mg, &m->b[l].mlp_gate, xn);
+        qmv(mu, &m->b[l].mlp_up, xn);
+        pf_add(PF_FFN, pft);
+        pft = pf_mark();
+        for (int i = 0; i < FFN; i++) mg[i] = siluf(mg[i]) * mu[i];
+        pf_add(PF_SILU, pft);
+        pft = pf_mark();
+        qmv(mo, &m->b[l].mlp_down, mg);
+        pf_add(PF_FFN, pft);
+        pft = pf_mark();
+        for (int e = 0; e < E; e++) x[e] += mo[e];
+        pf_add(PF_RESID, pft);
+    }
+
+    if (logits) {
+        pft = pf_mark();
+        rmsnorm_p(xn, x, m->norm_f, E);
+        qmv(logits, &m->out_head, xn);
+        pf_add(PF_HEAD, pft);
+    }
+}
+
+static void resonance_forward(void *model, kv_cache *kv, const int *tokens, int n,
+                              int pos0, float *logits) {
+    resonance_model *m = (resonance_model*)model;
+    /* Ten E-wide buffers (x, xn, q, k, v, content, rrpram, blend, proj, mlp-out),
+     * two FFN-wide, one score row per cached position, one rank row. Counting
+     * these wrong does not crash: the score row lands on top of the MLP output
+     * and the model answers with different tokens. */
+    size_t words = (size_t)m->embed * 10 + (size_t)m->ffn * 2
+                 + (size_t)kv->max_seq + (size_t)m->rank;
+    float *scratch = (float*)malloc(words * sizeof(float));
+    if (!scratch) return;
+    for (int j = 0; j < n; j++) {
+        int pos = pos0 + j;
+        if (pos >= kv->max_seq) break;
+        resonance_step(m, kv, tokens[j], pos,
+                       (logits && j == n - 1) ? logits : NULL, scratch);
+    }
+    free(scratch);
+}
+
+static const char *const RESONANCE_NAMES[] = { "resonance", NULL };
+
+const nt_arch nt_arch_resonance = {
+    .names = RESONANCE_NAMES,
+    .load = resonance_load,
+    .free = resonance_free,
+    .forward = resonance_forward,
+};

--- a/harness/main.c
+++ b/harness/main.c
@@ -21,6 +21,7 @@
 static const nt_arch *const ARCHS[] = {
     &nt_arch_gemma4,
     &nt_arch_olmoe,
+    &nt_arch_resonance,
     &nt_arch_llama,
 };
 

--- a/harness/test_resonance.sh
+++ b/harness/test_resonance.sh
@@ -1,0 +1,55 @@
+#!/bin/sh
+# test_resonance.sh — the ported Resonance forward against the one it was
+# ported from.
+#
+# The reference is arianna.c's tools/resonance_forward.h, which lives in another
+# repository and stays there; what travels here is its answer.
+# tests/resonance_golden_v3.txt holds the eight largest logits of the last
+# position for a fixed prompt, and this recomputes them.
+#
+#   ./harness/test_resonance.sh [model.gguf]
+#
+# Without a model it says so and exits 0 — the weights are not in this tree.
+set -eu
+cd "$(dirname "$0")/.."
+
+MODEL="${1:-$HOME/arianna-shared/arianna.c/weights/arianna_resonance_v3_f16.gguf}"
+GOLDEN=tests/resonance_golden_v3.txt
+IDS="487 1955 306"
+TOL=1e-3
+
+if [ ! -f "$MODEL" ]; then
+  echo "resonance  (no model at $MODEL — pass one to run this gate)"
+  echo "RESONANCE_SKIPPED"
+  exit 0
+fi
+
+BIN=$(mktemp -t nt_res_parity)
+trap 'rm -f "$BIN" "$BIN.out"' EXIT
+${CC:-cc} -O2 -std=gnu11 -I. -DUSE_BLAS -DACCELERATE -DACCELERATE_NEW_LAPACK \
+  -framework Accelerate -o "$BIN" \
+  tests/test_resonance_parity.c harness/arch_resonance.c harness/runtime.c \
+  gguf.c notorch.c -lm 2>/dev/null \
+  || ${CC:-cc} -O2 -std=gnu11 -I. -o "$BIN" \
+       tests/test_resonance_parity.c harness/arch_resonance.c harness/runtime.c \
+       gguf.c notorch.c -lm
+
+# shellcheck disable=SC2086
+"$BIN" "$MODEL" $IDS > "$BIN.out" 2>/dev/null
+
+grep -v '^#' "$GOLDEN" | grep -v '^[[:space:]]*$' | while read -r id want; do
+  got=$(sed -n "$((id + 1))p" "$BIN.out")
+  echo "$id $want $got"
+done > "$BIN.cmp"
+
+awk -v tol="$TOL" '
+  { d = $2 - $3; if (d < 0) d = -d
+    printf "resonance  [id %-5s] golden %-12s got %-12s |diff|=%.3e  %s\n",
+           $1, $2, $3, d, (d <= tol ? "PASS" : "FAIL")
+    if (d > tol) fails++
+    if (d > worst) worst = d }
+  END {
+    printf "resonance  [worst] %.3e against a %s tolerance\n", worst, tol
+    print (fails ? "RESONANCE_FAIL" : "RESONANCE_OK")
+    exit (fails ? 1 : 0)
+  }' "$BIN.cmp"

--- a/tests/resonance_golden_v3.txt
+++ b/tests/resonance_golden_v3.txt
@@ -1,0 +1,25 @@
+# Resonance 200M — the reference forward's answer, frozen.
+#
+# Source: ~/arianna-shared/arianna.c/tools/resonance_forward.h, built standalone
+# against this tree's gguf.c and notorch.c, run on arianna_resonance_v3_f16.gguf
+# with token ids 487 1955 306 ("The field is" under the model's own BPE), one
+# position per call. These are the eight largest logits of the last position.
+#
+# Why a golden and not a live comparison: the reference lives in another
+# repository and does not belong in this one, so the number travels instead of
+# the code. Why logits and not the argmax: transposing wr_a leaves the argmax
+# at 432 and moves the logits by 5.6, which an argmax check would call a pass.
+#
+# Tolerance is 1e-3. Observed on this machine: 1.8e-05, which is the four-lane
+# accumulation in dot_f32/axpy_f32 against the reference's scalar loops —
+# building the port with -U__ARM_NEON reproduces the reference bit for bit.
+#
+# id  logit
+257 6.47917223
+262 5.55650806
+432 7.45756912
+495 5.420959
+1939 5.64419127
+4162 5.49557209
+8740 6.25333786
+9938 5.9127779

--- a/tests/test_resonance_parity.c
+++ b/tests/test_resonance_parity.c
@@ -1,0 +1,58 @@
+/* test_resonance_parity.c — the ported Resonance forward, in logits.
+ *
+ * The harness prints text, and text is a poor instrument for a port: an argmax
+ * hides how far apart two vectors are and says nothing about where they parted.
+ * This calls the architecture through its own table entry — the same entry
+ * `notorch` uses — and writes the last position's logits, one per line, in the
+ * same %.9g form the standalone reference writes them.
+ *
+ *   cc -O2 -I. -o test_resonance_parity tests/test_resonance_parity.c \
+ *      harness/arch_resonance.c harness/runtime.c gguf.c notorch.c -lm
+ *   ./test_resonance_parity model.gguf 487 1955 306 > port.txt
+ *   diff <(...) port.txt     # or the max-abs comparison in the harness gate
+ */
+#include "harness/arch.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+    if (argc < 3) {
+        fprintf(stderr, "usage: %s <model.gguf> <id> [id ...]\n", argv[0]);
+        return 1;
+    }
+    gguf_file *gf = gguf_open(argv[1]);
+    if (!gf) return 1;
+
+    nt_dims dims = {0};
+    void *model = nt_arch_resonance.load(gf, &dims);
+    if (!model) { gguf_close(gf); return 1; }
+
+    int n = argc - 2;
+    int *ids = (int*)malloc((size_t)n * sizeof(int));
+    for (int i = 0; i < n; i++) {
+        ids[i] = atoi(argv[2 + i]);
+        if (ids[i] < 0 || ids[i] >= dims.vocab) {
+            fprintf(stderr, "id %d out of vocab %d\n", ids[i], dims.vocab);
+            return 1;
+        }
+    }
+
+    /* One position per call, the way decode drives it, so this exercises the
+     * same path a generation does rather than a prefill-only shape. */
+    kv_cache *kv = kv_new(dims.n_layers, n + 1, dims.kv_dim);
+    float *logits = (float*)calloc(dims.vocab, sizeof(float));
+    for (int i = 0; i < n; i++)
+        nt_arch_resonance.forward(model, kv, &ids[i], 1, i, logits);
+
+    for (int i = 0; i < dims.vocab; i++) printf("%.9g\n", logits[i]);
+
+    int best = 0;
+    for (int i = 1; i < dims.vocab; i++) if (logits[i] > logits[best]) best = i;
+    fprintf(stderr, "port: argmax=%d logit=%.9g\n", best, logits[best]);
+
+    free(logits); free(ids);
+    kv_free(kv);
+    nt_arch_resonance.free(model);
+    gguf_close(gf);
+    return 0;
+}


### PR DESCRIPTION
`harness/arch_resonance.c` runs Resonance 200M — E=768, H=12, D=64, FFN=2048, V=16384, 20 blocks, ctx 2048, rrpram_rank 48. The Method's own architecture, and the first one here that was already running somewhere else: the forward has lived in `arianna.c/tools/resonance_forward.h`, behind an AML program, since before this harness existed.

**What the architecture does.** A block runs two attentions over one set of values. The first is ordinary content attention. The second — RRPRAM — never looks at a key: it maps the normalised input through a learned low-rank basis, `temp[r] = Σ_e xn[e]·wr_a[h,e,r]`, and scores position *j* against a second learned basis, `Σ_r temp[r]·wr_b[h,r,j]`. One addressed by content, one by position, over the same V, mixed by a per-head sigmoid. `wr_b` is [H, R, T], so past T the model has no basis at all — that is a hard ceiling, not a soft one.

**The port was wrong, and not in the architecture — in the shapes.** This file writes `ne` outer dimension first, the reverse of the ggml convention `wt_load` reads. `mlp.w_gate.weight` is `ne=[2048,768]` where a llama-family file writes `ne=[768,2048]`; `wr_a` is `ne=[12,768,48]`, which only reads as [H,E,R] outer-first. Square matrices hide it completely — `wq/wk/wv/wo` are identical either way — and every other tensor comes out transposed, which is fluent, confident, wrong text. Shapes now come from the architecture's own config, the way the reference always took them; the dtype still comes from the file.

Found by bisection, not by rereading. Position 0 excludes two thirds of the block: a softmax over one score makes both attentions the identity on V, the blend is V whatever the gate says, and RoPE at pos 0 is the identity. The residual stream matched bit for bit entering block 0 and differed by 4.39 entering block 1.

**What the comparison measures.** Logits, against the reference forward built standalone against this tree:

| positions | max abs diff |
|---|---|
| 1 | 0.000e+00 across all 16384 |
| 2, 3, 12 | 1.3e-05 – 1.8e-05, mean \|logit\| 1.589 |

The residue is named rather than tolerated: rebuilding the port with `-U__ARM_NEON` gives **0.000e+00** at two, three and twelve positions, so it is exactly the four-lane accumulation in `dot_f32`/`axpy_f32` against the reference's scalar loops. Twenty greedy tokens are identical — *"The field is not a fixed point, but a living field where every wave is a wave in the air, a"*.

**Red hand on both halves of the block, and the second one is why this gate reads logits.** Swapping content and rrpram inside the per-head gate moves the argmax 432 → 262 and the logits by 4.8. Transposing `wr_a` **leaves the argmax at 432** and moves the logits by 5.6 — a text comparison would have called that a pass.

`harness/test_resonance.sh` holds the reference's eight largest logits in `tests/resonance_golden_v3.txt` at a 1e-3 tolerance and reads 4.29e-06. The reference itself stays in `arianna.c`; what travels here is its answer.

Adding the family needed no change to `harness/runtime.c` and none to `nt_arch` — one file, one line in the table, one local loader that overrides the shape convention for this file. Third architecture, third time the interface held.

Gates: `RESONANCE_OK`, `NOTORCH_PARITY_OK`, notorch_test 49/49 and 73/73, test_qmatmul 34/34. `test_quantize` still fails Q8_0 at 2.081e-04 over its 2.067e-04 bound, unchanged since `cd659e8`.

**Open, and it is what stops this being finished:** the GGUF carries no tokenizer — 243 tensors, eleven architecture keys, no tokens, merges or scores. The vocabulary lives in `arianna.c`'s source as 16128 integer merge pairs, so neither this harness nor llama.cpp can read the file alone, and the gate above is driven by ids. The canonical tokenizer on the Hub confirms what those integers mean: all 16128 merge pairs match its string pairs exactly, and its idmap shows the model's id space is byte-order (id *i* = byte *i*, id 256+*k* = merge *k*) while the Hub's JSON is in `tokenizers`' codepoint-rank order. Baking the vocabulary into a copy of the file, in byte-order, is the next piece.