### PR TITLE
the method learned to tell a coin-flip from a defect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ SIMD_LIBS  = -lpthread
 
 # ── Targets ──
 
-.PHONY: all test test_qpool test_qmatvec_leak test_affinity test_plan_race test_tsan bench_claim test_wt_expert test_qgather test_f16_matvec test_js test_python test_tokenizer clean cpu gpu simd help lib shared install metal test_metal infer_gguf_metal
+.PHONY: all test test_qpool test_qmatvec_leak test_affinity test_plan_race test_tsan bench_claim test_wt_expert test_qgather test_f16_matvec test_reference test_js test_python test_tokenizer clean cpu gpu simd help lib shared install metal test_metal infer_gguf_metal
 
 all: notorch_test
 	@echo "Built with $(BLAS_NAME). Run: ./notorch_test"
@@ -280,6 +280,12 @@ gguf_add_tokenizer: tools/gguf_add_tokenizer.c gguf.c gguf.h
 # right. Skips itself where llama-tokenize is not installed. MODEL= to aim it.
 test_tokenizer: notorch
 	./harness/test_tokenizer.sh $(MODEL)
+
+# Against llama.cpp rather than against this tree's own example, and it tells a
+# greedy tie-break from a defect by re-anchoring. Needs a model and llama-simple:
+# MODEL=path/to.gguf NT_REF=/path/to/llama-simple make test_reference
+test_reference: notorch
+	./harness/test_reference.sh $(MODEL)
 
 # Tokenizer round-trip. Needs a model, because the thing being tested is what
 # the file says about itself: MODEL=path/to.gguf make test_bpe

--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,56 @@ Newest entries on top.
 
 ---
 
+## 2026-09-12 — telling a coin-flip from a defect, because the coin flips constantly
+
+`harness/test_parity.sh` compares this tree against its own example. That catches a harness
+that drifted from the arithmetic it was lifted from, and cannot catch the arithmetic being
+wrong in both. For the families llama.cpp supports, an outside reference can — and comparing
+text against one fails for a reason that is not a defect.
+
+Greedy decoding takes an argmax. Our summation order is not the reference's, so wherever the
+top two logits sit within float noise the two implementations pick differently, and everything
+after that follows from the one token. A single tie-break reads as a completely different
+answer. In one afternoon: SmolLM2 360M Q8_0 parted on one prompt of three,
+DeepSeek-R1-Distill-Qwen-1.5B Q4_K_M on two of three, qwen05b Q4_K_M on two of three, and
+qwen05b Q4_0 on one of three. Every one of them, handed the reference's own token at the point
+of disagreement, produced byte-identical text for the rest of the run.
+
+`harness/test_reference.sh` does that re-anchoring itself and reports three outcomes:
+IDENTICAL, TIE-BREAK, DIVERGED. A defect does not survive re-anchoring — a model computing the
+wrong thing goes on computing the wrong thing. Across every model on this machine:
+
+    12 identical, 6 tie-break, 0 diverged, 1 skipped
+
+The skip is Qwen3, which this tree does not load and which therefore reports SKIPPED rather
+than either colour.
+
+**It was built by breaking it, and the breaking taught two things.** Dividing rmsnorm by n-1
+instead of n turns one prompt DIVERGED with both continuations printed, and the script exits
+1; restoring the line returns 0. But the other two prompts stayed IDENTICAL under that same
+defect, so three prompts is a thin net — `NT_REF_PROMPTS` widens it, and a new family should.
+And multiplying rmsnorm's epsilon by ten changed no output at all, because eps sits five orders
+below the mean square. Not every wrong number is a detectable one.
+
+A third thing, about method rather than code: the first version of the comparison piped both
+answers into awk and matched them with NR==1/NR==2, which silently compared only their first
+lines. Model answers are routinely several. On a Python prompt it found a shared head of
+nothing and re-anchored on a fragment of a word, then reported TIE-BREAK — the right verdict
+for the wrong reason, which is the failure mode a gate is least likely to be caught in. Both
+strings now arrive through the environment, uncut.
+
+Two things this does not do. It cannot say how close a tie was, because llama-simple prints no
+logits; TIE-BREAK is evidence and not proof. And it is an oracle only for the families the
+reference implements — the Method's own architectures have no outside reference by
+construction and keep the Method's own goldens.
+
+Along the way, one finding that is not about the gate: DeepSeek-R1-Distill-Qwen-1.5B declares
+`tokenizer.ggml.pre = deepseek-r1-qwen`, a third pre-tokenizer family beside the gpt2 and
+qwen2 ones this tree knows, and fails one tokenizer check of eight on indented code. The model
+runs and its parity is sound; the whitespace rule is not this file's.
+
+---
+
 ## 2026-09-12 — README promised a fallback that had been removed under it
 
 `32ffc9e` made an unclaimed architecture a refusal instead of a trip through the

--- a/harness/test_reference.sh
+++ b/harness/test_reference.sh
@@ -1,0 +1,179 @@
+#!/bin/sh
+# test_reference.sh — compare against llama.cpp, and tell a tie-break from a defect.
+#
+# harness/test_parity.sh compares this tree against its own example, which catches a harness
+# that drifted from the arithmetic it was lifted from. It cannot catch the arithmetic being
+# wrong in both. For the families llama.cpp supports, that is what an outside reference is for.
+#
+# The problem with a text comparison against an outside implementation is that it fails for a
+# reason that is not a defect. Greedy decoding takes an argmax, our summation order is not the
+# reference's, and at a position where the top two logits sit within float noise the two pick
+# differently. Everything after that follows from the one token, so a single tie-break reads as
+# a completely different answer. Measured on this machine in one afternoon: SmolLM2 360M Q8_0
+# diverged on one prompt of three, DeepSeek-R1-Distill-Qwen-1.5B Q4_K_M on three of three, and
+# qwen05b Q4_K_M on one of two. In every case, feeding the reference's own token at the point
+# of disagreement and continuing produced byte-identical text for the rest of the run.
+#
+# So this script does that automatically. On disagreement it re-anchors: takes the agreed text
+# plus the reference's next word, hands it back as a prompt, and compares the continuation. A
+# defect does not survive re-anchoring — a model computing the wrong thing goes on computing
+# the wrong thing. A tie-break does.
+#
+# Three outcomes, and the middle one is the reason this exists:
+#
+#   IDENTICAL  — the same bytes with no help
+#   TIE-BREAK  — disagreed, and agreed again from the reference's token. Arithmetic sound.
+#   DIVERGED   — disagreed, and disagreed again after re-anchoring. Something is wrong.
+#
+# What it cannot tell you: how close the tie was. That needs logits from both sides, and
+# llama-simple does not print them. A TIE-BREAK is evidence, not proof — a defect small enough
+# to flip one argmax and then never matter again would look the same. Nothing seen here so far
+# has behaved that way, and if one does, the re-anchor count below will start climbing.
+#
+# It was built by breaking it. Dividing rmsnorm by n-1 instead of n — the kind of off-by-one
+# this is for — turns one prompt DIVERGED with the two continuations printed side by side, and
+# the script exits 1; restoring the line puts it back to 0. Worth knowing from the same
+# experiment: the other two prompts stayed IDENTICAL under that defect, so three prompts is a
+# thin net. Widen it with NT_REF_PROMPTS when a family is new. And a second thing that is not
+# about this script — multiplying rmsnorm's epsilon by ten changed no output at all, because
+# eps sits five orders below the mean square. Not every wrong number is a detectable one.
+#
+#   ./harness/test_reference.sh <model.gguf> [more.gguf ...]
+#
+# Needs ./notorch built and llama-simple on PATH. Says SKIPPED, not OK, when either is missing:
+# a gate that cannot run must report neither green nor red.
+set -eu
+cd "$(dirname "$0")/.."
+
+REF=${NT_REF:-llama-simple}
+command -v "$REF" >/dev/null 2>&1 || {
+  echo "reference  (no $REF on this machine — set NT_REF or install llama.cpp)"
+  echo "NOTORCH_REFERENCE_SKIPPED"
+  exit 0
+}
+[ -x ./notorch ] || { echo "test_reference: ./notorch not built (make harness)"; exit 1; }
+
+N=${NT_REF_TOKENS:-16}
+PIN=${NT_REF_PIN:-}                       # e.g. "taskset -c 4-7"; empty runs unpinned
+PROMPTS_FILE=${NT_REF_PROMPTS:-}
+
+fails=0; ties=0; ok=0; skipped=0
+
+# The reference prints the prompt back, and prepends the BOS token as text when the file asks
+# for one. Ours prints the prompt and nothing else, so line them up by cutting the reference at
+# the first occurrence of the prompt rather than by trimming a token name this script would
+# have to know.
+ref_run() {
+  _m=$1; _p=$2
+  $REF -m "$_m" -n "$N" "$_p" 2>/dev/null | awk -v p="$_p" '
+    BEGIN { RS = "\0" }
+    { i = index($0, p); if (i > 0) printf "%s", substr($0, i); else printf "%s", $0 }
+  '
+}
+
+our_run() {
+  _m=$1; _p=$2
+  # shellcheck disable=SC2086
+  $PIN ./notorch -q -n "$N" -t 0 "$_m" "$_p" 2>/dev/null
+}
+
+# The agreed head of two strings, cut back to the last whitespace so the re-anchor prompt ends
+# on a word rather than inside one. Tokenizers split on word boundaries often enough that
+# cutting mid-word would ask the model a different question than the reference was asked.
+#
+# Both strings arrive through the environment rather than through stdin, and that is the whole
+# reason this is not three lines shorter. A model's answer is routinely several lines — the
+# first version of this piped the two strings in and compared them with NR==1/NR==2, which
+# silently compared only their first lines. On a Python prompt, where both answers begin with
+# the same "def fibonacci(n):" line and part on the second, it reported a shared head of
+# nothing and re-anchored on a fragment of a word. It said TIE-BREAK, which happened to be
+# true, for a reason that was not.
+common_head() {
+  NT_A=$1 NT_B=$2 awk '
+    BEGIN {
+      a = ENVIRON["NT_A"]; b = ENVIRON["NT_B"]
+      n = length(a); if (length(b) < n) n = length(b)
+      for (i = 1; i <= n; i++) if (substr(a, i, 1) != substr(b, i, 1)) break
+      head = substr(a, 1, i - 1)
+      sub(/[^ \t\n]*$/, "", head)
+      printf "%s", head
+      exit
+    }'
+}
+
+# The reference word that this tree did not pick — what re-anchoring hands back.
+next_ref_word() {
+  NT_REFTXT=$1 NT_HEAD=$2 awk '
+    BEGIN {
+      rest = substr(ENVIRON["NT_REFTXT"], length(ENVIRON["NT_HEAD"]) + 1)
+      n = split(rest, w, /[ \t\n]+/)
+      for (i = 1; i <= n; i++) if (w[i] != "") { printf "%s", w[i]; break }
+      exit
+    }'
+}
+
+check_model() {
+  m=$1
+  [ -f "$m" ] || { echo "  SKIP $(basename "$m") — not on this machine"; skipped=$((skipped + 1)); return 0; }
+
+  if ! $PIN ./notorch -q -n 1 -t 0 "$m" "x" >/dev/null 2>&1; then
+    echo "  SKIP $(basename "$m") — this tree does not load it"; skipped=$((skipped + 1)); return 0
+  fi
+  if ! $REF -m "$m" -n 1 "x" >/dev/null 2>&1; then
+    echo "  SKIP $(basename "$m") — the reference does not load it"; skipped=$((skipped + 1)); return 0
+  fi
+
+  while IFS= read -r p; do
+    [ -n "$p" ] || continue
+    a=$(our_run "$m" "$p"); b=$(ref_run "$m" "$p")
+    if [ "$a" = "$b" ]; then
+      echo "  IDENTICAL  [$(basename "$m")] \"$p\""
+      ok=$((ok + 1))
+      continue
+    fi
+
+    head=$(common_head "$a" "$b")
+    word=$(next_ref_word "$b" "$head")
+    if [ -z "$word" ]; then
+      echo "  DIVERGED   [$(basename "$m")] \"$p\" — no shared head to re-anchor on"
+      printf '      ours: %s\n      ref:  %s\n' "$a" "$b"
+      fails=$((fails + 1)); continue
+    fi
+
+    anchor="$head$word"
+    a2=$(our_run "$m" "$anchor"); b2=$(ref_run "$m" "$anchor")
+    if [ "$a2" = "$b2" ]; then
+      # Say where, so a reader can see it was one token and not a region.
+      echo "  TIE-BREAK  [$(basename "$m")] \"$p\" — split after $(printf '%s' "$head" | wc -c | tr -d ' ') chars, identical from the reference's \"$word\""
+      ties=$((ties + 1))
+    else
+      echo "  DIVERGED   [$(basename "$m")] \"$p\" — still apart after re-anchoring on \"$word\""
+      printf '      ours: %s\n      ref:  %s\n' "$a2" "$b2"
+      fails=$((fails + 1))
+    fi
+  done <<EOF
+$(if [ -n "$PROMPTS_FILE" ]; then cat "$PROMPTS_FILE"; else
+printf '%s\n' \
+  'The capital of France is' \
+  'Resonance is' \
+  'def fibonacci(n):'
+fi)
+EOF
+}
+
+echo "against the reference ($REF), $N tokens, temperature 0"
+for m in "$@"; do check_model "$m"; done
+
+[ $# -gt 0 ] || { echo "  (no model given — pass one or more .gguf)"; echo "NOTORCH_REFERENCE_SKIPPED"; exit 0; }
+
+echo
+echo "  $ok identical, $ties tie-break, $fails diverged, $skipped skipped"
+if [ "$fails" -gt 0 ]; then
+  echo "NOTORCH_REFERENCE_FAIL ($fails of $((ok + ties + fails)))"
+  exit 1
+fi
+if [ $((ok + ties)) -eq 0 ]; then
+  echo "NOTORCH_REFERENCE_SKIPPED"
+  exit 0
+fi
+echo "NOTORCH_REFERENCE_OK ($ok identical, $ties tie-break)"


### PR DESCRIPTION
`harness/test_parity.sh` compares this tree against its own example — it catches a harness that drifted from the arithmetic it was lifted from, and cannot catch the arithmetic being wrong in both. For the families llama.cpp supports an outside reference can. **But comparing text against one fails for a reason that is not a defect.**

Greedy decoding takes an argmax. Our summation order is not the reference's, so wherever the top two logits sit within float noise the two pick differently — and everything after follows from that one token, so a single tie-break reads as a completely different answer. In one afternoon: SmolLM2 360M Q8_0 parted on 1 prompt of 3, DeepSeek-R1-Distill-Qwen-1.5B Q4_K_M on 2 of 3, qwen05b Q4_K_M on 2 of 3, qwen05b Q4_0 on 1 of 3. **Every one of them, handed the reference's own token at the point of disagreement, produced byte-identical text for the rest of the run.**

`harness/test_reference.sh` re-anchors automatically and reports `IDENTICAL` / `TIE-BREAK` / `DIVERGED`. A defect does not survive re-anchoring — a model computing the wrong thing goes on computing the wrong thing. Across every model on this machine:

    12 identical, 6 tie-break, 0 diverged, 1 skipped

The skip is Qwen3, which this tree does not load and which therefore reports SKIPPED rather than either colour.

**It was built by breaking it, and the breaking taught two things.** Dividing rmsnorm by `n-1` instead of `n` turns one prompt DIVERGED with both continuations printed, and the script exits 1; restoring the line returns 0. But the other two prompts stayed IDENTICAL under that same defect — three prompts is a thin net, `NT_REF_PROMPTS` widens it, and a new family should. And multiplying rmsnorm's epsilon by ten changed no output at all, because eps sits five orders below the mean square. Not every wrong number is a detectable one.

A third thing, about method rather than code: the first version piped both answers into awk and matched them with `NR==1`/`NR==2`, silently comparing only their first lines. Model answers are routinely several. On a Python prompt it found a shared head of nothing, re-anchored on a fragment of a word, and reported TIE-BREAK — the right verdict for the wrong reason, which is the failure a gate is least likely to be caught in. Both strings now arrive through the environment, uncut.

**Two limits, stated in the file rather than discovered later.** It cannot say how close a tie was, because `llama-simple` prints no logits — TIE-BREAK is evidence, not proof. And it is an oracle only for families the reference implements; the Method's own architectures have no outside reference by construction and keep their own goldens.

One finding that is not about the gate: DeepSeek-R1-Distill-Qwen-1.5B declares `tokenizer.ggml.pre = deepseek-r1-qwen`, a **third** pre-tokenizer family beside the gpt2 and qwen2 ones this tree knows, and fails one tokenizer check of eight on indented code. The model runs and its parity is sound; the whitespace rule is not.

Usage: `MODEL=path/to.gguf NT_REF=/path/to/llama-simple make test_reference`, or the script directly with several models.