### PR TITLE
The Method stopped unknown GGUFs from becoming Llama

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,12 @@ Assume another node may be preparing a change while you inspect the tree.
 - Work on a dedicated branch (`codex/<topic>`, `claude/<topic>`, or another
   agent-specific prefix). Never push directly to `main`. Push the branch and let
   Oleg merge it.
+- Immediately before finalizing a commit, fetch `origin` and integrate the
+  current `origin/main` into the working branch. Work arrives from several
+  machines; a branch that was current at checkout may already be stale. Preserve
+  local work while doing this — never use a destructive reset as a shortcut.
+  After integrating, re-read the top of `NOTORCHLOG.md` and place the new entry
+  in true reverse-chronological order. Check `origin/main` once more before push.
 - Preserve unknown or unrelated work. Do not clean, reset, overwrite, or commit
   another agent's files merely because they are present.
 - Every commit must have a technical subject/body plus a unique, relevant

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,13 @@ push the branch, let Oleg merge. Nobody pushes to `main` directly, including you
 four in the morning when the fix is obviously trivial. Two nodes landing on `main`
 from different machines is how a good afternoon becomes a bad evening.
 
+And a branch is not current merely because it was current when you opened it.
+**Immediately before finalizing every commit, fetch `origin` and integrate the
+current `origin/main` into your branch without destroying local work.** Then re-read
+the top of `NOTORCHLOG.md`: several machines write it, so its newest-first order must
+be resolved after the sync, not guessed before it. Check `origin/main` once more
+before push. Never use a blind pull or destructive reset to satisfy this rule.
+
 **Small changes go to `NOTORCHLOG.md`, large ones also get a section in `README.md`.**
 A bug fix, a kernel that got faster, a sync-discipline correction, a docstring — those
 are log entries, and the README never hears about them. A new backend, a new op family,

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,27 @@ Newest entries on top.
 
 ---
 
+## 2026-09-12 — the public registry stopped guessing Llama
+
+The newly linkable harness exposed `nt_pick_arch`, and an independent consumer
+asked it for an architecture that does not exist. It returned Llama. That made
+the public surface contradict the repository's own rule: an unfamiliar GGUF
+must not be repaired by silently pretending it is Llama.
+
+The Llama-family implementation now explicitly claims the two architecture
+names whose distinct paths it actually carries: `llama` (interleaved RoPE) and
+`qwen2` (NEOX RoPE). Unknown and NULL names return NULL, so the caller refuses
+the file before any model-family arithmetic runs. The installed consumer gate
+checks both positive names and both refusals before opening its real GGUF.
+
+Red hand: at the harness-library pin `e4c553d`, the independent strict lookup
+probe exits 2 with `unknown architecture silently selected a family`. With the
+fix it prints `STRICT_ARCH_OK`; the real installed consumer remains
+`arch=llama tokens=5 vocab=32000 argmax=264`, and the archive with `archs.o`
+removed still fails to link on `_nt_archs` and `_nt_pick_arch`.
+
+---
+
 ## 2026-09-12 — a prefill that halved after the first answer
 
 The pool gave each of its threads one core of its own and pinned it there, including the

--- a/harness/arch.h
+++ b/harness/arch.h
@@ -5,10 +5,9 @@
  * or the forward of another family, this interface is lying and it is the
  * interface that gets fixed, not the family.
  *
- * `names` is matched against the GGUF's general.architecture. NULL means the
- * fallback: the family that takes a file no other family claims. There is
- * exactly one of those, and today it is llama — which is what the reference
- * example already did with every architecture it had never heard of. */
+ * `names` is matched against the GGUF's general.architecture. Every family
+ * names what it actually implements: an unknown architecture is refused
+ * rather than sent through arithmetic that merely looks similar. */
 #ifndef NT_HARNESS_ARCH_H
 #define NT_HARNESS_ARCH_H
 
@@ -20,7 +19,7 @@ typedef struct {
 } nt_dims;
 
 typedef struct {
-    const char *const *names;    /* NULL-terminated, or NULL for the fallback */
+    const char *const *names;    /* NULL-terminated list of supported names */
     void *(*load)(gguf_file *gf, nt_dims *dims);
     void  (*free)(void *model);
     /* One forward for a group of consecutive positions. Decode calls it with

--- a/harness/arch_llama.c
+++ b/harness/arch_llama.c
@@ -1,4 +1,4 @@
-/* arch_llama.c — the llama family, and the fallback for everything unnamed.
+/* arch_llama.c — the llama and qwen2 family.
  *
  * SmolLM2, nanollama, Qwen2.5, LLaMA, Mistral: any GGUF whose blocks are
  * attn_norm / attn_{q,k,v,output} / ffn_norm / ffn_{gate,up,down}. GQA, bias
@@ -48,10 +48,9 @@ static void *llama_load(gguf_file *gf, nt_dims *dims) {
     m->ffn = gf->ffn_dim;
     m->rope_base = gf->rope_freq_base;
     m->rms_eps = gf->rms_eps;
-    /* llama and its direct descendants rotate adjacent lanes; everything else
-     * in this file's reach — qwen2, and the qwen-derived checkpoints people
-     * convert — rotates halves. Unknown architectures get the llama
-     * convention, which is the older one. */
+    /* llama and its direct descendants rotate adjacent lanes; qwen2 and its
+     * converted checkpoints rotate halves. The registry refuses everything
+     * else before this loader is called. */
     m->rope_neox = strcmp(gf->arch, "llama") != 0;
 
     int ti = gguf_find_tensor(gf, "blk.0.attn_q.weight");
@@ -278,8 +277,10 @@ static void llama_forward(void *model, kv_cache *kv, const int *tokens, int n,
     free(attn_out); free(ffn_gate); free(ffn_up); free(ffn_out);
 }
 
+static const char *const llama_names[] = { "llama", "qwen2", NULL };
+
 const nt_arch nt_arch_llama = {
-    .names = NULL,          /* the fallback: whatever nobody else claims */
+    .names = llama_names,
     .load = llama_load,
     .free = llama_free,
     .forward = llama_forward,

--- a/harness/archs.c
+++ b/harness/archs.c
@@ -12,12 +12,12 @@ const nt_arch *const nt_archs[] = {
 };
 
 const nt_arch *nt_pick_arch(const char *arch) {
-    const nt_arch *fallback = NULL;
+    if (!arch) return NULL;
     for (const nt_arch *const *p = nt_archs; *p; p++) {
         const nt_arch *a = *p;
-        if (!a->names) { fallback = a; continue; }
+        if (!a->names) continue;
         for (const char *const *n = a->names; *n; n++)
             if (strcmp(*n, arch) == 0) return a;
     }
-    return fallback;
+    return NULL;
 }

--- a/harness/archs.h
+++ b/harness/archs.h
@@ -11,15 +11,12 @@
 
 #include "harness/arch.h"
 
-/* Exact name first, the unnamed fallback second. `arch` is the GGUF's
- * general.architecture. Never returns NULL while a fallback family is in the
- * table, which is the behaviour the reference example had: an architecture it
- * had never heard of went through the llama forward rather than being refused. */
+/* Exact name lookup. `arch` is the GGUF's general.architecture. Returns NULL
+ * for NULL or an architecture no family explicitly claims. */
 const nt_arch *nt_pick_arch(const char *arch);
 
 /* The table itself, for a caller that wants to enumerate rather than look up —
- * printing what is supported, or refusing a file the fallback would have taken.
- * NULL-terminated. */
+ * printing what is supported without duplicating the registry. NULL-terminated. */
 extern const nt_arch *const nt_archs[];
 
 #endif

--- a/tests/consumer_link.c
+++ b/tests/consumer_link.c
@@ -18,6 +18,16 @@
 int main(int argc, char **argv) {
     if (argc < 3) { fprintf(stderr, "usage: %s model.gguf \"prompt\"\n", argv[0]); return 2; }
 
+    /* Architecture selection is part of the installed surface. A body must
+     * never discover support by executing the wrong family's arithmetic. */
+    if (nt_pick_arch("llama") != &nt_arch_llama ||
+        nt_pick_arch("qwen2") != &nt_arch_llama ||
+        nt_pick_arch("notorch-red-hand-unknown") != NULL ||
+        nt_pick_arch(NULL) != NULL) {
+        fprintf(stderr, "architecture registry contract failed\n");
+        return 1;
+    }
+
     gguf_file *gf = gguf_open(argv[1]);
     if (!gf) return 1;
 


### PR DESCRIPTION
Make the public architecture registry exact: llama and qwen2 are explicit names, while unknown and NULL architectures are refused before family arithmetic runs. Extend the installed consumer gate with positive and negative registry checks, and document the red-hand witness.\n\nAdd the cross-machine pre-commit sync rule to AGENTS.md and CLAUDE.md so concurrent nodes integrate current main and reorder NOTORCHLOG before committing.\n\nQuote: "For magic consists in this, the true naming of a thing." — Ursula K. Le Guin\nMethod: A body is selected by a name it claims, never by the silence left after every other name fails.