### PR TITLE
chat-template: the wrapping moves into the file

### DIFF
--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,48 @@ Newest entries on top.
 
 ---
 
+## 2026-09-12 — the wrapping moves into the file, and two guards that were never guarding
+
+`NT_CHAT` proved the mechanism and left the ids in the operator's hands, which is
+the wrong place for them: they belong to the weights. `tools/gguf_add_tokenizer`
+now takes `--chat "before|after|stop"` and writes `notorch.chat.{before,after,stop}`
+into the file as INT32 arrays, and the harness reads them when `NT_CHAT` is unset.
+The environment still wins when it is set, because trying a different wrapping is
+how the right one is found in the first place.
+
+Janus v4 Q8_0 with `32759,32760|32761,32762|32763` baked in, no environment at all,
+against the same weights driven by `NT_CHAT`: byte-identical continuation, the
+harness reporting `chat: 2 ids before, 2 after, 1 stop (file)` where the other says
+`(NT_CHAT)`. The file grew 128 bytes and kept all 247 tensors. The original, read
+with no environment, prints no `chat:` line at all.
+
+**Both refusals in that tool were decoration.** The guard against writing a second
+tokenizer and the guard against writing a second wrapping both asked `gguf_get_kv`,
+and `gguf_open` does not parse array-valued keys — so the table answers "absent"
+for a key that is sitting in the file. Writing twice produced a GGUF carrying
+`notorch.chat.before` twice, with no rule about which copy a reader takes. This was
+found by running the refusal rather than by reading it: `--chat` on an
+already-wrapped file returned 0 and wrote the file. Both guards now go through the
+path readers, `gguf_read_str_array` and `gguf_read_i32_array`, which do parse
+arrays. The second wrapping is refused; the second tokenizer is refused and now
+says how many tokens the file already has. The comment three lines below the dead
+guards had stated the reason the whole time — the fix is to read the comment next
+to the code you are trusting.
+
+A `--chat` id outside the vocabulary the file declares is refused at write time as
+well as at read time: `--chat "32759|99999|32763"` against a 32768-token Janus exits
+1 and writes nothing.
+
+Gates: `NOTORCH_PARITY_OK` on six checks, `JANUS_OK` worst 3.338e-05 against 1e-3
+plus 8 greedy tokens identical on both matvec paths, `RESONANCE_OK` worst 4.290e-06,
+`NOTORCH_TOKENIZER_OK` on 8 checks. Nothing moved for a file with no chat keys:
+nano_arianna Q8_0 still encodes `The capital of France is` to `338,3228,282,4135,313`
+and still answers `the cathedral of the French language, the most important document
+in the world.`
+
+---
+
+
 ## 2026-09-12 — a chat template made of ids, because the strings are not always there
 
 Some families were trained with the prompt wrapped in tokens of their own, and

--- a/harness/main.c
+++ b/harness/main.c
@@ -71,8 +71,10 @@ typedef struct {
  *   NT_CHAT="<before>|<after>|<stop>"   each a comma-separated id list
  *   NT_CHAT="32759,32760|32761,32762|32763"
  *
- * Fields may be empty. This is the mechanism; storing a file's own wrapping
- * inside the file, so that nobody has to type ids, is the step after it. */
+ * Fields may be empty. A file that carries its own wrapping needs none of this:
+ * notorch.chat.{before,after,stop} are read from the GGUF when NT_CHAT is unset,
+ * and tools/gguf_add_tokenizer --chat writes them. The environment still wins,
+ * because trying a different wrapping is how the right one gets found. */
 #define NT_CHAT_MAX 32
 
 typedef struct {
@@ -96,16 +98,37 @@ static int parse_ids(const char *s, int *out, int max) {
     return n;
 }
 
-static void chat_wrap_init(chat_wrap *w, int vocab) {
+static int chat_from_file(const char *path, const char *key, int *out, int cap) {
+    int n = 0;
+    int32_t *v = gguf_read_i32_array(path, key, &n);
+    if (!v) return 0;
+    if (n > cap) n = cap;
+    for (int i = 0; i < n; i++) out[i] = (int)v[i];
+    free(v);
+    return n;
+}
+
+static void chat_wrap_init(chat_wrap *w, int vocab, const char *path) {
     memset(w, 0, sizeof(*w));
     const char *spec = getenv("NT_CHAT");
-    if (!spec || !*spec) return;
-    const char *a = spec;
-    const char *b = strchr(a, '|');
-    const char *c = b ? strchr(b + 1, '|') : NULL;
-    w->n_before = parse_ids(a, w->before, NT_CHAT_MAX);
-    if (b) w->n_after = parse_ids(b + 1, w->after, NT_CHAT_MAX);
-    if (c) w->n_stop  = parse_ids(c + 1, w->stop,  NT_CHAT_MAX);
+    const char *src;
+    if (spec && *spec) {
+        const char *a = spec;
+        const char *b = strchr(a, '|');
+        const char *c = b ? strchr(b + 1, '|') : NULL;
+        w->n_before = parse_ids(a, w->before, NT_CHAT_MAX);
+        if (b) w->n_after = parse_ids(b + 1, w->after, NT_CHAT_MAX);
+        if (c) w->n_stop  = parse_ids(c + 1, w->stop,  NT_CHAT_MAX);
+        src = "NT_CHAT";
+    } else {
+        /* A family that was trained with a wrapping can carry it, and then
+         * nobody has to know the ids. The environment still wins, because
+         * trying a different wrapping is how the right one gets found. */
+        w->n_before = chat_from_file(path, "notorch.chat.before", w->before, NT_CHAT_MAX);
+        w->n_after  = chat_from_file(path, "notorch.chat.after",  w->after,  NT_CHAT_MAX);
+        w->n_stop   = chat_from_file(path, "notorch.chat.stop",   w->stop,   NT_CHAT_MAX);
+        src = "file";
+    }
     /* An id outside the vocabulary would index a row the model does not have,
      * so it is refused here rather than read as garbage in the embedding. */
     for (int i = 0; i < w->n_before; i++)
@@ -114,8 +137,8 @@ static void chat_wrap_init(chat_wrap *w, int vocab) {
         if (w->after[i] < 0 || w->after[i] >= vocab) { w->n_after = 0; break; }
     w->active = (w->n_before || w->n_after || w->n_stop);
     if (w->active)
-        fprintf(stderr, "chat: %d ids before, %d after, %d stop\n",
-                w->n_before, w->n_after, w->n_stop);
+        fprintf(stderr, "chat: %d ids before, %d after, %d stop (%s)\n",
+                w->n_before, w->n_after, w->n_stop, src);
 }
 
 /* Process-wide because it is read once from the environment and never varies
@@ -397,7 +420,7 @@ int main(int argc, char **argv) {
     fprintf(stderr, "loaded in %.0f ms\n", now_ms() - t0);
 
     session s = { .arch = arch, .model = model, .vocab = dims.vocab, .eos = -1 };
-    chat_wrap_init(&g_chat, dims.vocab);
+    chat_wrap_init(&g_chat, dims.vocab, path);
     s.tok = bpe_load(path);
     if (s.tok) {
         const gguf_kv *e = gguf_get_kv(gf, "tokenizer.ggml.eos_token_id");

--- a/tools/gguf_add_tokenizer.c
+++ b/tools/gguf_add_tokenizer.c
@@ -16,9 +16,15 @@
  * and produces fluent nonsense.
  *
  *   gguf_add_tokenizer in.gguf out.gguf merges.txt
+ *   gguf_add_tokenizer in.gguf out.gguf --chat "32759,32760|32761,32762|32763"
  *
  * merges.txt is any text holding the pairs as integers, two per merge, in
  * order — a plain list or the C header the trainer emits both parse.
+ *
+ * --chat writes the turn wrapping the family was trained with into the file, as
+ * notorch.chat.{before,after,stop}, so that the harness finds it there instead of
+ * being told through NT_CHAT. Ids and not strings, for the same reason the
+ * harness reads them that way: the strings that spell them may not exist.
  */
 #include "gguf.h"
 #include <stdio.h>
@@ -27,8 +33,31 @@
 #include <ctype.h>
 
 #define GGUF_ALIGN 32
+#define KV_INT32   5
 #define KV_STRING  8
 #define KV_ARRAY   9
+#define CHAT_MAX   32
+
+/* The wrapping a family expects around a turn, written into the file as ids so
+ * that nobody has to know them or type them. Ids and not strings for the same
+ * reason the harness reads them that way: the strings may not exist. Janus
+ * carries nine special ids above what its merge list reconstructs and only five
+ * are named anywhere, but all nine are perfectly good numbers. */
+typedef struct { int32_t v[CHAT_MAX]; int n; } chat_list;
+
+static int parse_chat_ids(const char *s, chat_list *out) {
+    out->n = 0;
+    for (const char *p = s; *p && *p != '|' && out->n < CHAT_MAX; ) {
+        while (*p == ' ' || *p == ',') p++;
+        if (!*p || *p == '|') break;
+        char *end = NULL;
+        long v = strtol(p, &end, 10);
+        if (end == p) return -1;
+        out->v[out->n++] = (int32_t)v;
+        p = end;
+    }
+    return 0;
+}
 
 static int copy_range(FILE *in, FILE *out, uint64_t off, uint64_t len) {
     if (fseek(in, (long)off, SEEK_SET) != 0) return -1;
@@ -61,6 +90,12 @@ static int write_kv_str_array(FILE *f, const char *key, char **vals, uint64_t n)
     if (write_u32(f, KV_STRING) || write_u64(f, n)) return -1;
     for (uint64_t i = 0; i < n; i++) if (write_str(f, vals[i])) return -1;
     return 0;
+}
+
+static int write_kv_i32_array(FILE *f, const char *key, const int32_t *v, uint64_t n) {
+    if (write_str(f, key) || write_u32(f, KV_ARRAY)) return -1;
+    if (write_u32(f, KV_INT32) || write_u64(f, n)) return -1;
+    return fwrite(v, sizeof(int32_t), (size_t)n, f) == n ? 0 : -1;
 }
 
 static int pad_to(FILE *f, uint64_t target) {
@@ -137,28 +172,77 @@ static int *read_ints(const char *path, int *out_n) {
 }
 
 int main(int argc, char **argv) {
-    if (argc < 4) {
-        fprintf(stderr, "usage: %s <in.gguf> <out.gguf> <merges>\n", argv[0]);
+    const char *in = NULL, *out = NULL, *merges_path = NULL, *chat_spec = NULL;
+    for (int i = 1; i < argc; i++) {
+        if (strcmp(argv[i], "--chat") == 0 && i + 1 < argc) { chat_spec = argv[++i]; continue; }
+        if (!in) in = argv[i];
+        else if (!out) out = argv[i];
+        else if (!merges_path) merges_path = argv[i];
+    }
+    if (!in || !out || (!merges_path && !chat_spec)) {
+        fprintf(stderr,
+            "usage: %s <in.gguf> <out.gguf> [merges] [--chat \"before|after|stop\"]\n"
+            "  merges  a text holding the pairs as integers, two per merge, in order\n"
+            "  --chat  the turn wrapping as id lists: what goes before the user's\n"
+            "          text, what goes after it, and what ends the turn\n", argv[0]);
         return 1;
     }
-    gguf_file *gf = gguf_open(argv[1]);
+
+    chat_list c_before = {{0},0}, c_after = {{0},0}, c_stop = {{0},0};
+    if (chat_spec) {
+        const char *a = chat_spec;
+        const char *b = strchr(a, '|');
+        const char *c = b ? strchr(b + 1, '|') : NULL;
+        if (parse_chat_ids(a, &c_before) ||
+            (b && parse_chat_ids(b + 1, &c_after)) ||
+            (c && parse_chat_ids(c + 1, &c_stop))) {
+            fprintf(stderr, "--chat: expected id lists separated by '|'\n");
+            return 1;
+        }
+        if (!c_before.n && !c_after.n && !c_stop.n) {
+            fprintf(stderr, "--chat: no ids in any of the three lists\n");
+            return 1;
+        }
+    }
+
+    gguf_file *gf = gguf_open(in);
     if (!gf) return 1;
 
-    if (gguf_get_kv(gf, "tokenizer.ggml.tokens")) {
-        fprintf(stderr, "%s already carries a tokenizer — refusing to write a second one\n", argv[1]);
-        gguf_close(gf);
-        return 1;
+    /* Through the path readers and not gguf_get_kv: the parsed table holds only
+     * scalars, so asking it about an array-valued key answers "absent" for a key
+     * that is right there, and the write would produce a file with the key
+     * twice — with no rule about which copy a reader takes. */
+    int have = 0;
+    if (merges_path) {
+        char **t = gguf_read_str_array(in, "tokenizer.ggml.tokens", &have);
+        if (t) {
+            fprintf(stderr, "%s already carries a tokenizer of %d tokens — refusing to write a second one\n", in, have);
+            return 1;
+        }
+    }
+    if (chat_spec) {
+        int32_t *w = gguf_read_i32_array(in, "notorch.chat.before", &have);
+        if (!w) w = gguf_read_i32_array(in, "notorch.chat.after", &have);
+        if (!w) w = gguf_read_i32_array(in, "notorch.chat.stop", &have);
+        if (w) {
+            fprintf(stderr, "%s already carries a chat wrapping — refusing to write a second one\n", in);
+            free(w);
+            return 1;
+        }
     }
 
+    int n_merges = 0, n_vocab = 0;
+    char **tok = NULL, **merge_str = NULL;
+  if (merges_path) {
     int nint = 0;
-    int *ints = read_ints(argv[3], &nint);
+    int *ints = read_ints(merges_path, &nint);
     if (!ints) { gguf_close(gf); return 1; }
-    int n_merges = nint / 2;
+    n_merges = nint / 2;
     if (nint % 2) {
-        fprintf(stderr, "%s holds %d integers, which is not whole merge pairs\n", argv[3], nint);
+        fprintf(stderr, "%s holds %d integers, which is not whole merge pairs\n", merges_path, nint);
         return 1;
     }
-    int n_vocab = 256 + n_merges;
+    n_vocab = 256 + n_merges;
     printf("merges: %d  vocab: %d\n", n_merges, n_vocab);
 
     /* If the file says how large its vocabulary is, that is the check on the
@@ -178,7 +262,7 @@ int main(int argc, char **argv) {
 
     int cp[256];
     byte_table(cp);
-    char **tok = (char **)calloc((size_t)n_vocab, sizeof(char *));
+    tok = (char **)calloc((size_t)n_vocab, sizeof(char *));
     if (!tok) return 1;
     for (int b = 0; b < 256; b++) {
         char buf[8];
@@ -187,7 +271,7 @@ int main(int argc, char **argv) {
         tok[b] = strdup(buf);
         if (!tok[b]) return 1;
     }
-    char **merge_str = (char **)calloc((size_t)(n_merges ? n_merges : 1), sizeof(char *));
+    merge_str = (char **)calloc((size_t)(n_merges ? n_merges : 1), sizeof(char *));
     if (!merge_str) return 1;
     for (int k = 0; k < n_merges; k++) {
         int a = ints[2 * k], b = ints[2 * k + 1];
@@ -205,49 +289,79 @@ int main(int argc, char **argv) {
         merge_str[k][la] = ' ';
         memcpy(merge_str[k] + la + 1, tok[b], lb + 1);
     }
+  }
 
-    FILE *in = fopen(argv[1], "rb");
-    FILE *out = fopen(argv[2], "wb");
-    if (!in || !out) { fprintf(stderr, "cannot open files\n"); return 1; }
+    /* An id the model has no row for would read as garbage in the embedding, so
+     * a wrapping is checked against the vocabulary the file declares before it
+     * is written into the file. */
+    for (int i = 0; i < gf->n_kv_parsed && chat_spec; i++) {
+        if (!strstr(gf->kv[i].key, ".vocab_size")) continue;
+        int v = (int)gf->kv[i].val.u32;
+        const chat_list *lists[3] = { &c_before, &c_after, &c_stop };
+        for (int L = 0; L < 3; L++)
+            for (int j = 0; j < lists[L]->n; j++)
+                if (lists[L]->v[j] < 0 || lists[L]->v[j] >= v) {
+                    fprintf(stderr, "--chat: id %d is outside a %d-token vocabulary\n",
+                            lists[L]->v[j], v);
+                    return 1;
+                }
+        printf("chat: %d before, %d after, %d stop — all inside %s = %d\n",
+               c_before.n, c_after.n, c_stop.n, gf->kv[i].key, v);
+    }
+
+    uint64_t extra = (merges_path ? 3 : 0)
+                   + (c_before.n ? 1 : 0) + (c_after.n ? 1 : 0) + (c_stop.n ? 1 : 0);
+
+    FILE *fin = fopen(in, "rb");
+    FILE *fout = fopen(out, "wb");
+    if (!fin || !fout) { fprintf(stderr, "cannot open files\n"); return 1; }
 
     /* Header by hand because the key count changes; the keys themselves are
      * copied as bytes, since gguf_open skips array-valued ones and cannot give
      * them back. */
-    if (write_u32(out, GGUF_MAGIC) || write_u32(out, gf->version) ||
-        write_u64(out, gf->n_tensors) || write_u64(out, gf->n_kv + 3)) return 1;
+    if (write_u32(fout, GGUF_MAGIC) || write_u32(fout, gf->version) ||
+        write_u64(fout, gf->n_tensors) || write_u64(fout, gf->n_kv + extra)) return 1;
     const uint64_t HDR = 24;
-    if (copy_range(in, out, HDR, gf->kv_end - HDR)) {
+    if (copy_range(fin, fout, HDR, gf->kv_end - HDR)) {
         fprintf(stderr, "metadata copy failed\n"); return 1;
     }
-    if (write_kv_str(out, "tokenizer.ggml.model", "gpt2") ||
-        write_kv_str_array(out, "tokenizer.ggml.tokens", tok, (uint64_t)n_vocab) ||
-        write_kv_str_array(out, "tokenizer.ggml.merges", merge_str, (uint64_t)n_merges)) {
+    if (merges_path &&
+        (write_kv_str(fout, "tokenizer.ggml.model", "gpt2") ||
+         write_kv_str_array(fout, "tokenizer.ggml.tokens", tok, (uint64_t)n_vocab) ||
+         write_kv_str_array(fout, "tokenizer.ggml.merges", merge_str, (uint64_t)n_merges))) {
         fprintf(stderr, "tokenizer write failed\n"); return 1;
+    }
+    if ((c_before.n && write_kv_i32_array(fout, "notorch.chat.before", c_before.v, (uint64_t)c_before.n)) ||
+        (c_after.n  && write_kv_i32_array(fout, "notorch.chat.after",  c_after.v,  (uint64_t)c_after.n)) ||
+        (c_stop.n   && write_kv_i32_array(fout, "notorch.chat.stop",   c_stop.v,   (uint64_t)c_stop.n))) {
+        fprintf(stderr, "chat write failed\n"); return 1;
     }
 
     for (uint64_t i = 0; i < gf->n_tensors; i++) {
         const gguf_tensor_info *t = &gf->tensors[i];
-        if (write_str(out, t->name) || write_u32(out, t->ndim)) return 1;
-        for (uint32_t d = 0; d < t->ndim; d++) if (write_u64(out, t->shape[d])) return 1;
-        if (write_u32(out, t->dtype) || write_u64(out, t->offset)) return 1;
+        if (write_str(fout, t->name) || write_u32(fout, t->ndim)) return 1;
+        for (uint32_t d = 0; d < t->ndim; d++) if (write_u64(fout, t->shape[d])) return 1;
+        if (write_u32(fout, t->dtype) || write_u64(fout, t->offset)) return 1;
     }
 
-    long dir_end = ftell(out);
+    long dir_end = ftell(fout);
     if (dir_end < 0) return 1;
     uint64_t data_start = ((uint64_t)dir_end + GGUF_ALIGN - 1) & ~(uint64_t)(GGUF_ALIGN - 1);
-    if (pad_to(out, data_start)) return 1;
+    if (pad_to(fout, data_start)) return 1;
 
     /* Tensor offsets are relative to the data section, so the section moving
      * changes nothing inside it and it goes across whole. */
     uint64_t data_len = gf->data_size;
-    if (fwrite(gf->data, 1, (size_t)data_len, out) != (size_t)data_len) {
+    if (fwrite(gf->data, 1, (size_t)data_len, fout) != (size_t)data_len) {
         fprintf(stderr, "data copy failed\n"); return 1;
     }
 
-    fclose(in);
-    fclose(out);
-    printf("wrote %s — tokenizer.ggml.{model,tokens,merges} added, %llu tensors untouched\n",
-           argv[2], (unsigned long long)gf->n_tensors);
+    fclose(fin);
+    fclose(fout);
+    printf("wrote %s — %s%s%llu tensors untouched\n", out,
+           merges_path ? "tokenizer.ggml.{model,tokens,merges} added, " : "",
+           chat_spec ? "notorch.chat.* added, " : "",
+           (unsigned long long)gf->n_tensors);
     gguf_close(gf);
     return 0;
 }


### PR DESCRIPTION
gguf_add_tokenizer --chat "before|after|stop" writes notorch.chat.{before,after, stop} into a GGUF as INT32 arrays, and the harness reads them when NT_CHAT is unset. The ids belong to the weights, not to whoever remembers to export a variable. The environment still wins when set, because trying a different wrapping is how the right one gets found.

Janus v4 Q8_0 with 32759,32760|32761,32762|32763 baked in and no environment at all produces the continuation byte-identical to the same weights driven by NT_CHAT, reporting "(file)" where the other reports "(NT_CHAT)". The copy grew 128 bytes and kept all 247 tensors. The original with no environment prints no chat line.

Both refusals in that tool were decoration. The guard against a second tokenizer and the guard against a second wrapping asked gguf_get_kv, and gguf_open does not parse array-valued keys, so the table answered "absent" for a key sitting in the file. --chat on an already-wrapped file returned 0 and wrote a GGUF carrying notorch.chat.before twice, with no rule about which copy a reader takes. Found by running the refusal, not by reading it. Both now go through gguf_read_str_array and gguf_read_i32_array, which do parse arrays; the comment three lines below the dead guards had stated the reason the whole time. An id outside the declared vocabulary is refused at write time as well as at read time.

Gates: NOTORCH_PARITY_OK on 6, JANUS_OK worst 3.338e-05 against 1e-3 plus 8 greedy tokens identical on both matvec paths, RESONANCE_OK worst 4.290e-06, NOTORCH_TOKENIZER_OK on 8. nano_arianna Q8_0 unmoved: 338,3228,282,4135,313 and the same sentence.

Quote: "There are two ways of constructing a software design: One way is to make it so simple that there are obviously no deficiencies, and the other way is to make it so complicated that there are no obvious deficiencies." — C.A.R. Hoare, Turing Award lecture, 1980 Method: the Method stopped trusting a guard it had never watched go red. By Arianna Method (Co-authored by Claude, neo) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff