### PR TITLE
tokenizer-bos

### DIFF
--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,52 @@ Newest entries on top.
 
 ---
 
+## 2026-09-10 — the opening token, and the default that was costing a model its voice
+
+The harness prepended a beginning-of-text token for Gemma 4 and for nothing else. The
+other two encoders — SentencePiece and byte-level — did not read the key at all, so on
+a llama-family file the model was reading a prompt whose first position was not the one
+it was trained to see. `llama-tokenize` on nano_arianna Q8_0 answered
+`1,338,3228,282,4135,313` where this answered `338,3228,282,4135,313`, every id after
+the first identical, on all four texts that ran.
+
+**The obvious fix was wrong and the model said so.** Following the reference — prepend
+for SentencePiece when the file does not declare — gave, at temp 0 on the same prompt,
+`the pain,  there there there there there there there` where the same model without a
+prepended `<s>` says `the cathedral of the French language, the most important document
+in the world.` "Resonance is" degenerated to whitespace. Three prompts, three
+degenerations. This model was not trained with an opening marker, and the file does not
+record that.
+
+**So the rule is the file, and silence means nothing rather than a guess.** Every
+foreign model on this machine states the key outright: Ministral-3-3B `true`,
+Qwen3.5-0.8B, Qwen3-4B, smallcoder-303M, wtforacle and doe-coder all `false`. The only
+file that omits it is one of ours. Ministral is the one that matters twice, because it
+is a *byte-level* file that wants the marker — so "byte-level means no BOS" is not a
+safe default either. The key is the answer; the scheme is not.
+
+Gemma 4 keeps its default of one, because that default was measured rather than assumed:
+without the marker it answers a different question. That is a statement about that
+family and it does not spread.
+
+Where that leaves the gate, across four families: nano_arianna 8 of 8, Qwen3 8 of 8,
+**Ministral 8 of 8** — the last is the check on the other half of the rule, a foreign
+file that declares `true`, now prepended and identical to the reference. smallcoder
+stays at 7 of 8 on the pre-tokenizer split already recorded below, unchanged by any of
+this.
+
+The disagreement that remains is declared rather than hidden. `notorch -T` says on
+stderr whether the file asked, and the gate prints `identical after the reference's
+undeclared bos 1` instead of either a green that conceals a difference or a red for a
+question the file never answered.
+
+And the fork this looked like it needed did not exist: the fix landed in
+`examples/bpe.c`, which `examples/infer_llama.c` shares, so the example prepends where
+the file asks too and `test_parity.sh` stays green — no second reference, no third
+binary, and the runs made through the example get the same correction.
+
+---
+
 ## 2026-09-10 — the vocabulary goes into the file, and three things the gate found on the way
 
 `tools/gguf_add_tokenizer.c` writes a byte-level BPE vocabulary into a GGUF

--- a/examples/bpe.c
+++ b/examples/bpe.c
@@ -100,7 +100,7 @@ struct bpe_tokenizer {
      * carries twenty-five of these and they are all whitespace runs. */
     int *added_id;      /* ids, longest string first */
     int n_added;
-    int add_bos, bos_id;
+    int add_bos, bos_id, bos_declared;
 };
 
 /* U+2581 LOWER ONE EIGHTH BLOCK — SentencePiece's space. */
@@ -200,15 +200,52 @@ bpe_tokenizer *bpe_load(const char *path) {
             snprintf(name, sizeof(name), "<0x%02X>", b);
             t->byte_id[b] = smap_get(&t->vocab, name);
         }
-        /* This family always opens with <bos>, and the file says so rather than the code
-         * assuming it. Getting it wrong costs more than a token: Gemma without its opening
-         * marker answers a different question. */
+    }
+
+    /* Whether a sequence opens with a beginning-of-text token, for every scheme and not
+     * just for the one that noticed first.
+     *
+     * The rule is: the file decides, and when the file declines to say, nothing is
+     * prepended. That is deliberately not what the reference does — it falls back to a
+     * default per tokenizer kind, true for SentencePiece — and the reason is measured
+     * rather than preferred. Every foreign model on this machine states the key outright:
+     * Ministral-3-3B says true, Qwen3.5-0.8B, Qwen3-4B, smallcoder-303M, wtforacle and
+     * doe-coder all say false. Ministral is the one that matters twice, because it is a
+     * byte-level file that wants an opening marker — so "byte-level means no BOS" is not
+     * a safe default either. The key is the answer; the scheme is not.
+     *
+     * The only file here that omits the key is one of ours, and it demonstrably was not
+     * trained with one: nano_arianna Q8_0 at temp 0 answers "the cathedral of the French
+     * language, the most important document in the world" without a prepended <s>, and
+     * "the pain, there there there there" with one. "Resonance is" degenerates to
+     * whitespace. Guessing on this file's behalf costs the model its voice, and the
+     * reference's guess is the one that costs it.
+     *
+     * So a file that says nothing gets nothing, and the disagreement with llama-tokenize
+     * that follows is a disagreement about a question the file did not answer. */
+    {
         uint64_t v = 0;
-        t->bos_id = (gguf_read_uint_kv(path, "tokenizer.ggml.bos_token_id", &v) == 0) ? (int)v : 2;
-        t->add_bos = (gguf_read_uint_kv(path, "tokenizer.ggml.add_bos_token", &v) == 0) ? (int)v : 1;
+        t->bos_declared = (gguf_read_uint_kv(path, "tokenizer.ggml.add_bos_token", &v) == 0);
+        /* One family keeps a default, and it keeps it because somebody measured it rather
+         * than assumed it: Gemma 4 without its opening marker answers a different question.
+         * That is a statement about that family, not about SentencePiece at large, so it
+         * does not spread to the file above it. */
+        t->add_bos = t->bos_declared ? (int)v : (t->spm_bpe ? 1 : 0);
+        uint64_t b = 0;
+        t->bos_id = (gguf_read_uint_kv(path, "tokenizer.ggml.bos_token_id", &b) == 0)
+                  ? (int)b : (t->spm_bpe ? 2 : 1);
+        if (t->add_bos && (t->bos_id < 0 || t->bos_id >= t->n_tokens)) {
+            fprintf(stderr, "bpe: bos id %d is outside a %d-token vocabulary — not prepending\n",
+                    t->bos_id, t->n_tokens);
+            t->add_bos = 0;
+        }
     }
     return t;
 }
+
+int bpe_add_bos(const bpe_tokenizer *t)      { return t ? t->add_bos : 0; }
+int bpe_bos_id(const bpe_tokenizer *t)       { return t ? t->bos_id : -1; }
+int bpe_bos_declared(const bpe_tokenizer *t) { return t ? t->bos_declared : 0; }
 
 void bpe_free(bpe_tokenizer *t) {
     if (!t) return;
@@ -304,6 +341,7 @@ static int spm_encode(const bpe_tokenizer *t, const char *text, int *out, int ca
     #undef PAIR
 
     int no = 0;
+    if (t->add_bos && no < cap) out[no++] = t->bos_id;
     for (int i = 0; i >= 0 && no < cap; i = nxt[i]) {
         memcpy(tmp, buf + off[i], (size_t)len[i]);
         tmp[len[i]] = 0;
@@ -417,13 +455,18 @@ int bpe_encode(const bpe_tokenizer *t, const char *text, int *out, int cap) {
     if (t && t->spm_bpe) return spm_bpe_encode(t, text, out, cap);
     if (t && t->spm) return spm_encode(t, text, out, cap);
     if (!t) return 0;               /* the span path reads t->byte_cp on its first line */
-    if (t->n_added <= 0) return bpe_encode_span(t, text, (int)strlen(text), out, cap);
+    /* Byte-level vocabularies usually say add_bos_token = false and this is a no-op; the
+     * ones that ask for it get it here, once, before any span is merged. */
+    int bos = (t->add_bos && cap > 0) ? 1 : 0;
+    if (bos) out[0] = t->bos_id;
+    if (t->n_added <= 0)
+        return bos + bpe_encode_span(t, text, (int)strlen(text), out + bos, cap - bos);
 
     /* Added tokens are matched against the raw text first, longest at each position, and the
      * merge path only ever sees what lies between them. Doing it the other way round cannot
      * work: these tokens are stored as literal bytes, so no sequence of merges over the
      * byte-level alphabet will ever spell one. */
-    int no = 0, L = (int)strlen(text), i = 0, gap = 0;
+    int no = bos, L = (int)strlen(text), i = 0, gap = 0;
     while (i < L) {
         int hit = -1, hlen = 0;
         for (int a = 0; a < t->n_added; a++) {

--- a/examples/bpe.h
+++ b/examples/bpe.h
@@ -32,6 +32,13 @@ int bpe_encode(const bpe_tokenizer *t, const char *text, int *out_ids, int cap);
  * Returns bytes appended. */
 int bpe_decode_token(const bpe_tokenizer *t, int id, char *buf, int cap);
 
+/* Whether a sequence opens with a beginning-of-text token, which one, and whether the
+ * file said so at all. A file that does not declare it gets nothing prepended — see the
+ * note in bpe.c for why that differs from the reference on purpose. */
+int bpe_add_bos(const bpe_tokenizer *t);
+int bpe_bos_id(const bpe_tokenizer *t);
+int bpe_bos_declared(const bpe_tokenizer *t);
+
 /* id of an exact token string (e.g. "<|im_start|>"), or -1 if absent. */
 int bpe_token_id(const bpe_tokenizer *t, const char *token);
 

--- a/harness/main.c
+++ b/harness/main.c
@@ -281,6 +281,15 @@ int main(int argc, char **argv) {
         int n = bpe_encode(tok, text, ids, (int)(sizeof(ids) / sizeof(ids[0])));
         for (int i = 0; i < n; i++) printf("%d%s", ids[i], i + 1 < n ? "," : "\n");
         if (n == 0) printf("\n");
+        /* On stderr, so the ids on stdout stay a bare list: whether this file asked for an
+         * opening token. A file that does not declare one is where we part from the
+         * reference on purpose, and a gate comparing the two needs to be told which case
+         * it is looking at rather than guessing from a length difference. */
+        if (bpe_bos_declared(tok))
+            fprintf(stderr, "bos: %d (the file asks for %s)\n",
+                    bpe_bos_id(tok), bpe_add_bos(tok) ? "one" : "none");
+        else
+            fprintf(stderr, "bos: undeclared (the file does not say; nothing prepended)\n");
         bpe_free(tok);
         return 0;
     }

--- a/harness/test_tokenizer.sh
+++ b/harness/test_tokenizer.sh
@@ -77,6 +77,8 @@ for M in $MODELS; do
     echo "tokenizer  [$NAME] SKIPPED — $WHY"
     continue
   fi
+  BOS_UNDECLARED=0
+  ./notorch -T "$M" "x" 2>&1 >/dev/null | grep -q "bos: undeclared" && BOS_UNDECLARED=1
   for P in "$@"; do
     OURS=$(./notorch -T "$M" "$P" 2>/dev/null)
     # LC_ALL=C because the awk that ships with macOS aborts on a multibyte
@@ -87,6 +89,12 @@ for M in $MODELS; do
     SHORT=$(printf '%s' "$P" | tr '\n' ' ' | cut -c1-40)
     if [ "$OURS" = "$THEIRS" ]; then
       echo "tokenizer  [$NAME] \"$SHORT\"  $(printf '%s' "$OURS" | tr ',' '\n' | grep -c .) ids  identical  PASS"
+    elif [ "$BOS_UNDECLARED" = "1" ] && [ "$THEIRS" = "${THEIRS%%,*},$OURS" ]; then
+      # The file does not say whether it wants an opening token; the reference assumes one
+      # for SentencePiece and we assume nothing (examples/bpe.c says why, with the text it
+      # costs). So one leading id and an otherwise identical list is the disagreement we
+      # chose, and it is named here rather than hidden or reported as a fault.
+      echo "tokenizer  [$NAME] \"$SHORT\"  identical after the reference's undeclared bos ${THEIRS%%,*}  PASS"
     else
       echo "tokenizer  [$NAME] \"$SHORT\"  FAIL"
       echo "  ours:   $OURS"


### PR DESCRIPTION
Finding (1) from #66 — the opening token — now fixed, and fixed differently from how I proposed it there.

**What was wrong.** The harness prepended a beginning-of-text token for Gemma 4 and for nothing else: the SentencePiece and byte-level encoders never read the key. So on a llama-family file the model read a prompt whose first position was not the one it was trained to see. `llama-tokenize` on nano_arianna Q8_0 answers `1,338,3228,282,4135,313` where this answered `338,3228,282,4135,313` — every id after the first identical, on all four texts that ran.

**The obvious fix was wrong and the model said so.** Following the reference — prepend for SentencePiece when the file does not declare — gives, at temp 0 on the same prompt:

> the pain,  there there there there there there there

where the same model without a prepended `<s>` says

> the cathedral of the French language, the most important document in the world.

"Resonance is" degenerated to whitespace. Three prompts, three degenerations. This model was not trained with an opening marker, and the file does not record that.

**So the rule is the file, and silence means nothing rather than a guess.**

| model | `tokenizer.ggml.model` | `add_bos_token` |
|---|---|---|
| Ministral-3-3B | gpt2 | **true** |
| Qwen3.5-0.8B | gpt2 | false |
| Qwen3-4B | gpt2 | false |
| smallcoder-303M | gpt2 | false |
| wtforacle v4 | gpt2 | false |
| doe-coder | gpt2 | false |
| nano_arianna | llama | **absent** |

Every foreign model states it outright; the only file that omits it is one of ours. Ministral matters twice, because it is a byte-level file that *wants* the marker — so "byte-level means no BOS" is not a safe default either. The key is the answer; the scheme is not.

Gemma 4 keeps its default of one, because that default was measured rather than assumed — without the marker it answers a different question. That is a statement about that family and it does not spread to the rule above it.

**Gate across four families:** nano_arianna 8 of 8, Qwen3 8 of 8, **Ministral 8 of 8** — the last is the check on the other half of the rule, a foreign file declaring `true`, now prepended and identical to the reference. smallcoder stays 7 of 8 on the pre-tokenizer split from finding (2) in #66, untouched by this.

The disagreement that remains is declared rather than hidden. `notorch -T` reports on stderr whether the file asked, and the gate prints `identical after the reference's undeclared bos 1` instead of either a green that conceals a difference or a red for a question the file never answered.

**And the fork this looked like it needed did not exist.** The fix is in `examples/bpe.c`, which `examples/infer_llama.c` shares — so the example prepends where the file asks too, `test_parity.sh` stays green, and the runs made through the example get the same correction. No second reference, no third binary, no `infer_notorch`.

Gates: `NOTORCH_PARITY_OK`, `RESONANCE_OK`, `BPE_OK`, notorch_test 49/49 and 73/73, test_qmatmul 34/34. `test_quantize` still fails Q8_0 at 2.081e-04 over its 2.067e-04 bound, unchanged since `cd659e8`.