### PR TITLE
the method found a quarter of the machine doing all the work

### DIFF
--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,52 @@ Newest entries on top.
 
 ---
 
+## 2026-09-12 — a prefill that halved after the first answer, for two years of nobody noticing
+
+The pool gave each of its threads one core of its own and pinned it there, including the
+thread that starts it. Two things follow that nobody measured.
+
+A pinned thread cannot be moved off a busy core onto an idle one, so a pool thread waking for
+one matvec preempts whatever the scheduler had put there rather than going somewhere free.
+And on Linux a new thread inherits its parent's affinity mask — so from the first decode
+onward, every fan-out a batched matmul opened was born onto the single core the pool had
+pinned its parent to. The prompt was processed by one core with three idle beside it.
+
+Which reads as a prefill that drops by a third or a half after the first answer: every turn of
+a conversation but the first. A 350-token prompt, three passes in one process,
+`taskset -c 4-7`:
+
+    qwen05b Q4_0    96.7  47.5  47.8   ->   104.4  98.2  96.8
+    qwen05b Q4_K_M  89.0  36.0  35.7   ->    83.3  84.2  83.5
+    mamba-130m-f16  92.8  47.5  47.0   ->    85.6  94.2  95.8
+
+Decode, the thing the narrowing was for, measures the same or better on every model here:
+gemma-4 Q4_0 10.8 against 10.8, qwen Q4_0 51.0 against 56.9, mamba f16 36.2 against 38.7.
+Nothing was traded. The core *selection* is untouched and still worth what it was measured at
+— `NT_QMV_PIN=0` gives that up and remains the way to.
+
+**Two explanations were tried first and both were wrong.** The allocator: a new per-call chunk
+buffer had just been added elsewhere, and calloc over recycled heap writes every byte where
+calloc over fresh kernel pages does not — holding the buffer across calls changed the numbers
+by nothing. Heat: the die reads 55-57 C either way, and under `NT_QMV_PIN=0` the same three
+passes at the same temperature stay flat. What named the cause was deleting the caller's pin
+outright and watching the collapse go, then putting it back and watching it return.
+
+Widening only the fan-out was tried too and was not enough: the caller drains chunks as well,
+so a worker that cannot leave one core holds the whole call. Holding every thread to the whole
+chosen set is the change; there is no wrapper around the batched entries.
+
+`tests/test_affinity.c` asserted the old arrangement — "the driving thread holds one core of
+its own" — which is the bug written down as a requirement. It now asserts the set, and carries
+the consequence as its own check: a thread created after the pool exists must see every core
+the plan chose. Restoring one-core pinning turns both red, and the child's mask in the failure
+reads `cpus 4` where four were expected.
+
+Gates: 17 suites green, tokenizer identical on 24, harness parity OK, ThreadSanitizer clean on
+both pools.
+
+---
+
 ## 2026-09-12 — the wrapping moves into the file, and two guards that were never guarding
 
 `NT_CHAT` proved the mechanism and left the ids in the operator's hands, which is

--- a/notorch.c
+++ b/notorch.c
@@ -5604,18 +5604,44 @@ static inline const nt_qmv_plan *nt_qmv_get_plan(void) {
 
 static long nt_qmv_plan_thread_min(void) { return nt_qmv_get_plan()->thread_min; }
 
-static void nt_qmv_pin_nth(pthread_t t, int idx) {
+/* Hold a thread to the cores the plan chose, and let the scheduler place it among them.
+ *
+ * This used to give each thread one core of its own, by index. The core *selection* is what
+ * was measured and it stands — dropping the slowest cluster is worth a third on this SoC,
+ * and NT_QMV_PIN=0 gives that up. The per-thread narrowing is the part nobody measured, and
+ * it costs more than it was ever shown to buy.
+ *
+ * Two ways. A pinned thread cannot be moved off a busy core onto an idle one, so a pool
+ * thread waking for one matvec preempts whatever the scheduler had put there instead of
+ * going somewhere free. And on Linux a new thread inherits its parent's mask, so once the
+ * pool pinned the thread that started it to a single core, every fan-out a batched matmul
+ * opened from that thread afterwards was born onto that same core — a prefill running on one
+ * core with three idle beside it.
+ *
+ * Which reads as a prefill that drops by a third or a half after the first answer: on every
+ * turn of a conversation but the first. A 350-token prompt, three passes in one process,
+ * four big cores, `taskset -c 4-7`:
+ *
+ *     qwen05b Q4_0    96.7 then 47.5 and 47.8       Q4_K_M  89.0 then 36.0 and 35.7
+ *     mamba-130m-f16  92.8 then 47.5 and 47.0
+ *
+ * Holding every thread to the whole chosen set instead reads 104.4, 98.2, 96.8 on Q4_0 and
+ * 83.3, 84.2, 83.5 on Q4_K_M. Decode — the thing the narrowing was for — measures the same or
+ * better on every model here: gemma-4 Q4_0 10.8 against 10.8, qwen Q4_0 51.0 against 56.9,
+ * mamba f16 36.2 against 38.7. Nothing was traded for it.
+ *
+ * Two explanations were tried and refuted before this one. The allocator: the chunk buffers
+ * were being taken per call, and calloc over recycled heap has to write every byte where
+ * calloc over fresh kernel pages does not — holding the buffer changed nothing. And heat:
+ * the die reads 55-57 C either way, and with NT_QMV_PIN=0 the same three passes at the same
+ * temperature stay flat. */
+static void nt_qmv_place(pthread_t t) {
 #if defined(__linux__)
     const nt_qmv_plan *p = nt_qmv_get_plan();
     if (!p->pin || p->ncpu <= 0) return;
-    int want = idx % p->ncpu, seen = 0;
-    cpu_set_t one;
-    CPU_ZERO(&one);
-    for (int c = 0; c < CPU_SETSIZE; c++)
-        if (CPU_ISSET(c, &p->cpus) && seen++ == want) { CPU_SET(c, &one); break; }
-    if (CPU_COUNT(&one)) pthread_setaffinity_np(t, sizeof(one), &one);
+    pthread_setaffinity_np(t, sizeof(p->cpus), &p->cpus);
 #else
-    (void)t; (void)idx;
+    (void)t;
 #endif
 }
 
@@ -5745,12 +5771,12 @@ static void nt_qpool_shutdown(void) {
 
 static void nt_qpool_init_once(void) {
     int nt = nt_qmv_host_threads(NT_QMV_MAX_THREADS);
-    nt_qmv_pin_nth(pthread_self(), 0);
+    nt_qmv_place(pthread_self());
     for (int i = 0; i < nt; i++) {
         g_nt_qpool.ids[i] = i;
         if (pthread_create(&g_nt_qpool.threads[i], NULL, nt_qpool_loop, &g_nt_qpool.ids[i]) != 0)
             break;
-        nt_qmv_pin_nth(g_nt_qpool.threads[i], i + 1);
+        nt_qmv_place(g_nt_qpool.threads[i]);
         g_nt_qpool.nthreads++;
     }
     g_nt_qpool.ready = g_nt_qpool.nthreads > 0;
@@ -6879,11 +6905,11 @@ static void nt_qpool_i8_init_once(void) {
      * a pool sized to the core count puts one thread too many on the cluster and every
      * matvec pays for the context switch. */
     int nt = nt_qmv_host_threads(NT_QMV_MAX_THREADS) - 1;
-    nt_qmv_pin_nth(pthread_self(), 0);   /* the dispatcher takes a chunk too */
+    nt_qmv_place(pthread_self());        /* the dispatcher takes a chunk too */
     for (int i = 0; i < nt; i++) {
         if (pthread_create(&g_nt_qpool_i8.threads[i], NULL, nt_qpool_i8_loop, NULL) != 0)
             break;
-        nt_qmv_pin_nth(g_nt_qpool_i8.threads[i], i + 1);
+        nt_qmv_place(g_nt_qpool_i8.threads[i]);
         g_nt_qpool_i8.nthreads++;
     }
     g_nt_qpool_i8.ready = g_nt_qpool_i8.nthreads > 0;

--- a/tests/test_affinity.c
+++ b/tests/test_affinity.c
@@ -90,6 +90,14 @@ static int run_one_matvec(void) {
     return rc;
 }
 
+/* Reports the mask it was born with, which is the mask its parent held. */
+static void *child_mask(void *out) {
+    cpu_set_t *m = (cpu_set_t *)out;
+    CPU_ZERO(m);
+    pthread_getaffinity_np(pthread_self(), sizeof(*m), m);
+    return NULL;
+}
+
 int main(int argc, char **argv) {
     const char *mode = argc > 1 ? argv[1] : "default";
     printf("core selection [%s]\n", mode);
@@ -130,7 +138,7 @@ int main(int argc, char **argv) {
     describe(&want, a, sizeof(a));
 
     int planned = nt_qmv_planned_threads();
-    char detail[128];
+    char detail[640];
     snprintf(detail, sizeof(detail), "planned %d, expected %d over cpus %s", planned, want_n, a);
     check("thread count matches the core plan", planned == want_n, detail);
 
@@ -143,26 +151,46 @@ int main(int argc, char **argv) {
         return 1;
     }
     describe(&now, b, sizeof(b));
-    /* One thread per core, in order, so the thread that drove the matvec holds the first CPU
-     * of the plan and nothing else. A shared mask is not enough: the scheduler will put two
-     * spin-then-park threads on one core and keep them there. */
-    cpu_set_t first;
-    CPU_ZERO(&first);
-    if (!strcmp(mode, "nopin")) first = start;        /* nothing may have touched it */
-    else
-        for (int c = 0; c < CPU_SETSIZE; c++)
-            if (CPU_ISSET(c, &want)) { CPU_SET(c, &first); break; }
-    char fbuf[64];
-    describe(&first, fbuf, sizeof(fbuf));
-    /* The message has to name what this mode actually expects. With NT_QMV_PIN=0 the mask
-     * must come back untouched, and calling that "the plan's first core" would send whoever
-     * reads a failure here looking in the wrong place. */
+    /* Every thread is held to the plan's cores and placed among them by the scheduler.
+     *
+     * This used to assert the opposite — one core per thread, the driving thread on the first
+     * of them — and that assertion was the bug written down as a requirement. A thread pinned
+     * to one core cannot be moved off it, and on Linux a new thread inherits its parent's
+     * mask: once the pool narrowed the thread that started it, every fan-out a batched matmul
+     * opened afterwards was born onto that one core. Prefill after the first answer ran on a
+     * quarter of the machine. The set is what was measured and the set is what is asserted. */
+    cpu_set_t expect;
+    if (!strcmp(mode, "nopin")) expect = start;       /* nothing may have touched it */
+    else expect = want;
+    char fbuf[256];
+    describe(&expect, fbuf, sizeof(fbuf));
     if (!strcmp(mode, "nopin")) {
         snprintf(detail, sizeof(detail), "on cpus %s, expected the mask untouched: %s", b, fbuf);
-        check("nothing touched the affinity mask", CPU_EQUAL(&now, &first), detail);
+        check("nothing touched the affinity mask", CPU_EQUAL(&now, &expect), detail);
     } else {
-        snprintf(detail, sizeof(detail), "on cpus %s, expected the plan's first core %s", b, fbuf);
-        check("the driving thread holds one core of its own", CPU_EQUAL(&now, &first), detail);
+        snprintf(detail, sizeof(detail), "on cpus %s, expected the plan's cores %s", b, fbuf);
+        check("the driving thread holds the whole chosen set", CPU_EQUAL(&now, &expect), detail);
+    }
+
+    /* And the consequence, checked rather than reasoned about: a thread created after the
+     * pool exists must be able to run on every core the plan chose. This is the assertion the
+     * old one-core-per-thread arrangement fails, which is the point of having it. */
+    {
+        cpu_set_t child;
+        CPU_ZERO(&child);
+        pthread_t th;
+        if (pthread_create(&th, NULL, child_mask, &child) == 0) {
+            pthread_join(th, NULL);
+            char cbuf[256];
+            describe(&child, cbuf, sizeof(cbuf));
+            snprintf(detail, sizeof(detail),
+                     "a thread opened after the pool sees cpus %s, expected %s", cbuf, fbuf);
+            check("a thread born after the pool inherits every chosen core",
+                  CPU_EQUAL(&child, &expect), detail);
+        } else {
+            check("a thread born after the pool inherits every chosen core", 0,
+                  "pthread_create refused");
+        }
     }
 
     printf("\nResults: %s\n", fails ? "FAILED" : "all passed");


### PR DESCRIPTION
The pool gave each of its threads one core of its own and pinned it there — **including the thread that starts it**. Two things follow that nobody measured.

A pinned thread cannot be moved off a busy core onto an idle one, so a pool thread waking for one matvec preempts whatever the scheduler had put there rather than going somewhere free. And on Linux **a new thread inherits its parent's affinity mask** — so from the first decode onward, every fan-out a batched matmul opened was born onto the single core the pool had pinned its parent to. The prompt was processed by one core with three idle beside it.

Which reads as a prefill that drops by a third or a half **after the first answer** — every turn of a conversation but the first. 350-token prompt, three passes in one process, `taskset -c 4-7`:

| model | before | after |
|---|---|---|
| qwen05b Q4_0 | 96.7 · 47.5 · 47.8 | **104.4 · 98.2 · 96.8** |
| qwen05b Q4_K_M | 89.0 · 36.0 · 35.7 | **83.3 · 84.2 · 83.5** |
| mamba-130m-f16 | 92.8 · 47.5 · 47.0 | **85.6 · 94.2 · 95.8** |

Decode — the thing the narrowing was for — measures the same or better on every model here: gemma-4 Q4_0 10.8 vs 10.8, qwen Q4_0 51.0 vs 56.9, mamba f16 36.2 vs 38.7. Nothing was traded. The core *selection* is untouched and still worth what it was measured at; `NT_QMV_PIN=0` gives that up and remains the way to.

**Two explanations were tried first and both were wrong.** The allocator — a per-call chunk buffer had just been added elsewhere, and calloc over recycled heap writes every byte where calloc over fresh kernel pages does not; holding the buffer across calls changed the numbers by nothing. And heat — the die reads 55–57 °C either way, and under `NT_QMV_PIN=0` the same three passes at the same temperature stay flat. What named the cause was deleting the caller's pin outright and watching the collapse go, then putting it back and watching it return.

Widening only the fan-out was tried and was not enough: the caller drains chunks as well, so a worker that cannot leave one core holds the whole call.

`tests/test_affinity.c` asserted the old arrangement — *"the driving thread holds one core of its own"* — which is the bug written down as a requirement. It now asserts the set, and carries the consequence as its own check: **a thread created after the pool exists must see every core the plan chose.** Restoring one-core pinning turns both red, and the child's mask in that failure reads `cpus 4` where four were expected.

Gates: 17 suites green, tokenizer identical on 24, harness parity OK, ThreadSanitizer clean on both pools.