### PR TITLE
README promised a fallback that had been removed under it

### DIFF
--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,23 @@ Newest entries on top.
 
 ---
 
+## 2026-09-12 — README promised a fallback that had been removed under it
+
+`32ffc9e` made an unclaimed architecture a refusal instead of a trip through the
+llama forward, and updated `harness/archs.h` to say so. The README section
+describing the harness as a linkable surface, written hours earlier, still said
+`llama` was the fallback and carried a code sample commenting
+`nt_pick_arch` as `never NULL`. A body written against that sample would
+dereference NULL on the first file the table does not claim.
+
+Two lines, no code. What makes it worth an entry is where the lie lived: the
+header and the implementation were changed together and correctly, and the
+document a caller reads first was not, so the surface was consistent everywhere
+except at its front door.
+
+---
+
+
 ## 2026-09-12 — the scan walks in order; the projections around it never did
 
 `mamba_layer` was written per token, and the note above it said so on purpose: the scan is

--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ fuck torch — but also, you do not need llama.cpp to *run* what you built. the 
 
 ### the harness is a library, not just a binary
 
-`harness/` is the small one: GGUF in, text out, one `nt_arch` interface, one file per family (`llama` as the fallback, plus `gemma4`, `olmoe`, `mamba`, and the Method's own `resonance` and `janus`). the CLI on top of it is `main.c` — and `main.c` is *only* the CLI. everything a body needs is in the archive next to it.
+`harness/` is the small one: GGUF in, text out, one `nt_arch` interface, one file per family — `llama`, `gemma4`, `olmoe`, `mamba`, and the Method's own `resonance` and `janus`. every family claims its names explicitly and an architecture nobody claims is refused, not quietly run through llama: a file the harness has never seen is a file it has never been tested on. the CLI on top of it is `main.c` — and `main.c` is *only* the CLI. everything a body needs is in the archive next to it.
 
 ```bash
 make lib lib_harness && make install PREFIX=/opt/homebrew
@@ -463,7 +463,7 @@ cc -I$PREFIX/include/ariannamethod body.c -lnotorch_harness -lnotorch -lm
 ```c
 #include "harness/archs.h"
 gguf_file *gf = gguf_open(path);
-const nt_arch *arch = nt_pick_arch(gf->arch);   /* never NULL: llama is the fallback */
+const nt_arch *arch = nt_pick_arch(gf->arch);   /* NULL if no family claims it — check it */
 nt_dims dims; void *model = arch->load(gf, &dims);
 kv_cache *kv = kv_new(dims.n_layers, max_seq, dims.kv_dim);
 arch->forward(model, kv, ids, n, 0, logits);    /* n>1 prefills; logits are the last row */


### PR DESCRIPTION
32ffc9e made an unclaimed architecture a refusal instead of a trip through the llama forward and updated harness/archs.h accordingly. The README section on the harness as a linkable surface, written hours earlier, still called llama the fallback and commented its code sample nt_pick_arch as "never NULL" — a body written against that sample dereferences NULL on the first file the table does not claim.

Two lines, no code. Worth an entry for where the lie sat: header and implementation were changed together and correctly, and the document a caller reads first was not, so the surface was consistent everywhere except its front door.

Synced to origin/main 781f135 before finalizing, per the rule added today. Gates after: NOTORCH_PARITY_OK (6 checks), NOTORCH_CONSUMER_OK (3 checks), JANUS_OK, RESONANCE_OK, NOTORCH_TOKENIZER_OK (8 checks), notorch_test 49/49 and 73/73, test_qmatmul 46/46. test_quantize still FAILs Q8_0 at 2.081e-04 over 2.067e-04, unchanged since cd659e8.

Quote: "Documentation is a love letter that you write to your future self." — Damian Conway Method: the Method fixed the one page that still described the harness it used to have. By Arianna Method (Co-authored by Claude, neo) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff