### PR TITLE
gguf-add-tokenizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,5 @@ test_qgather
 test_plan_race_tsan
 
 gguf_quantize
+gguf_add_tokenizer
 test_quantize

--- a/Makefile
+++ b/Makefile
@@ -226,6 +226,13 @@ test_harness: notorch llama
 test_resonance:
 	./harness/test_resonance.sh $(MODEL)
 
+# Write a byte-level BPE vocabulary into a GGUF that has none, so the file can
+# be read by something other than the program it was written for.
+#   make gguf_add_tokenizer && ./gguf_add_tokenizer in.gguf out.gguf merges
+gguf_add_tokenizer: tools/gguf_add_tokenizer.c gguf.c gguf.h
+	$(CC) $(CFLAGS) $(BLAS_FLAGS) -o gguf_add_tokenizer tools/gguf_add_tokenizer.c gguf.c notorch.c -lm $(BLAS_LIBS)
+	@echo "Compiled: gguf_add_tokenizer"
+
 # Tokenizer ids against llama.cpp's, which is the only definition of a tokenizer being
 # right. Skips itself where llama-tokenize is not installed. MODEL= to aim it.
 test_tokenizer: notorch

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,84 @@ Newest entries on top.
 
 ---
 
+## 2026-09-10 — the vocabulary goes into the file, and three things the gate found on the way
+
+`tools/gguf_add_tokenizer.c` writes a byte-level BPE vocabulary into a GGUF
+that has none. Resonance 200M was one: 243 tensors, eleven architecture keys,
+and a vocabulary that lived in its trainer's source as 16128 integer merge
+pairs — readable by the AML program it was written for and by nothing else.
+
+The integers are ids in the space the weights were trained in: id *i* is byte
+*i*, id 256+*k* is the *k*-th merge. GGUF wants strings, so each id is spelled
+in the GPT-2 byte-level alphabet and the merges are those spellings in pairs.
+Order is the weights' order, not the alphabet's: sorted differently, the
+tokenizer addresses different rows of the embedding table and the model answers
+fluently and wrongly.
+
+Nothing in the tensor data moves. The header is rewritten with three more keys,
+the existing keys are copied as bytes — `gguf_open` skips array-valued ones and
+cannot give them back — the tensor directory is re-emitted with its offsets
+unchanged, and the data section goes across whole. 398 408 608 bytes in,
+398 908 384 out.
+
+**The tool's own check caught the tool's first bug.** Reading "every integer in
+the file" is the obvious way to parse the merge list and the wrong one: the
+trainer's C header also states its vocabulary size and merge count in its
+`#define`s and comments, which added four pairs and made a vocabulary four rows
+longer than the model has. `resonance.vocab_size` in the file said 16384
+against the 16388 those merges produced, and the run stopped. Integers now
+count only inside brackets when the file brackets them.
+
+After: `make test_bpe` on the new file reads a byte-level scheme with 16384
+tokens and passes all seven round-trips, and `notorch <file> "The field is"`
+tokenizes, runs and prints *"not a fixed point, but a living field where every
+wave is a wave in the air, a"* — the same text the reference produces from ids,
+now from one file with nothing beside it.
+
+**Three findings, in falling order of how much they matter.**
+
+*The harness never prepends BOS.* Pointing `test_tokenizer.sh` at a
+SentencePiece model for the first time made it visible: on nano_arianna Q8_0
+the reference answers `1,338,3228,282,4135,313` where we answer
+`338,3228,282,4135,313`, and every id after the first is identical on all four
+texts that ran. The file carries no `add_bos_token` key and `bos_token_id = 1`;
+the reference's rule is the key when present and otherwise the tokenizer's
+default, which is true for llama/SPM and false for gpt2 — smallcoder-303M says
+`add_bos_token = false` explicitly, which is why byte-level models passed. So
+for most llama-family files the model has been receiving a prompt without the
+token it was trained to see. Not fixed here, and the reason is a fork rather
+than an omission: `examples/infer_llama.c` does not prepend either, so adding
+it breaks `test_parity.sh` by construction. The example is the wrong reference
+for this question and `llama-tokenize` is the right one, but retiring a frozen
+reference is a decision, not a patch.
+
+*`bpe_encode` splits on spaces where the reference applies a regex.* On
+smallcoder-303M, an indented multi-line text diverges at one position: ours
+`...711,203,264,442...` against theirs `...711,284,442...`, one of their tokens
+against two of ours, everything before and after identical. A newline followed
+by indentation is one merge in their pre-tokenizer and two symbols in ours.
+Seven of eight texts pass; this is the eighth. Same shape as the OLMoE
+added-token find — the gate was not weak in its texts, it was weak in its
+corpus, and Qwen and Gemma happen to split this text the same way we do.
+
+*llama.cpp cannot load `resonance` at all* — `unknown model architecture` — so
+parity against the reference engine is unavailable for the Method's own
+families by construction. It reads the file, reports its format and size, and
+stops at the architecture table. Worth knowing before a campaign that plans to
+hold llama.cpp beside every model: Resonance and Janus are measured against the
+Method's own forward, and only the standard families get Gerganov.
+
+**Three gate defects fixed in passing, all exposed by running it here.** A
+model the reference cannot load is now SKIPPED with the reason printed instead
+of reporting eight mismatches against an empty answer. Zero checks now report
+SKIPPED rather than a green with nothing behind it — the same lie as the red
+with nothing behind it. And the reference's output is read under `LC_ALL=C`,
+because the awk macOS ships aborts on a multibyte character it cannot convert
+and two of the gate's texts are Cyrillic and emoji; those two now compare and
+pass.
+
+---
+
 ## 2026-09-10 — Resonance comes home, and the file's shapes are written backwards
 
 `harness/arch_resonance.c` runs Resonance 200M — E=768, H=12, D=64, FFN=2048,

--- a/harness/test_tokenizer.sh
+++ b/harness/test_tokenizer.sh
@@ -68,9 +68,21 @@ FAILS=0
 CHECKS=0
 for M in $MODELS; do
   NAME=$(basename "$M")
+  # The reference loads the whole model to reach its vocabulary, so a family it
+  # does not implement — resonance, for one — leaves it with nothing to say. A
+  # gate with no reference has not failed, it has not run, and reporting eight
+  # mismatches against an empty answer would be a red light meaning nothing.
+  if ! "$REF" -m "$M" -p "x" >/dev/null 2>&1; then
+    WHY=$("$REF" -m "$M" -p "x" 2>&1 | grep -m1 -i "error" || echo "the reference could not load it")
+    echo "tokenizer  [$NAME] SKIPPED — $WHY"
+    continue
+  fi
   for P in "$@"; do
     OURS=$(./notorch -T "$M" "$P" 2>/dev/null)
-    THEIRS=$("$REF" -m "$M" -p "$P" 2>/dev/null | awk -F" -> " 'NF>1 { gsub(/[^0-9]/, "", $1); if ($1 != "") printf "%s%s", (n++ ? "," : ""), $1 } END { print "" }')
+    # LC_ALL=C because the awk that ships with macOS aborts on a multibyte
+    # character it cannot convert, and two of these texts are Cyrillic and
+    # emoji. The fields being read are digits either way.
+    THEIRS=$("$REF" -m "$M" -p "$P" 2>/dev/null | LC_ALL=C awk -F" -> " 'NF>1 { gsub(/[^0-9]/, "", $1); if ($1 != "") printf "%s%s", (n++ ? "," : ""), $1 } END { print "" }')
     CHECKS=$((CHECKS + 1))
     SHORT=$(printf '%s' "$P" | tr '\n' ' ' | cut -c1-40)
     if [ "$OURS" = "$THEIRS" ]; then
@@ -84,7 +96,11 @@ for M in $MODELS; do
   done
 done
 
-if [ "$FAILS" -eq 0 ]; then
+if [ "$CHECKS" -eq 0 ]; then
+  # Green with nothing behind it is the same lie as a red with nothing behind
+  # it: every model given was one the reference could not open.
+  echo "NOTORCH_TOKENIZER_SKIPPED (no model the reference could load)"
+elif [ "$FAILS" -eq 0 ]; then
   echo "NOTORCH_TOKENIZER_OK ($CHECKS checks)"
 else
   echo "NOTORCH_TOKENIZER_FAIL ($FAILS of $CHECKS)"

--- a/tools/gguf_add_tokenizer.c
+++ b/tools/gguf_add_tokenizer.c
@@ -1,0 +1,253 @@
+/* gguf_add_tokenizer.c — put a byte-level BPE vocabulary into a GGUF that has none.
+ *
+ * Some files carry weights and nothing else. Resonance 200M is one: 243 tensors,
+ * eleven architecture keys, and a vocabulary that lives in its trainer's source
+ * as integer merge pairs. A file like that cannot be read by anything but the
+ * program it was written for — not this harness, not llama.cpp — so the fix is
+ * to write the vocabulary into the file rather than teach every reader where
+ * else to look.
+ *
+ * The merge list is integers because that is the id space the weights were
+ * trained in: id i is byte i for i < 256, and id 256+k is the k-th merge. GGUF
+ * wants strings, so each id is spelled in the GPT-2 byte-level alphabet — the
+ * same table examples/bpe.c builds — and the merges are those spellings in
+ * pairs. The order is the weights' order and not the alphabet's: a tokenizer
+ * whose ids are sorted differently addresses different rows of the embedding
+ * and produces fluent nonsense.
+ *
+ *   gguf_add_tokenizer in.gguf out.gguf merges.txt
+ *
+ * merges.txt is any text holding the pairs as integers, two per merge, in
+ * order — a plain list or the C header the trainer emits both parse.
+ */
+#include "gguf.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+
+#define GGUF_ALIGN 32
+#define KV_STRING  8
+#define KV_ARRAY   9
+
+static int copy_range(FILE *in, FILE *out, uint64_t off, uint64_t len) {
+    if (fseek(in, (long)off, SEEK_SET) != 0) return -1;
+    char buf[1 << 16];
+    while (len) {
+        size_t want = len < sizeof(buf) ? (size_t)len : sizeof(buf);
+        if (fread(buf, 1, want, in) != want) return -1;
+        if (fwrite(buf, 1, want, out) != want) return -1;
+        len -= want;
+    }
+    return 0;
+}
+
+static int write_u32(FILE *f, uint32_t v) { return fwrite(&v, 4, 1, f) == 1 ? 0 : -1; }
+static int write_u64(FILE *f, uint64_t v) { return fwrite(&v, 8, 1, f) == 1 ? 0 : -1; }
+
+static int write_str(FILE *f, const char *s) {
+    uint64_t n = strlen(s);
+    if (write_u64(f, n)) return -1;
+    return fwrite(s, 1, (size_t)n, f) == n ? 0 : -1;
+}
+
+static int write_kv_str(FILE *f, const char *key, const char *val) {
+    if (write_str(f, key) || write_u32(f, KV_STRING)) return -1;
+    return write_str(f, val);
+}
+
+static int write_kv_str_array(FILE *f, const char *key, char **vals, uint64_t n) {
+    if (write_str(f, key) || write_u32(f, KV_ARRAY)) return -1;
+    if (write_u32(f, KV_STRING) || write_u64(f, n)) return -1;
+    for (uint64_t i = 0; i < n; i++) if (write_str(f, vals[i])) return -1;
+    return 0;
+}
+
+static int pad_to(FILE *f, uint64_t target) {
+    long pos = ftell(f);
+    if (pos < 0 || (uint64_t)pos > target) return -1;
+    static const char zeros[GGUF_ALIGN] = {0};
+    uint64_t need = target - (uint64_t)pos;
+    while (need) {
+        size_t want = need < sizeof(zeros) ? (size_t)need : sizeof(zeros);
+        if (fwrite(zeros, 1, want, f) != want) return -1;
+        need -= want;
+    }
+    return 0;
+}
+
+/* GPT-2 byte <-> unicode, the same construction as examples/bpe.c. Bytes that
+ * are not printable get a codepoint above 255 so that every token is a string
+ * with no whitespace or control characters in it. */
+static void byte_table(int cp[256]) {
+    int n = 0;
+    for (int b = 0; b < 256; b++) {
+        int printable = (b >= 33 && b <= 126) || (b >= 161 && b <= 172) || (b >= 174 && b <= 255);
+        cp[b] = printable ? b : (256 + n);
+        if (!printable) n++;
+    }
+}
+
+static int utf8_enc(int cp, char *out) {
+    if (cp < 0x80)  { out[0] = (char)cp; return 1; }
+    if (cp < 0x800) { out[0] = (char)(0xC0 | (cp >> 6)); out[1] = (char)(0x80 | (cp & 0x3F)); return 2; }
+    out[0] = (char)(0xE0 | (cp >> 12));
+    out[1] = (char)(0x80 | ((cp >> 6) & 0x3F));
+    out[2] = (char)(0x80 | (cp & 0x3F));
+    return 3;
+}
+
+/* The merge integers, in order.
+ *
+ * "Every number in the file" is the obvious reading and the wrong one: the
+ * trainer's C header also states its vocabulary size, its merge count and the
+ * model's size in its comments, and those four extra pairs make a vocabulary
+ * four rows longer than the model has. So when the file brackets its pairs —
+ * a C initialiser does — only what is inside a bracket counts, and a bare list
+ * with no brackets is read whole. */
+static int *read_ints(const char *path, int *out_n) {
+    FILE *f = fopen(path, "rb");
+    if (!f) { fprintf(stderr, "cannot open %s\n", path); return NULL; }
+    int braced = 0;
+    for (int c; (c = fgetc(f)) != EOF; ) if (c == '{') { braced = 1; break; }
+    rewind(f);
+
+    int cap = 4096, n = 0, depth = 0;
+    int *v = (int *)malloc((size_t)cap * sizeof(int));
+    if (!v) { fclose(f); return NULL; }
+    int c, cur = 0, in_num = 0;
+    while ((c = fgetc(f)) != EOF) {
+        if (c == '{') { depth++; continue; }
+        if (c == '}') { if (depth) depth--; }
+        if (isdigit(c) && (!braced || depth)) { cur = cur * 10 + (c - '0'); in_num = 1; continue; }
+        if (in_num) {
+            if (n == cap) {
+                cap *= 2;
+                int *g = (int *)realloc(v, (size_t)cap * sizeof(int));
+                if (!g) { free(v); fclose(f); return NULL; }
+                v = g;
+            }
+            v[n++] = cur; cur = 0; in_num = 0;
+        }
+    }
+    if (in_num && n < cap) v[n++] = cur;
+    fclose(f);
+    *out_n = n;
+    return v;
+}
+
+int main(int argc, char **argv) {
+    if (argc < 4) {
+        fprintf(stderr, "usage: %s <in.gguf> <out.gguf> <merges>\n", argv[0]);
+        return 1;
+    }
+    gguf_file *gf = gguf_open(argv[1]);
+    if (!gf) return 1;
+
+    if (gguf_get_kv(gf, "tokenizer.ggml.tokens")) {
+        fprintf(stderr, "%s already carries a tokenizer — refusing to write a second one\n", argv[1]);
+        gguf_close(gf);
+        return 1;
+    }
+
+    int nint = 0;
+    int *ints = read_ints(argv[3], &nint);
+    if (!ints) { gguf_close(gf); return 1; }
+    int n_merges = nint / 2;
+    if (nint % 2) {
+        fprintf(stderr, "%s holds %d integers, which is not whole merge pairs\n", argv[3], nint);
+        return 1;
+    }
+    int n_vocab = 256 + n_merges;
+    printf("merges: %d  vocab: %d\n", n_merges, n_vocab);
+
+    /* If the file says how large its vocabulary is, that is the check on the
+     * merge list: the wrong list produces a tokenizer that indexes rows the
+     * model does not have. */
+    for (int i = 0; i < gf->n_kv_parsed; i++) {
+        if (strstr(gf->kv[i].key, ".vocab_size")) {
+            int want = (int)gf->kv[i].val.u32;
+            if (want != n_vocab) {
+                fprintf(stderr, "%s says vocab_size=%d, these merges make %d\n",
+                        gf->kv[i].key, want, n_vocab);
+                return 1;
+            }
+            printf("checked against %s = %d\n", gf->kv[i].key, want);
+        }
+    }
+
+    int cp[256];
+    byte_table(cp);
+    char **tok = (char **)calloc((size_t)n_vocab, sizeof(char *));
+    if (!tok) return 1;
+    for (int b = 0; b < 256; b++) {
+        char buf[8];
+        int n = utf8_enc(cp[b], buf);
+        buf[n] = 0;
+        tok[b] = strdup(buf);
+        if (!tok[b]) return 1;
+    }
+    char **merge_str = (char **)calloc((size_t)(n_merges ? n_merges : 1), sizeof(char *));
+    if (!merge_str) return 1;
+    for (int k = 0; k < n_merges; k++) {
+        int a = ints[2 * k], b = ints[2 * k + 1];
+        if (a < 0 || b < 0 || a >= 256 + k || b >= 256 + k) {
+            fprintf(stderr, "merge %d refers to id %d,%d which does not exist yet\n", k, a, b);
+            return 1;
+        }
+        size_t la = strlen(tok[a]), lb = strlen(tok[b]);
+        tok[256 + k] = (char *)malloc(la + lb + 1);
+        merge_str[k] = (char *)malloc(la + lb + 2);
+        if (!tok[256 + k] || !merge_str[k]) return 1;
+        memcpy(tok[256 + k], tok[a], la);
+        memcpy(tok[256 + k] + la, tok[b], lb + 1);
+        memcpy(merge_str[k], tok[a], la);
+        merge_str[k][la] = ' ';
+        memcpy(merge_str[k] + la + 1, tok[b], lb + 1);
+    }
+
+    FILE *in = fopen(argv[1], "rb");
+    FILE *out = fopen(argv[2], "wb");
+    if (!in || !out) { fprintf(stderr, "cannot open files\n"); return 1; }
+
+    /* Header by hand because the key count changes; the keys themselves are
+     * copied as bytes, since gguf_open skips array-valued ones and cannot give
+     * them back. */
+    if (write_u32(out, GGUF_MAGIC) || write_u32(out, gf->version) ||
+        write_u64(out, gf->n_tensors) || write_u64(out, gf->n_kv + 3)) return 1;
+    const uint64_t HDR = 24;
+    if (copy_range(in, out, HDR, gf->kv_end - HDR)) {
+        fprintf(stderr, "metadata copy failed\n"); return 1;
+    }
+    if (write_kv_str(out, "tokenizer.ggml.model", "gpt2") ||
+        write_kv_str_array(out, "tokenizer.ggml.tokens", tok, (uint64_t)n_vocab) ||
+        write_kv_str_array(out, "tokenizer.ggml.merges", merge_str, (uint64_t)n_merges)) {
+        fprintf(stderr, "tokenizer write failed\n"); return 1;
+    }
+
+    for (uint64_t i = 0; i < gf->n_tensors; i++) {
+        const gguf_tensor_info *t = &gf->tensors[i];
+        if (write_str(out, t->name) || write_u32(out, t->ndim)) return 1;
+        for (uint32_t d = 0; d < t->ndim; d++) if (write_u64(out, t->shape[d])) return 1;
+        if (write_u32(out, t->dtype) || write_u64(out, t->offset)) return 1;
+    }
+
+    long dir_end = ftell(out);
+    if (dir_end < 0) return 1;
+    uint64_t data_start = ((uint64_t)dir_end + GGUF_ALIGN - 1) & ~(uint64_t)(GGUF_ALIGN - 1);
+    if (pad_to(out, data_start)) return 1;
+
+    /* Tensor offsets are relative to the data section, so the section moving
+     * changes nothing inside it and it goes across whole. */
+    uint64_t data_len = gf->data_size;
+    if (fwrite(gf->data, 1, (size_t)data_len, out) != (size_t)data_len) {
+        fprintf(stderr, "data copy failed\n"); return 1;
+    }
+
+    fclose(in);
+    fclose(out);
+    printf("wrote %s — tokenizer.ggml.{model,tokens,merges} added, %llu tensors untouched\n",
+           argv[2], (unsigned long long)gf->n_tensors);
+    gguf_close(gf);
+    return 0;
+}


### PR DESCRIPTION
`tools/gguf_add_tokenizer.c` writes a byte-level BPE vocabulary into a GGUF that has none.

Resonance 200M was one: 243 tensors, eleven architecture keys, and a vocabulary that lived in its trainer's source as 16128 integer merge pairs — readable by the AML program it was written for and by nothing else. That is why the Resonance gate in #65 had to be driven by ids.

**What the integers mean.** They are ids in the space the weights were trained in: id *i* is byte *i*, id 256+*k* is the *k*-th merge. GGUF wants strings, so each id is spelled in the GPT-2 byte-level alphabet and the merges are those spellings in pairs. The order is the weights' order and not the alphabet's — sorted differently, the tokenizer addresses different rows of the embedding table and the model answers fluently and wrongly. (The Hub's canonical `tokenizer.json` is in `tokenizers`' codepoint-rank order; its own idmap is the permutation between the two.)

Nothing in the tensor data moves. The header is rewritten with three more keys, existing keys are copied as bytes — `gguf_open` skips array-valued ones and cannot give them back — the tensor directory is re-emitted with offsets unchanged, and the data section goes across whole. 398 408 608 bytes in, 398 908 384 out.

**The tool's own check caught the tool's first bug.** Reading "every integer in the file" is the obvious parse and the wrong one: the trainer's C header states its vocabulary size and merge count in its `#define`s and comments, which added four pairs and made a vocabulary four rows longer than the model has. `resonance.vocab_size` said 16384 against the 16388 those merges produced, and the run stopped. Integers now count only inside brackets when the file brackets them.

After: `make test_bpe` on the new file reads a byte-level scheme with 16384 tokens and passes all seven round-trips, and `notorch <file> "The field is"` tokenizes, runs and prints *"not a fixed point, but a living field where every wave is a wave in the air, a"* — the same text the reference produces from ids, now from one file with nothing beside it.

---

**Three findings, reported and not fixed.**

**1. The harness never prepends BOS.** Pointing `test_tokenizer.sh` at a SentencePiece model for the first time made it visible — on nano_arianna Q8_0:

```
theirs: 1,338,3228,282,4135,313
ours:     338,3228,282,4135,313
```

Every id after the first is identical, on all four texts that ran. The file carries no `add_bos_token` key and `bos_token_id = 1`; the reference's rule is the key when present and otherwise the tokenizer's default — true for llama/SPM, false for gpt2 — and smallcoder-303M says `add_bos_token = false` explicitly, which is why byte-level models passed all along. So for most llama-family files the model has been receiving a prompt without the token it was trained to see.

Not fixed here because it is a fork, not an omission: `examples/infer_llama.c` does not prepend either, so adding BOS breaks `test_parity.sh` by construction. The example is the wrong reference for this question and `llama-tokenize` is the right one — but retiring a frozen reference is a decision, not a patch.

**2. `bpe_encode` splits on spaces where the reference applies a regex.** On smallcoder-303M an indented multi-line text diverges at one position: ours `...711,203,264,442...` against theirs `...711,284,442...` — one of their tokens against two of ours, everything before and after identical. A newline followed by indentation is one merge in their pre-tokenizer and two symbols in ours. Seven of eight texts pass; this is the eighth. Same shape as the OLMoE added-token find: the gate was not weak in its texts, it was weak in its corpus.

**3. llama.cpp cannot load `resonance` at all** — `unknown model architecture` — so parity against the reference engine is unavailable for the Method's own families by construction. It reads the file, reports format and size, and stops at the architecture table. Worth knowing before a campaign that plans to keep llama.cpp beside every model.

---

**Three gate defects fixed in passing, all exposed by running it here.** A model the reference cannot load is now SKIPPED with the reason printed, instead of reporting eight mismatches against an empty answer. Zero checks now report SKIPPED rather than a green with nothing behind it — the same lie as a red with nothing behind it. And the reference's output is read under `LC_ALL=C`, because the awk macOS ships aborts on a multibyte character it cannot convert and two of the gate's texts are Cyrillic and emoji; those two now compare and pass.

Gates: `BPE_OK` on the new file, `RESONANCE_OK`, `NOTORCH_PARITY_OK`, notorch_test 49/49 and 73/73, test_qmatmul 34/34. `test_quantize` still fails Q8_0 at 2.081e-04 over its 2.067e-04 bound, unchanged since `cd659e8`.