### PR TITLE
test_parity: a gate that cannot run reports neither green nor red

### DIFF
--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,48 @@ Newest entries on top.
 
 ---
 
+## 2026-09-12 — the parity gate could not run, and said FAIL
+
+The agent rules in this tree carry "a gate that cannot run must report neither
+green nor red" as one of four things already paid for. `harness/test_parity.sh`
+had never been brought up to it, and it had all three failure directions at once.
+
+Against Janus Q8_0 the reference exits 1 with `llama: missing critical weights`
+and the gate printed **three FAILs** with an empty `example:` line under each —
+a red about the harness produced by a reference that never loaded the model. That
+is the same shape as the eight tokenizer "mismatches" from 09-10, in the script
+next to it.
+
+Against a truncated GGUF neither binary loads, `A=$(./notorch ...)` fails, `set -e`
+kills the script, and it printed **nothing at all**: no verdict line, rc=1. A
+wrapper reading stdout for `NOTORCH_PARITY_*` sees neither.
+
+And with both sides empty the comparison is `"" = ""`, which is **PASS**. Proved
+rather than argued: the same script with the two capture lines forced empty prints
+`NOTORCH_PARITY_OK (3 checks)` under the old condition and `NOTORCH_PARITY_FAIL (3)`
+under the new one.
+
+Each model is now offered to both binaries before anything is compared, and one
+that will not load is `SKIPPED` with the reason taken off stderr — the first line
+that reads like an error, since the first line is the shape banner, and the last
+line said before it gave up when nothing matches. `NOTORCH_PARITY_OK` now carries
+its check count and is unreachable at zero: every model skipped prints
+`NOTORCH_PARITY_SKIPPED`. An empty harness side is a failure even when the
+reference side is empty too.
+
+One thing this cost twice: `set -e` kills a function at `OUT=$(cmd)` when the
+command exits non-zero, so the first version of the reason lookup silently
+returned nothing at all — the truncated file reported `SKIPPED — ` with the reason
+missing. A pipeline hides it (the status is the last stage) and a bare assignment
+does not.
+
+Janus, the truncated file and a path that does not exist all skip with a real
+reason at rc=0. `make test_harness` unmoved: 6 PASS, `NOTORCH_PARITY_OK (6 checks)`.
+Mixed input skips Janus and still compares nano_arianna, 3 checks, rc=0.
+
+---
+
+
 ## 2026-09-12 — the wrapping moves into the file, and two guards that were never guarding
 
 `NT_CHAT` proved the mechanism and left the ids in the operator's hands, which is

--- a/harness/test_parity.sh
+++ b/harness/test_parity.sh
@@ -41,13 +41,43 @@ ref_text() {
   '
 }
 
+# A comparison needs both sides to have run. The reference loads only the
+# standard families, so on resonance or janus it prints nothing and every
+# prompt reads as a mismatch — three FAILs that say nothing about the harness.
+# Ask each binary to load the model before comparing anything, and when one
+# cannot, say so and move on: neither green nor red.
+can_load() {
+  "$1" "$2" "x" 1 0 >/dev/null 2>&1
+}
+# The first line of stderr is the shape banner, so the reason is the first line
+# that reads like one, and failing that the last thing said before it gave up.
+why_not() {
+  OUT=$("$1" "$2" "x" 1 0 2>&1 >/dev/null) || true
+  R=$(printf '%s\n' "$OUT" | grep -m1 -iE 'error|cannot|missing|unsupported|unknown|failed|truncat|short') || true
+  [ -n "$R" ] || R=$(printf '%s\n' "$OUT" | grep . | tail -1) || true
+  [ -n "$R" ] || R="it exited non-zero with nothing to say"
+  printf '%s\n' "$R"
+}
+
 FAILS=0
+CHECKS=0
 for M in $MODELS; do
   NAME=$(basename "$M")
+  if ! can_load ./notorch "$M"; then
+    echo "parity  [$NAME] SKIPPED — the harness could not load it: $(why_not ./notorch "$M")"
+    continue
+  fi
+  if ! can_load ./infer_llama "$M"; then
+    echo "parity  [$NAME] SKIPPED — the reference could not load it: $(why_not ./infer_llama "$M")"
+    continue
+  fi
   for P in "The capital of France is" "Resonance is" "def fibonacci(n):"; do
     A=$(./notorch "$M" "$P" 24 0 2>/dev/null)
     B=$(./infer_llama "$M" "$P" 24 0 2>/dev/null | ref_text)
-    if [ "$A" = "$B" ]; then
+    CHECKS=$((CHECKS + 1))
+    # Two empty strings are equal and prove nothing, so an empty side is a
+    # failure even when both sides are empty.
+    if [ -n "$A" ] && [ "$A" = "$B" ]; then
       echo "parity  [$NAME] \"$P\"  identical  PASS"
     else
       echo "parity  [$NAME] \"$P\"  FAIL"
@@ -58,9 +88,12 @@ for M in $MODELS; do
   done
 done
 
-if [ "$FAILS" -eq 0 ]; then
-  echo "NOTORCH_PARITY_OK"
-else
+if [ "$FAILS" -ne 0 ]; then
   echo "NOTORCH_PARITY_FAIL ($FAILS)"
   exit 1
+elif [ "$CHECKS" -eq 0 ]; then
+  echo "parity  (every model given was skipped — nothing was compared)"
+  echo "NOTORCH_PARITY_SKIPPED"
+else
+  echo "NOTORCH_PARITY_OK ($CHECKS checks)"
 fi


### PR DESCRIPTION
harness/test_parity.sh had all three failure directions of an unrunnable gate.

Against Janus Q8_0 the reference exits 1 with "llama: missing critical weights" and the gate printed three FAILs with an empty example: line under each — a red about the harness produced by a reference that never loaded the model, the same shape as the eight tokenizer mismatches from 09-10, in the script beside it.

Against a truncated GGUF neither binary loads, A=$(./notorch ...) fails, set -e kills the script, and it printed nothing at all: no verdict, rc=1. Anything reading stdout for NOTORCH_PARITY_* sees neither.

And two empty sides compare equal, which was PASS. Proved rather than argued: the same script with both capture lines forced empty prints NOTORCH_PARITY_OK (3 checks) under the old condition and NOTORCH_PARITY_FAIL (3) under the new.

Each model is offered to both binaries before anything is compared; one that will not load is SKIPPED with the reason off stderr — the first line that reads like an error, since the first line is the shape banner. NOTORCH_PARITY_OK carries its check count and is unreachable at zero. An empty harness side fails even when the reference side is empty too.

Cost twice on the way: set -e kills a function at OUT=$(cmd) on non-zero, so the first reason lookup returned nothing and the truncated file reported "SKIPPED — " with the reason missing. A pipeline hides that; a bare assignment does not.

Janus, the truncated file and a nonexistent path all skip with a real reason at rc=0. make test_harness unmoved: 6 PASS, NOTORCH_PARITY_OK (6 checks). Mixed input skips Janus and still compares nano_arianna, 3 checks, rc=0.

Quote: "Far better an approximate answer to the right question, which is often vague, than an exact answer to the wrong question, which can always be made precise." — John W. Tukey, The Future of Data Analysis, 1962 Method: the Method made its gate admit when it had not measured anything. By Arianna Method (Co-authored by Claude, neo) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff