### PR TITLE
the method vectorized the format that had never been optimized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,7 @@ bench_dtype
 check_requant
 test_wt_expert
 test_qgather
+test_f16_matvec
 test_plan_race_tsan
 
 gguf_quantize

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ SIMD_LIBS  = -lpthread
 
 # ── Targets ──
 
-.PHONY: all test test_qpool test_qmatvec_leak test_affinity test_plan_race test_tsan bench_claim test_wt_expert test_qgather test_js test_python test_tokenizer clean cpu gpu simd help lib shared install metal test_metal infer_gguf_metal
+.PHONY: all test test_qpool test_qmatvec_leak test_affinity test_plan_race test_tsan bench_claim test_wt_expert test_qgather test_f16_matvec test_js test_python test_tokenizer clean cpu gpu simd help lib shared install metal test_metal infer_gguf_metal
 
 all: notorch_test
 	@echo "Built with $(BLAS_NAME). Run: ./notorch_test"
@@ -369,6 +369,10 @@ test_qmatmul: tests/test_qmatmul.c notorch.c notorch.h
 	$(CC) $(CFLAGS) $(BLAS_FLAGS) -o test_qmatmul tests/test_qmatmul.c notorch.c -lm $(BLAS_LIBS)
 	@echo "Compiled: test_qmatmul (batched packed matmul vs per-token, $(BLAS_NAME))"
 
+test_f16_matvec: tests/test_f16_matvec.c notorch.c notorch.h
+	$(CC) $(CFLAGS) $(BLAS_FLAGS) -I. -o test_f16_matvec tests/test_f16_matvec.c notorch.c -lm $(BLAS_LIBS)
+	@echo "Compiled: test_f16_matvec (unpacked matvec against a double accumulation, $(BLAS_NAME))"
+
 test_qgather: tests/test_qgather.c notorch.c notorch.h
 	$(CC) $(CFLAGS) $(BLAS_FLAGS) -I. -o test_qgather tests/test_qgather.c notorch.c -lm $(BLAS_LIBS)
 	@echo "Compiled: test_qgather (gathered matvec against the loop, $(BLAS_NAME))"
@@ -413,7 +417,7 @@ test_affinity: tests/test_affinity.c notorch.c notorch.h
 	$(CC) $(CFLAGS) $(BLAS_FLAGS) -o test_affinity tests/test_affinity.c notorch.c -lm $(BLAS_LIBS)
 	@echo "Compiled: test_affinity (core selection on mixed-speed machines, $(BLAS_NAME))"
 
-test: notorch_test test_vision test_qpool test_qmatmul test_quantize test_qmatvec_leak test_affinity test_plan_race test_wt_expert test_qgather
+test: notorch_test test_vision test_qpool test_qmatmul test_quantize test_qmatvec_leak test_affinity test_plan_race test_wt_expert test_qgather test_f16_matvec
 	./notorch_test
 	./test_vision
 	./test_qpool
@@ -431,6 +435,7 @@ test: notorch_test test_vision test_qpool test_qmatmul test_quantize test_qmatve
 	./test_wt_expert
 	./test_qgather
 	NT_QMV_CHUNKS=1 ./test_qgather
+	./test_f16_matvec
 
 test_js:
 	node js-edition/test_op_parity.mjs

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -99,6 +99,60 @@ creating a second process for another agent.
 
 ---
 
+## 2026-09-11 — the format nobody optimized, because nobody ships it
+
+`nt_f16_rows` was a scalar loop over one half at a time, and so it read 9.02 GiB/s on
+[50304, 2048] where the Q8_0 kernel beside it read 18.90 — half the rate for the format that
+has the least to do, since f16 unpacks nothing. Eight halves a step through two FCVTLs and two
+f32 accumulators brings it to 17.92-18.74 across three runs, which is Q8_0's rate and therefore
+the machine's, so the matvec has nothing further to give. `taskset -c 4-7`, Exynos 1580,
+`make bench_dtype`.
+
+End to end on the two f16 files here, prompt and length fixed, four interleaved pairs of old
+binary against new so the machine's drift falls on both sides:
+
+    qwen05b_fp16.gguf   decode 8.1-8.4 -> 14.7-15.3 t/s    prefill 10.7-10.9 -> 19.3-20.7
+    mamba-130m-f16      decode 21.4-23.6 -> 39.2-40.0      prefill 24.7-30.3 -> 41.0-45.7
+
+Interleaving is not decoration. The first attempt at the qwen numbers ran all three old passes
+and then all three new ones, and reported the new kernel *slower* — 6.6 against 8.3 — with
+prefill swinging from 2106 ms to 734 ms inside one process. The file was 100 percent resident
+both times, checked with `mincore`, so the usual suspect was not it. Alternating the two
+binaries produced four consecutive agreeing pairs instead.
+
+Which leaves a fact about this machine worth writing down, because it will mislead the next
+person who looks: **load average here is permanently around 14 and means nothing.** Thirteen
+kernel threads — `tz_worker_thread/0` through `/7`, `ree_time`, `tz_iwlog_thread` and their
+neighbours — sit in uninterruptible sleep forever. Linux counts D state toward load, so the
+number reads as an overloaded machine while no core is contended.
+
+Why it matters beyond one format: f16 is what a model is before anybody quantizes it. Mamba's
+whole decode is f16 because that is the only checkpoint published, the first download of
+anything is f16, and a dtype with no packed kernel falls back to it.
+
+**The gate is new and the first two versions of it were worthless.** `tests/test_f16_matvec.c`
+compares against a double accumulation across every k from 1 to 40 — every remainder of the
+vector step several times over — plus long rows where a dropped tail would be a small fraction
+of the answer. Version one used tidy values on both sides: every partial sum was exact in f32
+and the worst error came out a clean zero for every k, which is not a strong result, it is a
+measurement that cannot see the thing that changed. Version two gave the activation a full
+mantissa and went red on correct code, because it normalised the error by the answer — and a
+dot product of 2048 signed terms cancels, so a sum of magnitude one over terms of magnitude
+one divides by nearly nothing. Normalised by the sum of the magnitudes it reports what it
+means. Red-hand: dropping the scalar tail turns 37 checks red and the binary returns 1;
+restoring it returns 0.
+
+The tolerance is one part in a hundred thousand, set by the machine without a vector path
+rather than this one — a serial sum of 2048 terms drifts by about the square root of that many
+epsilons. The vector path measures 2.5e-8 against it.
+
+`bench_dtype` grew F16 and F32 columns, which is how the gap was found in the first place.
+
+Gates: 17 suites green, tokenizer identical on 24, harness parity OK on Q4_0, and both f16
+models byte-identical to the reference on three prompts each.
+
+---
+
 ## 2026-09-11 — a family with no attention, and the interface holds a fifth time
 
 `harness/arch_mamba.c` runs Mamba. Everything this tree had run until now keeps a KV cache and

--- a/notorch.c
+++ b/notorch.c
@@ -5297,13 +5297,34 @@ static void nt_q6_k_rows(float *out, const uint8_t *W, const float *x,
 
 // F16: contiguous half weights — converted per element. Keeps weights at 2 B/param
 // (half the RAM of dense f32) without ever materializing a full f32 tensor.
+/* Eight halves a step, converted in two FCVTLs and accumulated in two f32 lanes. The scalar
+ * loop this replaces read 9.02 GiB/s on [50304, 2048] where Q8_0 beside it read 18.90 — half
+ * the rate for a format that does no unpacking at all, because a per-element __fp16 cast the
+ * compiler will not gather into FCVTL costs more than the four bits Q4_0 has to unpick. Every
+ * f16 file in the tree was paying that, and an f16 file is what a model looks like before
+ * anyone quantizes it: Mamba's whole decode is f16, and so is the first download of anything.
+ *
+ * Two accumulators rather than one because the sum is the dependency chain here, not the
+ * loads — and rather than four, because four measured the same and costs a wider tail. This
+ * is a different summation order from the scalar loop, so the last bit moves; the gate for
+ * that is tests/test_f16_matvec.c, which holds both orders and compares them. */
 static void nt_f16_rows(float *out, const uint8_t *W, const float *x,
                         int r0, int r1, int k) {
     const uint16_t *Wh = (const uint16_t *)W;
     for (int row = r0; row < r1; row++) {
         const uint16_t *r = Wh + (long)row * k;
         float acc = 0.0f;
-        for (int j = 0; j < k; j++) acc += nt_f16_to_f32(r[j]) * x[j];
+        int j = 0;
+#if defined(__aarch64__) && defined(__ARM_NEON)
+        float32x4_t a0 = vdupq_n_f32(0.0f), a1 = vdupq_n_f32(0.0f);
+        for (; j + 8 <= k; j += 8) {
+            float16x8_t h = vreinterpretq_f16_u16(vld1q_u16(r + j));
+            a0 = vfmaq_f32(a0, vcvt_f32_f16(vget_low_f16(h)),  vld1q_f32(x + j));
+            a1 = vfmaq_f32(a1, vcvt_f32_f16(vget_high_f16(h)), vld1q_f32(x + j + 4));
+        }
+        acc = vaddvq_f32(vaddq_f32(a0, a1));
+#endif
+        for (; j < k; j++) acc += nt_f16_to_f32(r[j]) * x[j];
         out[row] = acc;
     }
 }

--- a/tests/bench_dtype.c
+++ b/tests/bench_dtype.c
@@ -31,19 +31,39 @@
 #include "gguf.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 static double now(void){ struct timespec t; clock_gettime(CLOCK_MONOTONIC,&t);
     return (double)t.tv_sec*1e3 + (double)t.tv_nsec*1e-6; }
 static size_t rb_of(int d,int k){ switch(d){
+    case GGUF_TYPE_F32:  return (size_t)k*4;        case GGUF_TYPE_F16:  return (size_t)k*2;
     case GGUF_TYPE_Q4_0: return (size_t)(k/32)*18;  case GGUF_TYPE_Q5_0: return (size_t)(k/32)*22;
     case GGUF_TYPE_Q8_0: return (size_t)(k/32)*34;  case GGUF_TYPE_Q4_K: return (size_t)(k/256)*144;
     case GGUF_TYPE_Q6_K: return (size_t)(k/256)*210; default: return 0; } }
+
+/* The unpacked formats are not quantized, so they are written here rather than through
+ * nt_quantize_row, and they do not go through the i8 entry either — that one is for the
+ * packed dtypes and refuses these. Both differences are the reason they belong in this
+ * table: whatever the unpacked path costs, no packed measurement reveals it. */
+static int fill_plain(uint8_t *dst, const float *row, int k, int d) {
+    if (d == GGUF_TYPE_F32) { memcpy(dst, row, (size_t)k*4); return 1; }
+#if defined(__ARM_NEON) || defined(__FP16_VALUE__) || defined(__ARM_FP16_FORMAT_IEEE)
+    if (d == GGUF_TYPE_F16) {
+        __fp16 *h = (__fp16 *)dst;
+        for (int i = 0; i < k; i++) h[i] = (__fp16)row[i];
+        return 1;
+    }
+#endif
+    return 0;
+}
+static int is_plain(int d){ return d == GGUF_TYPE_F32 || d == GGUF_TYPE_F16; }
 int main(int argc, char **argv) {
     int rows = argc > 1 ? atoi(argv[1]) : 50304;   /* OLMoE vocab */
     int k    = argc > 2 ? atoi(argv[2]) : 2048;    /* n_embd */
     int reps = argc > 3 ? atoi(argv[3]) : 30;
-    int dts[] = { GGUF_TYPE_Q4_0, GGUF_TYPE_Q5_0, GGUF_TYPE_Q8_0, GGUF_TYPE_Q4_K, GGUF_TYPE_Q6_K };
-    const char *nm[] = { "Q4_0", "Q5_0", "Q8_0", "Q4_K", "Q6_K" };
+    int dts[] = { GGUF_TYPE_Q4_0, GGUF_TYPE_Q5_0, GGUF_TYPE_Q8_0, GGUF_TYPE_Q4_K, GGUF_TYPE_Q6_K,
+                  GGUF_TYPE_F16, GGUF_TYPE_F32 };
+    const char *nm[] = { "Q4_0", "Q5_0", "Q8_0", "Q4_K", "Q6_K", "F16", "F32" };
     float *x = malloc((size_t)k*sizeof(float)), *o = malloc((size_t)rows*sizeof(float));
     float *row = malloc((size_t)k*sizeof(float));
     for (int i=0;i<k;i++) x[i]=(float)((i%31)-15)*0.0625f;
@@ -53,15 +73,18 @@ int main(int argc, char **argv) {
         if (!rb) continue;
         uint8_t *W = malloc(rb*(size_t)rows);
         if (!W) { printf("  %s: no memory\n", nm[d]); continue; }
-        int ok = 1;
+        int ok = 1, plain = is_plain(dts[d]);
         for (long r = 0; r < rows && ok; r++) {
             for (int i=0;i<k;i++) row[i]=(float)(((r*7919+i*104729)%2001)-1000)/500.0f;
-            if (nt_quantize_row(row, W + rb*(size_t)r, k, dts[d]) != 0) ok = 0;
+            if (plain) ok = fill_plain(W + rb*(size_t)r, row, k, dts[d]);
+            else if (nt_quantize_row(row, W + rb*(size_t)r, k, dts[d]) != 0) ok = 0;
         }
         if (!ok) { printf("  %s: this build cannot pack it\n", nm[d]); free(W); continue; }
-        for (int r=0;r<3;r++) nt_qmatvec_i8(o,W,dts[d],x,rows,k);
+        for (int r=0;r<3;r++)
+            if (plain) nt_qmatvec(o,W,dts[d],x,rows,k); else nt_qmatvec_i8(o,W,dts[d],x,rows,k);
         double t0=now();
-        for (int r=0;r<reps;r++) nt_qmatvec_i8(o,W,dts[d],x,rows,k);
+        for (int r=0;r<reps;r++)
+            if (plain) nt_qmatvec(o,W,dts[d],x,rows,k); else nt_qmatvec_i8(o,W,dts[d],x,rows,k);
         double dt=now()-t0;
         double mib = (double)rb*rows/(1024.0*1024.0);
         printf("  %-5s %7.2f MiB  %6.2f ms/pass  %5.2f GiB/s\n",

--- a/tests/test_f16_matvec.c
+++ b/tests/test_f16_matvec.c
@@ -1,0 +1,200 @@
+/* test_f16_matvec.c — the unpacked formats, which had no gate until their kernels changed.
+ *
+ * F16 and F32 reach nt_qmatvec rather than the i8 entry, and every other dtype in this tree
+ * is covered by a test that the packed ones share. These two were not, which was survivable
+ * while both were a scalar loop over one element at a time and stopped being so the moment
+ * eight halves started moving at once.
+ *
+ * Two things a vector loop can get wrong and a scalar one cannot. The tail: a row whose
+ * length is not a multiple of the step has a remainder, and a kernel that drops it answers
+ * with a number rather than an error — so every k from 1 to 40 runs here, which covers every
+ * remainder of eight several times over, and 2048 plus a remainder covers the case where the
+ * vector body is long enough to hide a wrong tail in the noise. And the sum: partial
+ * accumulators reassociate the addition, so the last bit moves. That is allowed and it is
+ * measured rather than assumed — the reference here is a double accumulation, which both
+ * float orders approximate, and the check is on the distance to it.
+ *
+ * The reference is written out in this file instead of borrowed from the library, because a
+ * test that calls the code it is checking agrees with it however wrong it is.
+ */
+#include "notorch.h"
+#include "gguf.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+static int fails = 0;
+
+static void check(const char *what, int ok, const char *detail) {
+    printf("  %s %s%s%s\n", ok ? "PASS" : "FAIL", what, detail ? " — " : "", detail ? detail : "");
+    if (!ok) fails++;
+}
+
+/* IEEE half -> float, written here rather than taken from notorch.c for the reason above. */
+static float half_to_float(uint16_t h) {
+    uint32_t s = (h >> 15) & 1, e = (h >> 10) & 0x1F, m = h & 0x3FF, bits;
+    if (e == 0) {
+        if (m == 0) bits = s << 31;
+        else { e = 127 - 15 + 1; while (!(m & 0x400)) { m <<= 1; e--; } m &= 0x3FF;
+               bits = (s << 31) | (e << 23) | (m << 13); }
+    } else if (e == 0x1F) bits = (s << 31) | (0xFFu << 23) | (m << 13);
+    else bits = (s << 31) | ((e - 15 + 127) << 23) | (m << 13);
+    float f; memcpy(&f, &bits, 4); return f;
+}
+
+/* float -> IEEE half, round-to-nearest-even, for building the weights. The values below are
+ * chosen to be exactly representable, so this rounds nothing and a bug in it cannot pass for
+ * a bug in the kernel — but it is written correctly anyway, since the next person will widen
+ * the value range before they read this comment. */
+static uint16_t float_to_half(float f) {
+    uint32_t b; memcpy(&b, &f, 4);
+    uint32_t s = (b >> 16) & 0x8000;
+    int32_t  e = (int32_t)((b >> 23) & 0xFF) - 127 + 15;
+    uint32_t m = b & 0x7FFFFF;
+    if (e <= 0) return (uint16_t)s;                        /* underflow to zero: not exercised */
+    if (e >= 0x1F) return (uint16_t)(s | 0x7C00);
+    uint32_t h = s | ((uint32_t)e << 10) | (m >> 13);
+    uint32_t rem = m & 0x1FFF;
+    if (rem > 0x1000 || (rem == 0x1000 && (h & 1))) h++;
+    return (uint16_t)h;
+}
+
+/* A value that a half holds exactly: a small integer scaled by a power of two. Weights are
+ * built from these because the point of the test is the kernel, not float_to_half's rounding. */
+static float nice_value(long i) { return (float)((i % 61) - 30) * 0.125f; }
+
+/* The activation is the opposite: a full mantissa, and an exponent range wide enough that the
+ * products do not all land on the same scale. Without this the test passes trivially — the
+ * first version used tidy values on both sides, every partial sum was exact in f32, and the
+ * worst error came out as a clean zero for every k. Zero error is not a strong result here,
+ * it means the measurement cannot see reassociation at all, and reassociation is exactly what
+ * changed. With a ragged activation the two summation orders genuinely differ and the
+ * tolerance starts holding something. */
+static float ragged_value(long i) {
+    uint32_t s = (uint32_t)(i * 2654435761u + 12345u);
+    s ^= s >> 13; s *= 1274126177u; s ^= s >> 16;
+    float m = 1.0f + (float)(s & 0x7FFFFF) / (float)0x800000;   /* [1, 2) with every bit set */
+    int e = (int)((s >> 24) % 9) - 4;                            /* spread over 2^-4 .. 2^4 */
+    return ((s >> 23) & 1 ? -m : m) * ldexpf(1.0f, e);
+}
+
+static int run_f16(int rows, int k, double tol) {
+    uint16_t *W = (uint16_t *)malloc((size_t)rows * k * sizeof(uint16_t));
+    float *x = (float *)malloc((size_t)k * sizeof(float));
+    float *got = (float *)malloc((size_t)rows * sizeof(float));
+    if (!W || !x || !got) { free(W); free(x); free(got); printf("  FAIL out of memory\n"); fails++; return 0; }
+
+    for (long r = 0; r < rows; r++)
+        for (int j = 0; j < k; j++) W[r * k + j] = float_to_half(nice_value(r * 7 + j * 3));
+    for (int j = 0; j < k; j++) x[j] = ragged_value(j * 5 + 1);
+
+    char detail[224];
+    int rc = nt_qmatvec(got, (const uint8_t *)W, GGUF_TYPE_F16, x, rows, k);
+    if (rc != 0) {
+        snprintf(detail, sizeof(detail), "k=%d returned %d", k, rc);
+        check("f16 matvec takes the shape", 0, detail);
+        free(W); free(x); free(got); return 0;
+    }
+
+    /* Normalised by the sum of the magnitudes rather than by the answer. A dot product of
+     * signed terms cancels — 2048 products of size one can sum to 0.01 — and dividing the
+     * error by that near-zero reports a catastrophe where the arithmetic did nothing wrong.
+     * The first version of this test did exactly that and went red on the correct kernel.
+     * Against the magnitudes the number means what it is meant to: how much of the
+     * summation's own precision was lost. */
+    double worst = 0.0; int worst_row = -1;
+    for (long r = 0; r < rows; r++) {
+        double want = 0.0, mag = 0.0;
+        for (int j = 0; j < k; j++) {
+            double p = (double)half_to_float(W[r * k + j]) * (double)x[j];
+            want += p; mag += fabs(p);
+        }
+        double scale = mag > 1e-30 ? mag : 1.0;
+        double err = fabs((double)got[r] - want) / scale;
+        if (err > worst) { worst = err; worst_row = (int)r; }
+    }
+    snprintf(detail, sizeof(detail), "k=%d worst relative error %.3g at row %d, limit %.3g",
+             k, worst, worst_row, tol);
+    check("f16 matvec matches a double accumulation", worst <= tol, detail);
+
+    free(W); free(x); free(got);
+    return worst <= tol;
+}
+
+static int run_f32(int rows, int k, double tol) {
+    float *W = (float *)malloc((size_t)rows * k * sizeof(float));
+    float *x = (float *)malloc((size_t)k * sizeof(float));
+    float *got = (float *)malloc((size_t)rows * sizeof(float));
+    if (!W || !x || !got) { free(W); free(x); free(got); printf("  FAIL out of memory\n"); fails++; return 0; }
+
+    for (long r = 0; r < rows; r++)
+        for (int j = 0; j < k; j++) W[r * k + j] = ragged_value(r * 11 + j * 4);
+    for (int j = 0; j < k; j++) x[j] = ragged_value(j * 5 + 1);
+
+    char detail[224];
+    int rc = nt_qmatvec(got, (const uint8_t *)W, GGUF_TYPE_F32, x, rows, k);
+    if (rc != 0) {
+        snprintf(detail, sizeof(detail), "k=%d returned %d", k, rc);
+        check("f32 matvec takes the shape", 0, detail);
+        free(W); free(x); free(got); return 0;
+    }
+
+    double worst = 0.0;
+    for (long r = 0; r < rows; r++) {
+        double want = 0.0, mag = 0.0;
+        for (int j = 0; j < k; j++) {
+            double p = (double)W[r * k + j] * (double)x[j];
+            want += p; mag += fabs(p);
+        }
+        double scale = mag > 1e-30 ? mag : 1.0;
+        double err = fabs((double)got[r] - want) / scale;
+        if (err > worst) worst = err;
+    }
+    snprintf(detail, sizeof(detail), "k=%d worst relative error %.3g, limit %.3g", k, worst, tol);
+    check("f32 matvec matches a double accumulation", worst <= tol, detail);
+
+    free(W); free(x); free(got);
+    return worst <= tol;
+}
+
+int main(void) {
+    printf("unpacked matvec against a double accumulation\n");
+
+    /* Every remainder of the vector step, several times over, at a row count that crosses the
+     * threading floor in both directions so a threaded split is covered too. */
+    int worst_k = -1;
+    double tol = 1e-5;
+    for (int k = 1; k <= 40; k++) {
+        if (!run_f16(9, k, tol) && worst_k < 0) worst_k = k;
+    }
+    if (worst_k >= 0) printf("  first failing k was %d\n", worst_k);
+
+    /* A body long enough that a dropped tail is a small fraction of the answer — which is
+     * how a wrong tail survives a test that only looks at short rows. */
+    run_f16(64, 2048, 1e-5);
+    run_f16(64, 2048 + 1, 1e-5);
+    run_f16(64, 2048 + 7, 1e-5);
+    /* Above the threading floor: 64K elements is where nt_qmatvec starts splitting rows. */
+    run_f16(512, 2048, 1e-5);
+
+    /* Same limit for both, and it is set by the slowest machine rather than this one. Where
+     * there is no vector path the sum runs serially over every element, and a serial sum of
+     * 2048 terms drifts about the square root of that many epsilons — a few parts in a
+     * million. One part in a hundred thousand clears that everywhere and still sits three
+     * orders above what the vector path measures here, which is what a portable limit costs.
+     * The structural failures this is built to catch are not close to it: a dropped tail on
+     * the shapes below moves the answer by percent, not by parts per million. */
+    run_f32(9, 33, 1e-5);
+    run_f32(64, 2048 + 5, 1e-5);
+    run_f32(512, 2048, 1e-5);
+
+    /* What must be refused rather than answered. */
+    float out[4], x[8] = {0};
+    uint16_t w[32] = {0};
+    check("an unknown dtype is refused",
+          nt_qmatvec(out, (const uint8_t *)w, 99, x, 4, 8) != 0, NULL);
+
+    printf("\nResults: %s\n", fails ? "FAILED" : "all passed");
+    return fails ? 1 : 0;
+}


### PR DESCRIPTION
`nt_f16_rows` was a scalar loop over one half at a time. On `[50304, 2048]` it read **9.02 GiB/s** where the Q8_0 kernel beside it read **18.90** — half the rate for the format with the least to do, since f16 unpacks nothing at all. Eight halves a step through two FCVTLs and two f32 accumulators brings it to **17.92–18.74** across three runs, which is Q8_0's rate and therefore the machine's. The matvec has nothing further to give. `taskset -c 4-7`, Exynos 1580, `make bench_dtype`.

End to end on both f16 files here, prompt and length fixed, four interleaved pairs of old binary against new:

| file | decode | prefill |
|---|---|---|
| `qwen05b_fp16.gguf` | 8.1–8.4 → **14.7–15.3 t/s** | 10.7–10.9 → **19.3–20.7** |
| `mamba-130m-f16` | 21.4–23.6 → **39.2–40.0** | 24.7–30.3 → **41.0–45.7** |

**Interleaving is not decoration.** Run sequentially — three old passes then three new — the same binaries reported the new kernel *slower*, 6.6 against 8.3, with prefill swinging from 2106 ms to 734 ms inside one process. The file was 100 % resident both times, checked with `mincore`, so the usual suspect was not it. Alternating gave four consecutive agreeing pairs.

A fact about this machine that will mislead whoever looks next: **load average here is permanently ~14 and means nothing.** Thirteen kernel threads — `tz_worker_thread/0`…`/7`, `ree_time`, `tz_iwlog_thread` — sit in uninterruptible sleep forever, and Linux counts D state toward load.

Why this matters past one format: f16 is what a model is before anybody quantizes it. Mamba's whole decode is f16 because that is the only checkpoint published, the first download of anything is f16, and a dtype with no packed kernel falls back to it.

**The gate is new, and its first two versions were worthless.** `tests/test_f16_matvec.c` compares against a double accumulation across every k from 1 to 40 — every remainder of the vector step several times over — plus long rows where a dropped tail would be a small fraction of the answer. Version one used tidy values on both sides: every partial sum was exact in f32 and the worst error came out a clean zero for every k, which is a measurement that cannot see the thing that changed. Version two gave the activation a full mantissa and went red on correct code, because it divided the error by the answer — and a dot product of 2048 signed terms cancels, so it was dividing by nearly nothing. Normalised by the sum of the magnitudes it reports what it means. Red hand: dropping the scalar tail turns 37 checks red and the binary returns 1; restoring it returns 0.

The tolerance is 1e-5, set by the machine without a vector path rather than by this one — a serial sum of 2048 terms drifts by about √n epsilons. The vector path measures 2.5e-8 against it.

Gates: 17 suites green, tokenizer identical on 24, harness parity OK on Q4_0, and both f16 models byte-identical to the reference on three prompts each.

Still open, and a separate change: prefill. `qmm` for an unpacked dtype loops `qmv` per token and re-reads the whole model n times, where the reference reads it once — which is 45 t/s against 309 on mamba.