### PR TITLE
the method read the weights once for the whole prompt

### DIFF
--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,51 @@ Newest entries on top.
 
 ---
 
+## 2026-09-12 — prefill stopped reading the file once per token, for f16
+
+`nt_qmatmul_i8` has said since it was written that a prompt of n tokens streams the weights n
+times if nobody batches, and the unpacked formats had nobody. `qmm` asked the int8 entry, was
+refused, and fell to the per-token loop — so every f16 model here ran its prefill at decode
+speed. `nt_qmatmul` is the other half: one pass over an f16 row against a tile of activations,
+no activation quantization, since f16 weights meet float activations directly.
+
+qwen05b_fp16, 350-token prompt, two runs each, `taskset -c 4-7`:
+
+    prefill  20.1-20.6  ->  41.9-42.0 t/s
+
+Per (row, activation) the walk over k is the same eight-wide two-accumulator shape as
+`nt_f16_rows` with the scalar tail added in the same order, so batched and per-token agree bit
+for bit. `tests/test_qmatmul.c` grew eleven f16 cases asserting equality rather than a
+tolerance, including three where k is not a multiple of eight — dropping the tail turns exactly
+those three red, which is how you can tell they are there on purpose. Writing the result
+through a factor of 1.0000001 turns nine red. Restoring gives 46 passed, 0 failed.
+
+Tile width, measured where it is used: four gives 36.4 t/s, **eight 41.9**, sixteen 39.2, and
+the int8 path's thirty-two collapses to 25.7-28.9 where the register spills start. Eight
+activations need sixteen vector registers for partial sums plus two for the converted weights,
+against thirty-two that exist.
+
+**The first version of that table measured nothing.** It was taken on mamba-130m-f16, which
+walks its prompt one position at a time — so the kernel under test never ran, and four, eight
+and sixteen read 37.3, 40.2 and 39.6, which is the spread of an idle measurement. A tile width
+has to be measured where the tile is used.
+
+Which names the next piece rather than hiding it. `mamba_forward` loops positions and calls
+`qmv` inside each, because the scan is a recurrence — but only the scan is. The projections
+around it do not look across positions and could go through this kernel for the whole chunk at
+once, which is what the reference does and why it reads 309 t/s of prefill where this tree
+reads 40.
+
+F32 is deliberately not batched. Its tensors in every file on this machine are norms and
+biases — 121 of them in qwen05b_fp16, none large — so there is no traffic to save, and writing
+the kernel would take the summation order away from the compiler for nothing.
+
+Gates: 17 suites green, tokenizer identical on 24, harness parity OK on Q4_0, both f16 models
+byte-identical to the reference on three prompts, and qwen05b_fp16 byte-identical on the
+350-token prompt that actually exercises the new path.
+
+---
+
 ## 2026-09-12 — the wrapping moves into the file, and two guards that were never guarding
 
 `NT_CHAT` proved the mechanism and left the ids in the operator's hands, which is

--- a/harness/runtime.c
+++ b/harness/runtime.c
@@ -108,6 +108,12 @@ void qmv(float *out, const wt *w, const float *x) {
 void qmm(float *out, const wt *w, const float *X, int n) {
     if (n > 1 && w->use_i8 && w->q &&
         nt_qmatmul_i8(out, w->q, w->dtype, X, w->rows, w->cols, n) == 0) return;
+    /* An unpacked weight reaches neither the line above nor use_i8, and fell through to
+     * the loop — which re-reads the whole matrix per token and is why an f16 prefill ran
+     * at decode speed. Both entries refuse what they cannot take, so asking costs a
+     * comparison and the loop stays underneath as the answer for everything else. */
+    if (n > 1 && w->q &&
+        nt_qmatmul(out, w->q, w->dtype, X, w->rows, w->cols, n) == 0) return;
     for (int j = 0; j < n; j++)
         qmv(out + (long)j * w->rows, w, X + (long)j * w->cols);
 }

--- a/notorch.c
+++ b/notorch.c
@@ -8290,6 +8290,122 @@ int nt_qmatmul_i8(float *out, const uint8_t *Wq, int dtype,
     return 0;
 }
 
+
+// ── batched f16 matmul — the unpacked half of the same argument ─────────────────
+/* Everything the batched int8 entry above says about prefill is true of f16 and was not
+ * being acted on: with no batched kernel the harness looped the per-token matvec, so an
+ * n-token prompt streamed the whole file n times. On mamba-130m-f16 that is 45 t/s of
+ * prefill against the reference's 309, and the gap is entirely re-reading.
+ *
+ * There is no activation quantization here, which is the whole difference from the int8
+ * path — f16 weights meet float activations directly, so a tile costs nothing to set up
+ * and the only question is how wide it can be before the accumulators spill. Eight
+ * activations need sixteen vector registers for their partial sums plus two for the
+ * converted weights; thirty-two exist. Measured on a 350-token prefill of qwen05b_fp16,
+ * two runs each: four gives 36.4 t/s, eight 41.9, sixteen 39.2, and the int8 path's
+ * thirty-two collapses to 25.7-28.9 where the spills start. Eight it is.
+ *
+ * The first attempt at that table was taken on mamba-130m-f16 and measured nothing at
+ * all: that family walks its prompt one position at a time, so this kernel never ran and
+ * the three numbers were noise reading 37 to 40. A tile width has to be measured where
+ * the tile is used.
+ *
+ * Per (row, activation) the walk over k is the same eight-wide, two-accumulator shape as
+ * nt_f16_rows, and the scalar tail is added to the vector sum in the same order. So a
+ * batched prefill and a token-by-token one agree bit for bit, and tests/test_qmatmul.c
+ * asserts equality rather than a tolerance.
+ *
+ * F32 is deliberately not here. Its tensors in every file on this machine are norms and
+ * biases — 121 of them in qwen05b_fp16, none large — so batching them buys nothing
+ * measurable, while writing the kernel would take the summation order away from the
+ * compiler and change results for no reason. */
+#define NT_QMM_TILE_F 8   /* activations carried through one pass over an f16 row */
+
+typedef void (*nt_fmmrows_fn)(float *out, int m, const uint8_t *W, const float *X,
+                              int r0, int r1, int k, int n);
+
+static void nt_f16_rows_n(float *out, int m, const uint8_t *W, const float *X,
+                          int r0, int r1, int k, int n) {
+    const uint16_t *Wh = (const uint16_t *)W;
+    for (int j0 = 0; j0 < n; j0 += NT_QMM_TILE_F) {
+        int jn = n - j0; if (jn > NT_QMM_TILE_F) jn = NT_QMM_TILE_F;
+        for (int row = r0; row < r1; row++) {
+            const uint16_t *r = Wh + (long)row * k;
+            float acc[NT_QMM_TILE_F];
+            int i = 0;
+            for (int j = 0; j < jn; j++) acc[j] = 0.0f;
+#if defined(__aarch64__) && defined(__ARM_NEON)
+            float32x4_t a0[NT_QMM_TILE_F], a1[NT_QMM_TILE_F];
+            for (int j = 0; j < jn; j++) { a0[j] = vdupq_n_f32(0.0f); a1[j] = vdupq_n_f32(0.0f); }
+            for (; i + 8 <= k; i += 8) {
+                float16x8_t h = vreinterpretq_f16_u16(vld1q_u16(r + i));
+                float32x4_t w0 = vcvt_f32_f16(vget_low_f16(h));
+                float32x4_t w1 = vcvt_f32_f16(vget_high_f16(h));
+                for (int j = 0; j < jn; j++) {
+                    const float *xj = X + (long)(j0 + j) * k + i;
+                    a0[j] = vfmaq_f32(a0[j], w0, vld1q_f32(xj));
+                    a1[j] = vfmaq_f32(a1[j], w1, vld1q_f32(xj + 4));
+                }
+            }
+            for (int j = 0; j < jn; j++) acc[j] = vaddvq_f32(vaddq_f32(a0[j], a1[j]));
+#endif
+            for (int j = 0; j < jn; j++) {
+                const float *xj = X + (long)(j0 + j) * k;
+                float s = acc[j];
+                for (int t = i; t < k; t++) s += nt_f16_to_f32(r[t]) * xj[t];
+                out[(long)(j0 + j) * m + row] = s;
+            }
+        }
+    }
+}
+
+/* Its own job rather than the int8 one, whose three activation pointers have no meaning
+ * here; the row-claiming is the same because the reason for it is the same. */
+typedef struct {
+    nt_fmmrows_fn fn;
+    float *out; const uint8_t *W; const float *X;
+    int m, k, n, hi, chunk;
+    int next;
+} nt_fmm_job;
+
+static void nt_fmm_drain(nt_fmm_job *j) {
+    for (;;) {
+        int r0 = __atomic_fetch_add(&j->next, j->chunk, __ATOMIC_RELAXED);
+        if (r0 >= j->hi) return;
+        int r1 = r0 + j->chunk; if (r1 > j->hi) r1 = j->hi;
+        j->fn(j->out, j->m, j->W, j->X, r0, r1, j->k, j->n);
+    }
+}
+
+static void *nt_fmm_worker(void *p) { nt_fmm_drain((nt_fmm_job *)p); return NULL; }
+
+int nt_qmatmul(float *out, const uint8_t *W, int dtype,
+               const float *X, int m, int k, int n) {
+    if (!out || !W || !X || m <= 0 || k <= 0 || n <= 0) return -1;
+    if (n == 1) return nt_qmatvec(out, W, dtype, X, m, k);
+    if (dtype != 1) return -1;           /* only f16 has a batched unpacked kernel */
+
+    /* Same gate as the int8 entry, and for the same reason: the work is m*k*n, and
+     * leaving n out of it left most of a prefill on one core. */
+    int nt = nt_qmv_host_threads(m);
+    if (nt <= 1 || (long)m * k * (long)n < nt_qmv_thread_floor()) {
+        nt_f16_rows_n(out, m, W, X, 0, m, k, n);
+        return 0;
+    }
+
+    nt_fmm_job job = { nt_f16_rows_n, out, W, X, m, k, n, m, 0, 0 };
+    job.chunk = m / (nt * 8); if (job.chunk < 1) job.chunk = 1;
+    pthread_t th[NT_QMV_MAX_THREADS];
+    int launched = 0;
+    for (int t = 0; t + 1 < nt; t++) {
+        if (pthread_create(&th[t], NULL, nt_fmm_worker, &job) != 0) break;
+        launched++;
+    }
+    nt_fmm_drain(&job);                   /* the caller is a worker too */
+    for (int t = 0; t < launched; t++) pthread_join(th[t], NULL);
+    return 0;
+}
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // IMAGE OPS — conv2d (im2col + GEMM) + group norm — forward-only inference ops
 // for diffusion engines (Stable-Diffusion UNet/VAE). Companions to nt_qmatvec:

--- a/notorch.h
+++ b/notorch.h
@@ -597,6 +597,15 @@ int nt_quantize_row(const float *x, void *dst, int k, int dtype);
 int nt_qmatmul_i8(float *out, const uint8_t *Wq, int dtype,
                   const float *X, int m, int k, int n);
 
+// The same for the unpacked formats, which the entry above refuses. F16 only: its
+// tensors are what a model is made of before anyone quantizes it, while the F32 ones
+// in a real file are norms and biases and carry no traffic worth batching. X is [n, k]
+// row-major, out is [n, m] row-major, and the per-row accumulation order is the one
+// nt_qmatvec uses, so results are identical to calling it n times rather than close.
+// Returns -1 for any other dtype; a caller that gets it loops nt_qmatvec and is correct.
+int nt_qmatmul(float *out, const uint8_t *W, int dtype,
+               const float *X, int m, int k, int n);
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // IMAGE OPS — forward-only conv2d + group norm for diffusion inference engines
 // ═══════════════════════════════════════════════════════════════════════════════

--- a/tests/test_qmatmul.c
+++ b/tests/test_qmatmul.c
@@ -97,6 +97,66 @@ static uint8_t *make_weights(int dtype, int m, int k, unsigned seed) {
     }
 }
 
+/* F16 rows. Halves built from small integers over a power of two so every one of them is
+ * exact — the equality below is about the kernel's accumulation order, and a weight that
+ * rounds on the way in would put a second story in the same number. */
+static uint8_t *make_f16(int m, int k, unsigned seed) {
+    uint16_t *W = (uint16_t *)malloc(sizeof(uint16_t) * (size_t)m * k);
+    if (!W) return NULL;
+    srand(seed);
+    for (long i = 0; i < (long)m * k; i++) {
+        float v = (float)((rand() % 121) - 60) * 0.0625f;
+#if defined(__aarch64__) && defined(__ARM_NEON)
+        __fp16 h = (__fp16)v; memcpy(&W[i], &h, sizeof(h));
+#else
+        /* No half type to lean on: build the pattern directly. The values above are
+         * m * 2^-4 with |m| <= 960, which a half holds exactly, so this is a shift. */
+        int q = (int)(v * 16.0f); unsigned sgn = q < 0 ? 0x8000u : 0u; if (q < 0) q = -q;
+        if (q == 0) { W[i] = (uint16_t)sgn; continue; }
+        int e = 0; int mant = q; while (mant >= 2) { mant >>= 1; e++; }
+        int frac = q - (1 << e);
+        W[i] = (uint16_t)(sgn | (unsigned)((e - 4 + 15) << 10) |
+                          (unsigned)(frac << (10 - e)));
+#endif
+    }
+    return (uint8_t *)W;
+}
+
+/* The unpacked entry pair, which quantizes no activations and so has its own reference. */
+static int check_plain(int dtype, int m, int k, int n, int *pass, int *fail) {
+    uint8_t *W = make_f16(m, k, 4321u + (unsigned)n);
+    float *X   = (float *)malloc(sizeof(float) * (size_t)k * n);
+    float *ref = (float *)malloc(sizeof(float) * (size_t)m * n);
+    float *got = (float *)malloc(sizeof(float) * (size_t)m * n);
+    if (!W || !X || !ref || !got) { printf("  alloc failed\n"); (*fail)++; return -1; }
+
+    for (long i = 0; i < (long)k * n; i++) X[i] = (float)((double)rand() / RAND_MAX * 2.0 - 1.0);
+
+    for (int j = 0; j < n; j++)
+        if (nt_qmatvec(ref + (long)j * m, W, dtype, X + (long)j * k, m, k) != 0) {
+            printf("  dtype=%d m=%d k=%d n=%d: reference matvec refused\n", dtype, m, k, n); (*fail)++;
+            free(W); free(X); free(ref); free(got); return -1;
+        }
+    if (nt_qmatmul(got, W, dtype, X, m, k, n) != 0) {
+        printf("  dtype=%d m=%d k=%d n=%d: batched matmul refused\n", dtype, m, k, n); (*fail)++;
+        free(W); free(X); free(ref); free(got); return -1;
+    }
+
+    long bad = 0;
+    for (long i = 0; i < (long)m * n; i++)
+        if (memcmp(&ref[i], &got[i], sizeof(float)) != 0) bad++;
+    if (bad) {
+        printf("  FAIL dtype=%d m=%d k=%d n=%d: %ld of %ld outputs differ (first ref=%g got=%g)\n",
+               dtype, m, k, n, bad, (long)m * n, ref[0], got[0]);
+        (*fail)++;
+    } else {
+        printf("  PASS dtype=%2d m=%4d k=%4d n=%3d: %ld outputs identical\n", dtype, m, k, n, (long)m * n);
+        (*pass)++;
+    }
+    free(W); free(X); free(ref); free(got);
+    return bad ? -1 : 0;
+}
+
 static int check(int dtype, int m, int k, int n, int *pass, int *fail) {
     uint8_t *W = make_weights(dtype, m, k, 1234u + (unsigned)n);
     float *X   = (float *)malloc(sizeof(float) * (size_t)k * n);
@@ -189,6 +249,39 @@ int main(void) {
     check(14, 128,  512, 33, &pass, &fail);
     check(14, 2048, 4096, 8, &pass, &fail);
     check(14, 896, 4864, 17, &pass, &fail);   /* a real down-projection shape */
+
+    /* F16 through the unpacked entry. Its tile is eight, not thirty-two, so the boundary
+     * cases sit elsewhere — and k is walked eight at a time, so a k that is not a multiple
+     * of eight exercises the scalar tail inside a batched pass, which is the one place the
+     * two entries could disagree while both looking right. */
+    check_plain(1, 64,   256,  1, &pass, &fail);   /* n = 1 delegates to the matvec entry */
+    check_plain(1, 64,   256,  3, &pass, &fail);
+    check_plain(1, 128,  512,  7, &pass, &fail);   /* just under the tile */
+    check_plain(1, 128,  512,  8, &pass, &fail);   /* exactly the tile */
+    check_plain(1, 128,  512,  9, &pass, &fail);   /* one past it: second pass is short */
+    check_plain(1, 128,  512, 33, &pass, &fail);   /* several whole tiles and a remainder */
+    check_plain(1, 2048, 4096, 8, &pass, &fail);   /* over the threading gate: fan-out engaged */
+    check_plain(1, 127,  517,  9, &pass, &fail);   /* odd rows, odd k, odd tile at once */
+    check_plain(1, 1,    515,  8, &pass, &fail);   /* a single row */
+    check_plain(1, 64,      5,  8, &pass, &fail);  /* k shorter than one vector step */
+    /* What must be refused rather than answered. F32 has no batched kernel by choice, and
+     * a caller that gets -1 loops the matvec and is correct — so the contract is that it
+     * says so instead of writing something. */
+    {
+        uint8_t *W = make_f16(8, 64, 9u);
+        float X[64 * 4] = {0}, out[8 * 4];
+        for (int i = 0; i < 8 * 4; i++) out[i] = -12345.0f;
+        int refused = nt_qmatmul(out, W, 0, X, 8, 64, 4) != 0;
+        int untouched = 1;
+        for (int i = 0; i < 8 * 4; i++) if (out[i] != -12345.0f) untouched = 0;
+        printf("  %s dtype= 0 batched entry refuses and writes nothing\n",
+               (refused && untouched) ? "PASS" : "FAIL");
+        if (refused && untouched) pass++; else fail++;
+        printf("  %s a null weight is refused\n",
+               nt_qmatmul(out, NULL, 1, X, 8, 64, 4) != 0 ? "PASS" : "FAIL");
+        if (nt_qmatmul(out, NULL, 1, X, 8, 64, 4) != 0) pass++; else fail++;
+        free(W);
+    }
 
     check(6,  127,  512, 32, &pass, &fail);   /* odd rows on every dtype: the pair loop leaves one */
     check(8,  127,  512, 32, &pass, &fail);


### PR DESCRIPTION
`nt_qmatmul_i8` has said since it was written that a prompt of n tokens streams the weights n times if nobody batches — and the unpacked formats had nobody. `qmm` asked the int8 entry, was refused, and fell to the per-token loop, so **every f16 model here ran its prefill at decode speed**. `nt_qmatmul` is the other half: one pass over an f16 row against a tile of activations, no activation quantization, since f16 weights meet float activations directly.

qwen05b_fp16, 350-token prompt, two runs each, `taskset -c 4-7`:

    prefill  20.1-20.6  ->  41.9-42.0 t/s

Per (row, activation) the walk over k is the same eight-wide two-accumulator shape as `nt_f16_rows`, tail added in the same order, so **batched and per-token agree bit for bit**. `tests/test_qmatmul.c` grew eleven f16 cases asserting equality rather than a tolerance, including three where k is not a multiple of eight — dropping the tail turns exactly those three red, which is how you can tell they are there on purpose. Writing the result through a factor of 1.0000001 turns nine red. Restoring: 46 passed, 0 failed.

**Tile width, measured where it is used:** 4 → 36.4 t/s, **8 → 41.9**, 16 → 39.2, and the int8 path's 32 collapses to 25.7–28.9 where the register spills start.

The first version of that table measured nothing. It was taken on mamba-130m-f16, which walks its prompt one position at a time — so the kernel under test never ran, and 4/8/16 read 37.3/40.2/39.6, the spread of an idle measurement. A tile width has to be measured where the tile is used.

Which names the next piece rather than hiding it: `mamba_forward` loops positions and calls `qmv` inside each because the scan is a recurrence — but only the scan is. The projections around it do not look across positions and could go through this kernel for a whole chunk at once, which is what the reference does and why it reads 309 t/s of prefill where this tree reads 40.

F32 is deliberately not batched: its tensors in every file here are norms and biases (121 of them in qwen05b_fp16, none large), so there is no traffic to save, and writing the kernel would take the summation order away from the compiler for nothing.

Gates: 17 suites green, tokenizer identical on 24, harness parity OK on Q4_0, both f16 models byte-identical to the reference on three prompts, and qwen05b_fp16 byte-identical on the 350-token prompt that actually exercises the new path.