### PR TITLE
goldens re-derived; the harness becomes a linkable surface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,14 +160,46 @@ libnotorch.$(SOEXT): notorch.c notorch.h gguf.c gguf.h
 	$(CC) $(CFLAGS) $(BLAS_FLAGS) -fPIC -shared -o libnotorch.$(SOEXT) notorch.c gguf.c -lm $(BLAS_LIBS)
 	@echo "Built: libnotorch.$(SOEXT) ($(BLAS_NAME)) — load it with any FFI"
 
+# ── The harness as a linkable surface ──────────────────────────────────────
+#
+# A body that wants to run a GGUF through this tree used to have two options:
+# copy harness/*.c into its own build, or link main.c and inherit its main().
+# The first is a fork, the second is not a library. Yent's inference is being
+# rebuilt on this harness, so the third option now exists: the arithmetic, the
+# family table, the KV cache and the tokenizer in one archive, and main.c left
+# out of it as the CLI it is.
+#
+# Two archives and not one, because the split is real: libnotorch is the
+# substrate anything can use, libnotorch_harness is model-family code that only
+# means something to a caller that runs models. Link both, harness first.
+HARNESS_LIB_OBJ = harness/archs.o harness/runtime.o harness/arch_llama.o \
+                  harness/arch_gemma4.o harness/arch_olmoe.o harness/arch_mamba.o \
+                  harness/arch_resonance.o harness/arch_janus.o examples/bpe.o
+
+lib_harness: libnotorch_harness.a
+
+libnotorch_harness.a: $(HARNESS_LIB_OBJ)
+	$(AR) rcs libnotorch_harness.a $(HARNESS_LIB_OBJ)
+	@echo "Built: libnotorch_harness.a (families, runtime, tokenizer — link with -lnotorch)"
+
+$(HARNESS_LIB_OBJ): %.o: %.c $(HARNESS_HDR)
+	$(CC) $(CFLAGS) $(BLAS_FLAGS) -c $< -o $@
+
 # ── Install — system-wide baseline at $PREFIX (default /opt/homebrew) ──
 PREFIX ?= /opt/homebrew
 
-install: lib
-	install -d $(PREFIX)/lib $(PREFIX)/include/ariannamethod
+install: lib lib_harness
+	install -d $(PREFIX)/lib $(PREFIX)/include/ariannamethod $(PREFIX)/include/ariannamethod/harness $(PREFIX)/include/ariannamethod/examples
 	install -m 0644 libnotorch.a $(PREFIX)/lib/libnotorch.a
+	install -m 0644 libnotorch_harness.a $(PREFIX)/lib/libnotorch_harness.a
 	install -m 0644 notorch.h    $(PREFIX)/include/ariannamethod/notorch.h
 	install -m 0644 gguf.h       $(PREFIX)/include/ariannamethod/gguf.h
+	# The harness headers include each other as "harness/arch.h", so they are
+	# installed under a directory of that name and the caller adds one -I.
+	install -m 0644 harness/arch.h    $(PREFIX)/include/ariannamethod/harness/arch.h
+	install -m 0644 harness/archs.h   $(PREFIX)/include/ariannamethod/harness/archs.h
+	install -m 0644 harness/runtime.h $(PREFIX)/include/ariannamethod/harness/runtime.h
+	install -m 0644 examples/bpe.h    $(PREFIX)/include/ariannamethod/examples/bpe.h
 	install -m 0644 notorch_vision.h $(PREFIX)/include/ariannamethod/notorch_vision.h
 	install -m 0644 stb_image.h  $(PREFIX)/include/ariannamethod/stb_image.h
 ifeq ($(UNAME),Darwin)
@@ -203,12 +235,12 @@ llama: examples/infer_llama.c examples/bpe.c examples/bpe.h gguf.c gguf.h notorc
 # One binary, one command: ./notorch model.gguf "prompt". Architectures are a
 # table in harness/main.c; adding a family adds a file, not a branch.
 
-HARNESS_SRC = harness/main.c harness/runtime.c harness/arch_llama.c harness/arch_gemma4.c harness/arch_olmoe.c harness/arch_mamba.c harness/arch_resonance.c harness/arch_janus.c examples/bpe.c gguf.c notorch.c
-HARNESS_HDR = harness/arch.h harness/runtime.h harness/logo.h examples/bpe.h gguf.h notorch.h
+HARNESS_SRC = harness/main.c harness/archs.c harness/runtime.c harness/arch_llama.c harness/arch_gemma4.c harness/arch_olmoe.c harness/arch_mamba.c harness/arch_resonance.c harness/arch_janus.c examples/bpe.c gguf.c notorch.c
+HARNESS_HDR = harness/arch.h harness/archs.h harness/runtime.h harness/logo.h examples/bpe.h gguf.h notorch.h
 
 # `harness` is phony because a directory of that name sits right there, and
 # make would otherwise call it up to date and build nothing.
-.PHONY: harness test_harness test_resonance test_janus
+.PHONY: harness test_harness test_resonance test_janus test_consumer_link lib_harness
 
 harness: notorch
 
@@ -220,6 +252,12 @@ notorch: $(HARNESS_SRC) $(HARNESS_HDR)
 # nothing. MODEL= to point it at one file, otherwise it looks for its defaults.
 test_harness: notorch llama
 	./harness/test_parity.sh $(MODEL)
+
+# The harness as a body sees it: two installed archives, four installed
+# headers, no notorch source. Runs the negative case too, so a pass means the
+# archive carried the symbols rather than the compiler finding them elsewhere.
+test_consumer_link:
+	./harness/test_consumer_link.sh $(MODEL)
 
 # Janus against the forward it was ported from: the exact-matvec build against
 # the reference's frozen answer, and the shipped build against its own generation.

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,91 @@ Newest entries on top.
 
 ---
 
+## 2026-09-12 — the goldens re-derived, and the harness made linkable
+
+Two things that both come down to the same question: does the thing everyone is
+about to build on actually hold.
+
+### The goldens had one witness, and it was us
+
+`tests/resonance_golden_v3.txt` and `tests/janus_golden_v4.txt` are the only
+reference for the Method's own two families — llama.cpp refuses both with
+`unknown model architecture`, so there is no outside oracle. Three green gates
+hang off two text files, and the header of each says where its numbers came
+from. Nobody had ever run that recipe back.
+
+Both were re-derived from `arianna.c`'s own forwards, with drivers written from
+scratch rather than recovered, and both were re-derived a second time with the
+entire substrate swapped for `arianna.c`'s vendored notorch — a different
+`notorch.c` by 3867 lines and a different `gguf.c` by 353.
+
+- **Resonance** comes back with a worst distance of **7.15e-06** on this tree's
+  substrate and **8.58e-06** on the vendored one, against a 1e-3 tolerance. The
+  two substrates sit **3.34e-06** apart, so on this path our kernels and the
+  ones the model was actually run with are not covering for each other.
+- **Janus** comes back **bit-identical** on both, all eight logits to the
+  printed digit.
+
+Three things the exercise turned up that the headers did not say.
+
+The Janus recipe as written **does not run**. That file is Q8_0, dtype 8, and
+the reference's packed path takes F16 only: `not F16 (packed path needs F16;
+use YENT_DENSE=1)`. `YENT_DENSE=1` is required and was never recorded, which
+also means the reference runs dense F32 there while the port runs packed — the
+tolerance measures dequantization and the exact integer matvec against dense
+arithmetic, not one packed path against another.
+
+The reference forward applies a low-rank delta mid-block, and it loads that
+delta by a path **relative to the working directory**
+(`weights/arianna.delta.r`, inside `resonance_load_gguf`). It is absent here —
+rank 8, alpha 0, `sum|A| = 0` — so the goldens are clean, but a driver run from
+a directory where that file exists would have frozen a different model with no
+sign of it. Both headers now say so.
+
+And the number that had been asserted in a comment is now measured: the shipped
+integer-matvec build sits **1.240e-01** from the reference on those eight ids,
+8 of 8 matched. The exact-matvec build, which is what the tolerance gate
+compares, sits at 3.338e-05.
+
+The drivers stay out of this tree. They include `arianna.c` headers, and a
+build here that reaches into a sibling repository is the contamination rule.
+What travels is the number and a recipe that has now been run.
+
+### The harness became a linkable surface
+
+`libnotorch.a` was `notorch.o` and `gguf.o`, nothing else, and `make install`
+shipped four headers, none of them the harness's. A body wanting to run a GGUF
+through this tree had two options: copy `harness/*.c` into its own build, or
+link `main.c` and inherit its `main()`. The first is a fork; the second is not
+a library. Yent's inference is being rebuilt on this harness, so it needed a
+third option.
+
+The family table and its lookup moved out of `main.c` into `harness/archs.c`
+behind `harness/archs.h` — `main.c` had kept everything else `static`, so that
+table was the only thing a caller needed and could not reach.
+`libnotorch_harness.a` now carries the six families, the runtime, the KV cache
+and the tokenizer; `make install` adds it and four more headers under
+`include/ariannamethod/harness/` and `.../examples/`. Two archives and not one,
+because the split is real: `libnotorch` is the substrate anything can use,
+`libnotorch_harness` is family code that only means something to a caller
+running models.
+
+`harness/test_consumer_link.sh` installs into a throwaway prefix and builds
+`tests/consumer_link.c` against it with `-lnotorch_harness -lnotorch` and no
+notorch source on the command line — `arch=llama tokens=5 vocab=32000
+argmax=264`. It runs the negative case in the same pass and requires the build
+**without** `-lnotorch_harness` to fail, because a link test that would pass
+without the archive is testing nothing. Red hand: dropping `archs.o` from the
+archive puts the gate straight into `Undefined symbols: _nt_pick_arch`.
+
+Gates unmoved by the split: `NOTORCH_PARITY_OK (6 checks)`, `JANUS_OK`,
+`RESONANCE_OK`, `NOTORCH_CONSUMER_OK (3 checks)`, notorch_test 49/49 and 73/73,
+test_qmatmul 34/34. `test_quantize` still FAILs Q8_0 at 2.081e-04 over
+2.067e-04, unchanged since `cd659e8`.
+
+---
+
+
 ## 2026-09-12 — the parity gate could not run, and said FAIL
 
 The agent rules in this tree carry "a gate that cannot run must report neither

--- a/README.md
+++ b/README.md
@@ -451,6 +451,28 @@ the f32 engines are still here for what fits in RAM without packing:
 
 fuck torch — but also, you do not need llama.cpp to *run* what you built. the packed-Metal path is what turns "run a 24B on the laptop you already own" into a true sentence.
 
+### the harness is a library, not just a binary
+
+`harness/` is the small one: GGUF in, text out, one `nt_arch` interface, one file per family (`llama` as the fallback, plus `gemma4`, `olmoe`, `mamba`, and the Method's own `resonance` and `janus`). the CLI on top of it is `main.c` — and `main.c` is *only* the CLI. everything a body needs is in the archive next to it.
+
+```bash
+make lib lib_harness && make install PREFIX=/opt/homebrew
+cc -I$PREFIX/include/ariannamethod body.c -lnotorch_harness -lnotorch -lm
+```
+
+```c
+#include "harness/archs.h"
+gguf_file *gf = gguf_open(path);
+const nt_arch *arch = nt_pick_arch(gf->arch);   /* never NULL: llama is the fallback */
+nt_dims dims; void *model = arch->load(gf, &dims);
+kv_cache *kv = kv_new(dims.n_layers, max_seq, dims.kv_dim);
+arch->forward(model, kv, ids, n, 0, logits);    /* n>1 prefills; logits are the last row */
+```
+
+two archives on purpose. `libnotorch` is the substrate anything can use — tensors, kernels, GGUF. `libnotorch_harness` is family code that only means something to a caller running models: the six forwards, the runtime, the KV cache, the GGUF-embedded BPE. an organism links both and vendors neither, which is the difference between depending on notorch and forking it.
+
+`make test_consumer_link` proves it the only way that counts: install into a throwaway prefix, build a program from outside the tree with nothing but those two `-l` flags, run a model through it — and then build it *again* without `-lnotorch_harness` and require that one to fail.
+
 ---
 
 ## alignment training — DPO / GRPO / distillation

--- a/harness/archs.c
+++ b/harness/archs.c
@@ -1,0 +1,23 @@
+#include "harness/archs.h"
+#include <string.h>
+
+const nt_arch *const nt_archs[] = {
+    &nt_arch_gemma4,
+    &nt_arch_olmoe,
+    &nt_arch_mamba,
+    &nt_arch_resonance,
+    &nt_arch_janus,
+    &nt_arch_llama,
+    NULL,
+};
+
+const nt_arch *nt_pick_arch(const char *arch) {
+    const nt_arch *fallback = NULL;
+    for (const nt_arch *const *p = nt_archs; *p; p++) {
+        const nt_arch *a = *p;
+        if (!a->names) { fallback = a; continue; }
+        for (const char *const *n = a->names; *n; n++)
+            if (strcmp(*n, arch) == 0) return a;
+    }
+    return fallback;
+}

--- a/harness/archs.h
+++ b/harness/archs.h
@@ -1,0 +1,25 @@
+/* archs.h — the table of families, and the one lookup into it.
+ *
+ * This used to live in main.c, which meant a body wanting the harness had to
+ * either copy the table or compile main.c and inherit its main(). Neither is a
+ * dependency; both are a fork waiting to happen. The table is the harness's
+ * answer to "what can this read", so it belongs in the library, not in the CLI
+ * that happens to be the first caller.
+ */
+#ifndef NT_HARNESS_ARCHS_H
+#define NT_HARNESS_ARCHS_H
+
+#include "harness/arch.h"
+
+/* Exact name first, the unnamed fallback second. `arch` is the GGUF's
+ * general.architecture. Never returns NULL while a fallback family is in the
+ * table, which is the behaviour the reference example had: an architecture it
+ * had never heard of went through the llama forward rather than being refused. */
+const nt_arch *nt_pick_arch(const char *arch);
+
+/* The table itself, for a caller that wants to enumerate rather than look up —
+ * printing what is supported, or refusing a file the fallback would have taken.
+ * NULL-terminated. */
+extern const nt_arch *const nt_archs[];
+
+#endif

--- a/harness/main.c
+++ b/harness/main.c
@@ -9,37 +9,15 @@
  * timings, the profile. A run redirected to a file is text, not a transcript
  * of the tool.
  *
- * Architectures are a table. Adding a family is adding a file next to
- * arch_llama.c and one line to ARCHS. */
-#include "harness/arch.h"
+ * Architectures are a table, and the table lives in archs.c so that a body can
+ * link it without linking this file. Adding a family is adding a file next to
+ * arch_llama.c and one line to nt_archs. */
+#include "harness/archs.h"
 #include "harness/logo.h"
 #include "examples/bpe.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-static const nt_arch *const ARCHS[] = {
-    &nt_arch_gemma4,
-    &nt_arch_olmoe,
-    &nt_arch_mamba,
-    &nt_arch_resonance,
-    &nt_arch_janus,
-    &nt_arch_llama,
-};
-
-/* Exact name first, the unnamed fallback second. The reference example ran any
- * architecture it had never heard of through the llama forward, and losing
- * that on the way here would have been a regression dressed as a refactor. */
-static const nt_arch *pick_arch(const char *arch) {
-    const nt_arch *fallback = NULL;
-    for (unsigned i = 0; i < sizeof(ARCHS) / sizeof(ARCHS[0]); i++) {
-        const nt_arch *a = ARCHS[i];
-        if (!a->names) { fallback = a; continue; }
-        for (const char *const *n = a->names; *n; n++)
-            if (strcmp(*n, arch) == 0) return a;
-    }
-    return fallback;
-}
 
 /* Everything a turn needs, so one-shot and chat run the same code. */
 typedef struct {
@@ -407,7 +385,7 @@ int main(int argc, char **argv) {
     gguf_file *gf = gguf_open(path);
     if (!gf) return 1;
 
-    const nt_arch *arch = pick_arch(gf->arch);
+    const nt_arch *arch = nt_pick_arch(gf->arch);
     if (!arch) {
         fprintf(stderr, "notorch: no architecture handles '%s'\n", gf->arch);
         gguf_close(gf);

--- a/harness/test_consumer_link.sh
+++ b/harness/test_consumer_link.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+# test_consumer_link.sh — the harness is a library, or it is not.
+#
+# Installs into a throwaway prefix and builds tests/consumer_link.c against it
+# with nothing but -lnotorch_harness -lnotorch and the installed headers. No
+# notorch source on the command line: if a symbol a body needs is still trapped
+# in main.c, this fails to link, which is the whole point.
+#
+#   ./harness/test_consumer_link.sh [model.gguf]
+#
+# The negative case runs too. A link test that would pass without the archive
+# is testing nothing, so it also builds without -lnotorch_harness and requires
+# that one to fail.
+set -eu
+cd "$(dirname "$0")/.."
+
+MODEL="${1:-$HOME/arianna/weights/nano_arianna_full_resft_2026_07_09/nano_arianna_q8_0.gguf}"
+if [ ! -f "$MODEL" ]; then
+  echo "consumer  (no model at $MODEL — pass one to run this gate)"
+  echo "NOTORCH_CONSUMER_SKIPPED"
+  exit 0
+fi
+
+PREFIX=$(mktemp -d -t nt_consumer)
+trap 'rm -rf "$PREFIX"' EXIT
+
+make -s lib lib_harness >/dev/null
+make -s install PREFIX="$PREFIX" >/dev/null
+
+INC="$PREFIX/include/ariannamethod"
+for h in harness/arch.h harness/archs.h harness/runtime.h examples/bpe.h gguf.h notorch.h; do
+  [ -f "$INC/$h" ] || { echo "consumer  header $h was not installed  FAIL"; echo "NOTORCH_CONSUMER_FAIL"; exit 1; }
+done
+[ -f "$PREFIX/lib/libnotorch_harness.a" ] || { echo "consumer  libnotorch_harness.a was not installed  FAIL"; echo "NOTORCH_CONSUMER_FAIL"; exit 1; }
+
+# Accelerate on this machine, nothing on a machine without it. The point of the
+# gate is the two archives, not the BLAS underneath them.
+EXTRA=""
+[ "$(uname)" = "Darwin" ] && EXTRA="-framework Accelerate"
+
+# shellcheck disable=SC2086
+if ! ${CC:-cc} -O2 -std=gnu11 -I"$INC" -o "$PREFIX/consumer" tests/consumer_link.c \
+       -L"$PREFIX/lib" -lnotorch_harness -lnotorch $EXTRA -lm 2>"$PREFIX/link.err"; then
+  echo "consumer  linking against the installed archives  FAIL"
+  sed 's/^/  /' "$PREFIX/link.err"
+  echo "NOTORCH_CONSUMER_FAIL"
+  exit 1
+fi
+echo "consumer  links with -lnotorch_harness -lnotorch and no notorch source  PASS"
+
+OUT=$("$PREFIX/consumer" "$MODEL" "The capital of France is" 2>/dev/null) || {
+  echo "consumer  running the linked binary  FAIL"; echo "NOTORCH_CONSUMER_FAIL"; exit 1
+}
+case "$OUT" in
+  arch=*tokens=*vocab=*argmax=*) echo "consumer  ran a model through the archive: $OUT  PASS" ;;
+  *) echo "consumer  unexpected output: $OUT  FAIL"; echo "NOTORCH_CONSUMER_FAIL"; exit 1 ;;
+esac
+
+# shellcheck disable=SC2086
+if ${CC:-cc} -O2 -std=gnu11 -I"$INC" -o "$PREFIX/consumer_red" tests/consumer_link.c \
+     -L"$PREFIX/lib" -lnotorch $EXTRA -lm 2>/dev/null; then
+  echo "consumer  it linked WITHOUT -lnotorch_harness — this gate proves nothing  FAIL"
+  echo "NOTORCH_CONSUMER_FAIL"
+  exit 1
+fi
+echo "consumer  refuses to link without the harness archive  PASS"
+
+echo "NOTORCH_CONSUMER_OK (3 checks)"

--- a/tests/consumer_link.c
+++ b/tests/consumer_link.c
@@ -1,0 +1,47 @@
+/* consumer_link.c — the harness used the way a body uses it.
+ *
+ * Not a correctness test: harness/test_parity.sh and the architecture goldens
+ * do that. This asserts one thing those cannot, because they all compile the
+ * tree's own sources — that a program outside the tree can run a model by
+ * linking two installed archives and including four installed headers, with no
+ * notorch source on its command line.
+ *
+ * Yent's inference is being rebuilt on this harness, so the day that stops
+ * being true is a day somebody discovers by hand. harness/test_consumer_link.sh
+ * installs into a throwaway prefix and builds this against it.
+ */
+#include "harness/archs.h"
+#include "examples/bpe.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+int main(int argc, char **argv) {
+    if (argc < 3) { fprintf(stderr, "usage: %s model.gguf \"prompt\"\n", argv[0]); return 2; }
+
+    gguf_file *gf = gguf_open(argv[1]);
+    if (!gf) return 1;
+
+    const nt_arch *arch = nt_pick_arch(gf->arch);
+    if (!arch) { fprintf(stderr, "no family for '%s'\n", gf->arch); return 1; }
+
+    nt_dims dims;
+    void *model = arch->load(gf, &dims);
+    if (!model) { fprintf(stderr, "load failed\n"); return 1; }
+
+    bpe_tokenizer *tok = bpe_load(argv[1]);
+    int ids[512], n = 0;
+    if (tok) n = bpe_encode(tok, argv[2], ids, 512);
+    else { ids[n++] = 1; for (int i = 0; argv[2][i] && n < 512; i++) ids[n++] = (unsigned char)argv[2][i]; }
+
+    kv_cache *kv = kv_new(dims.n_layers, n + 8, dims.kv_dim);
+    float *logits = (float *)malloc((size_t)dims.vocab * sizeof(float));
+    if (!kv || !logits) return 1;
+
+    arch->forward(model, kv, ids, n, 0, logits);
+
+    int best = 0;
+    for (int i = 1; i < dims.vocab; i++) if (logits[i] > logits[best]) best = i;
+
+    printf("arch=%s tokens=%d vocab=%d argmax=%d\n", gf->arch, n, dims.vocab, best);
+    return 0;
+}

--- a/tests/janus_golden_v4.txt
+++ b/tests/janus_golden_v4.txt
@@ -6,6 +6,26 @@
 # autoregressive path, not the batched one. These are the eight largest logits
 # of the last position, after the 15*tanh(l/15) cap.
 #
+# Re-derived 2026-09-12, because a golden nobody can reproduce is a number with
+# a story attached. A driver written from scratch against yent_read_cfg +
+# yent_load_gguf + forward_token reproduces all eight to the printed digit, and
+# reproduces them again when the whole substrate is swapped for arianna.c's own
+# vendored notorch (ariannamethod/notorch/, 3867 lines of notorch.c and 353 of
+# gguf.c different from this tree's): bit-identical on both.
+#
+# One thing the recipe above left out and did not survive re-running: this file
+# is Q8_0, dtype 8, and the reference's packed path takes F16 only — it exits
+# with "not F16 (packed path needs F16; use YENT_DENSE=1)". YENT_DENSE=1 is part
+# of the recipe. It also means the reference runs dense F32 here while the port
+# runs packed, so what the tolerance below measures is dequantization and the
+# exact integer matvec against dense arithmetic, not one packed path against
+# another.
+#
+# The delta sidecar the forward applies mid-block is absent: rank 8, alpha 0,
+# A and B allocated but never filled — weights/arianna.delta.r does not exist,
+# and the reference loads it by a path relative to the working directory, so a
+# driver run from the wrong place would silently fold in a different model.
+#
 # Why the per-token path and not the batched prefill: they are not the same
 # model. The batched one sums the low-rank RRPRAM state over every position of
 # the prompt and hands that to all of them, so row 0's scores carry tokens that

--- a/tests/resonance_golden_v3.txt
+++ b/tests/resonance_golden_v3.txt
@@ -14,6 +14,20 @@
 # accumulation in dot_f32/axpy_f32 against the reference's scalar loops —
 # building the port with -U__ARM_NEON reproduces the reference bit for bit.
 #
+# Re-derived 2026-09-12, because a golden nobody can reproduce is a number with
+# a story attached. A driver written from scratch against resonance_load_gguf +
+# forward_token gives these eight ids back with a worst distance of 7.15e-06,
+# and gives them again with a worst distance of 8.58e-06 when the substrate is
+# swapped for arianna.c's own vendored notorch (ariannamethod/notorch/, 3867
+# lines of notorch.c and 353 of gguf.c different from this tree's). The two
+# substrates sit 3.34e-06 apart, so on this path our kernels and the ones the
+# model was actually run with are not hiding anything from each other.
+#
+# The delta sidecar the forward applies mid-block is absent: rank 8, alpha 0,
+# sum|A| = 0 — weights/arianna.delta.r does not exist, and resonance_load_gguf
+# loads it by a path relative to the working directory, so a driver run from the
+# wrong place would silently fold in a different model.
+#
 # id  logit
 257 6.47917223
 262 5.55650806


### PR DESCRIPTION
Two questions with one shape: does the thing everyone is about to build on hold.

THE GOLDENS. tests/resonance_golden_v3.txt and tests/janus_golden_v4.txt are the only reference for the Method's own two families — llama.cpp refuses both with "unknown model architecture" — and nobody had ever run their recipe back. Both re-derived from arianna.c's own forwards with drivers written from scratch, then re-derived again with the entire substrate swapped for arianna.c's vendored notorch (notorch.c differs by 3867 lines, gguf.c by 353). Resonance: worst 7.15e-06 on this tree's substrate, 8.58e-06 on the vendored one, the two substrates 3.34e-06 apart, against a 1e-3 tolerance. Janus: bit-identical on both, all eight logits to the printed digit.

Three things the headers did not say. The Janus recipe as written does not run — Q8_0 is dtype 8 and the reference's packed path takes F16 only, so YENT_DENSE=1 is required and was never recorded; it also means the reference runs dense F32 there while the port runs packed. The reference forward loads a low-rank delta by a path relative to the working directory, absent here (rank 8, alpha 0, sum|A| = 0) — a driver run from a directory holding that file would have frozen a different model silently. And the shipped integer-matvec build sits 1.240e-01 from the reference on those eight ids, 8 of 8 matched, a number that until now lived only in a comment. Both headers now carry all three.

The drivers stay out of this tree: they include arianna.c headers, and a build here that reaches into a sibling repository is the contamination rule. What travels is the number and a recipe that has been run.

THE HARNESS. libnotorch.a was notorch.o and gguf.o and nothing else, and install shipped no harness header — so a body had two options, copy harness/*.c or link main.c and inherit its main(). The first is a fork, the second is not a library. The family table and its lookup moved out of main.c into harness/archs.c behind harness/archs.h; main.c had kept everything else static, so that table was the only thing a caller needed and could not reach. libnotorch_harness.a now carries the six families, the runtime, the KV cache and the tokenizer, and install adds four headers under include/ariannamethod/harness and .../examples. Two archives because the split is real: substrate, and family code that only means something to a caller running models.

harness/test_consumer_link.sh installs into a throwaway prefix and builds tests/consumer_link.c with -lnotorch_harness -lnotorch and no notorch source: arch=llama tokens=5 vocab=32000 argmax=264. It runs the negative case in the same pass and requires the build without the harness archive to fail. Red hand: dropping archs.o from the archive puts it straight into "Undefined symbols: _nt_pick_arch".

Gates unmoved: NOTORCH_PARITY_OK (6 checks), JANUS_OK, RESONANCE_OK, NOTORCH_CONSUMER_OK (3 checks), notorch_test 49/49 and 73/73, test_qmatmul 34/34. test_quantize still FAILs Q8_0 at 2.081e-04 over 2.067e-04, unchanged since cd659e8.

Quote: "Show me your flowcharts and conceal your tables, and I shall continue to be mystified. Show me your tables, and I won't usually need your flowcharts; they'll be obvious." — Frederick P. Brooks, The Mythical Man-Month, 1975 Method: the Method took its own tables out of the program that was hiding them. By Arianna Method (Co-authored by Claude, neo) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff