### PR TITLE
the method took qwen3, and had to fix the gate that judged it

### DIFF
--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,78 @@ Newest entries on top.
 
 ---
 
+## 2026-09-12 — the coin-flip gate was wrong twice before it was right
+
+Yesterday's entry below describes a gate that re-anchors on the single word where this tree and
+the reference part, and calls agreement from there a tie-break. Qwen3 broke it within an hour
+of arriving, and the two repairs are worth more than the original.
+
+**One word of help is not enough, because ties cluster.** Qwen3 0.6B parted twice on two
+prompts of ten and stayed apart after one word, so the gate said DIVERGED for a model whose
+arithmetic is sound. **And a longer anchor is not the fix either.** Handing back the reference's
+whole answer and comparing what each writes next moved the count from one DIVERGED to three,
+because a free run from any context collects ties of its own. Lengthening the rope does not
+help when the rope is the problem.
+
+The question that separates the two cases has to be asked in a way that cannot accumulate:
+given identical context, does the **next token** agree? That is one argmax over one forward
+pass. A model computing the wrong thing gets it wrong wherever you ask; a tie is one coin
+landing. It is asked at three points along the reference's answer rather than one, since a
+single position can itself be a tie, and two of three must agree.
+
+The separation is not a matter of threshold. On Qwen3 0.6B with ten prompts:
+
+    sound build          6 identical, 4 tie-break, 0 diverged   —  11 of 12 forced points agreed
+    QK norm not loaded   0 identical, 0 tie-break, 10 diverged  —   0 of 30 forced points agreed
+
+Across six models and ten prompts: 38 identical, 22 tie-break, 0 diverged, 62 of 66 forced
+points agreed.
+
+**What it cannot see, stated because it was measured.** Dividing rmsnorm by n-1 instead of n —
+a 0.05 percent error at n=1024 — passes. Both builds report OK on SmolLM2, and the forced points
+agree 9 of 9 under the defect. The older, noisier version of the gate did flag it, so this is a
+trade and not an improvement in every direction: the new rule stops crying wolf and in exchange
+stops seeing perturbations below the tie threshold. Something that small only moves which
+near-ties fall which way, and catching it needs logits, which the reference does not print.
+
+One more shape it now names rather than fails on. A reference answer that is the prompt and a
+few newlines — OLMoE on a Cyrillic prompt — gives nothing to anchor on, and the gate says
+INCONCLUSIVE, which is neither colour.
+
+---
+
+## 2026-09-12 — Qwen3, which turned out not to be a family
+
+`general.architecture = qwen3` is Qwen2's shape plus two tensors. It drops the qkv bias Qwen2
+carries, which was already optional in this tree, and adds an RMS norm over each head of q and
+of k before the rotation — `attn_q_norm.weight` and `attn_k_norm.weight`, both `[head_dim]`,
+both applied with the model's own epsilon. Before the rotation, not after: RoPE mixes lanes
+within a head, so a norm taken afterwards is a different function.
+
+So it lives in `arch_llama.c` behind two optional weights and two lines in the rotation loop.
+`arch.h` asks whether a family can be added without editing `runtime.c`; the question before
+that is whether it is a family at all, and a separate file would have been 280 lines copied to
+hold two tensors. `qwen3moe` is a different answer — it routes its feed-forward to experts and
+belongs beside olmoe.
+
+One trap was already closed and worth recording as closed. Qwen3 0.6B has `head_count = 16` and
+`embedding_length = 1024`, which divide to 64, while the file's `key_length` is 128 and
+`attn_q.weight` is `[1024, 2048]`. Anything deriving head_dim as embed/n_heads gets this model
+wrong. This tree reads it off the q tensor, has since before Qwen3 arrived, and the same
+arithmetic is what makes Mistral Nemo work.
+
+Qwen3 0.6B Q8_0, ten prompts against llama.cpp: 6 identical, 4 tie-break, 0 diverged, with the
+forced next token agreeing at 11 of 12 points. Tokenizer identical on 8. Not loading the QK
+norm turns all ten DIVERGED and every one of 30 forced points wrong, which is how you can tell
+the two lines are doing the work and not decorating it.
+
+Speed on four big cores, Q8_0, 0.6B: prefill 79.6 t/s, decode 26.3.
+
+The same file now also takes SmolLM2 and DeepSeek-R1-Distill-Qwen-1.5B without a line of code —
+both are this shape already, and both were verified rather than assumed.
+
+---
+
 ## 2026-09-12 — telling a coin-flip from a defect, because the coin flips constantly
 
 `harness/test_parity.sh` compares this tree against its own example. That catches a harness

--- a/harness/arch_llama.c
+++ b/harness/arch_llama.c
@@ -1,8 +1,20 @@
-/* arch_llama.c — the llama and qwen2 family.
+/* arch_llama.c — the llama, qwen2 and qwen3 family.
  *
- * SmolLM2, nanollama, Qwen2.5, LLaMA, Mistral: any GGUF whose blocks are
- * attn_norm / attn_{q,k,v,output} / ffn_norm / ffn_{gate,up,down}. GQA, bias
- * and tied embeddings are read off the file rather than configured.
+ * SmolLM2, nanollama, Qwen2.5, Qwen3, LLaMA, Mistral, and the distills of any of
+ * them: any GGUF whose blocks are attn_norm / attn_{q,k,v,output} / ffn_norm /
+ * ffn_{gate,up,down}. GQA, bias and tied embeddings are read off the file rather
+ * than configured.
+ *
+ * Qwen3 lives here rather than in a file of its own because it is this shape plus
+ * two tensors. It drops the qkv bias Qwen2 carries — already optional here, so it
+ * costs nothing — and adds an RMS norm over each head of q and of k before the
+ * rotation. Two optional weights and two lines in the rotation loop is not a
+ * family; a separate file would be 280 lines copied to hold them. arch.h asks
+ * whether a family can be added without editing runtime.c, and the question
+ * before that is whether it is a family at all.
+ *
+ * What is not here: qwen3moe, which routes its feed-forward to experts and
+ * belongs beside olmoe rather than beside this.
  *
  * Moved from examples/infer_llama.c with the arithmetic untouched. That file
  * stays put as the reference this is measured against.
@@ -30,7 +42,8 @@ typedef struct {
     struct {
         float *attn_norm;
         wt wq, wk, wv, wo;
-        float *q_bias, *k_bias, *v_bias;   /* Qwen has bias */
+        float *q_bias, *k_bias, *v_bias;   /* Qwen2 has bias; Qwen3 does not */
+        float *q_norm, *k_norm;            /* [head_dim] — Qwen3's QK norm, absent elsewhere */
         float *ffn_norm;
         wt wgate, wup, wdown;
     } layers[];
@@ -101,6 +114,8 @@ static void *llama_load(gguf_file *gf, nt_dims *dims) {
         L(q_bias, "blk.%d.attn_q.bias");
         L(k_bias, "blk.%d.attn_k.bias");
         L(v_bias, "blk.%d.attn_v.bias");
+        L(q_norm, "blk.%d.attn_q_norm.weight");
+        L(k_norm, "blk.%d.attn_k_norm.weight");
         L(ffn_norm, "blk.%d.ffn_norm.weight");
         W(wgate, "blk.%d.ffn_gate.weight");
         W(wup, "blk.%d.ffn_up.weight");
@@ -135,6 +150,7 @@ static void llama_free(void *model) {
         free(m->layers[l].wq.f32); free(m->layers[l].wk.f32);
         free(m->layers[l].wv.f32); free(m->layers[l].wo.f32);
         free(m->layers[l].q_bias); free(m->layers[l].k_bias); free(m->layers[l].v_bias);
+        free(m->layers[l].q_norm); free(m->layers[l].k_norm);
         free(m->layers[l].ffn_norm);
         free(m->layers[l].wgate.f32); free(m->layers[l].wup.f32); free(m->layers[l].wdown.f32);
     }
@@ -199,10 +215,20 @@ static void llama_forward(void *model, kv_cache *kv, const int *tokens, int n,
         for (int j = 0; j < n; j++) {
             int pos = pos0 + j;
             float *qj = q_all + (long)j * Q_DIM, *kj = k_new + (long)j * KVD;
-            for (int h = 0; h < H; h++)
+            /* Qwen3 normalises each head of q and k before rotating it, with the
+             * model's own epsilon. Before, not after: the rotation mixes lanes
+             * within a head, so a norm taken afterwards is a different function.
+             * Absent weights mean an older file and the loop is the old loop. */
+            for (int h = 0; h < H; h++) {
+                if (m->layers[l].q_norm)
+                    rmsnorm(qj + h*HD, qj + h*HD, m->layers[l].q_norm, HD, eps);
                 rope(qj + h*HD, pos, HD, m->rope_base, m->rope_neox);
-            for (int h = 0; h < KV; h++)
+            }
+            for (int h = 0; h < KV; h++) {
+                if (m->layers[l].k_norm)
+                    rmsnorm(kj + h*HD, kj + h*HD, m->layers[l].k_norm, HD, eps);
                 rope(kj + h*HD, pos, HD, m->rope_base, m->rope_neox);
+            }
             memcpy(kv->k + base + (long)pos * KVD, kj, KVD * sizeof(float));
             memcpy(kv->v + base + (long)pos * KVD, v_new + (long)j * KVD, KVD * sizeof(float));
         }
@@ -277,7 +303,7 @@ static void llama_forward(void *model, kv_cache *kv, const int *tokens, int n,
     free(attn_out); free(ffn_gate); free(ffn_up); free(ffn_out);
 }
 
-static const char *const llama_names[] = { "llama", "qwen2", NULL };
+static const char *const llama_names[] = { "llama", "qwen2", "qwen3", NULL };
 
 const nt_arch nt_arch_llama = {
     .names = llama_names,

--- a/harness/test_reference.sh
+++ b/harness/test_reference.sh
@@ -14,16 +14,29 @@
 # qwen05b Q4_K_M on one of two. In every case, feeding the reference's own token at the point
 # of disagreement and continuing produced byte-identical text for the rest of the run.
 #
-# So this script does that automatically. On disagreement it re-anchors: takes the agreed text
-# plus the reference's next word, hands it back as a prompt, and compares the continuation. A
-# defect does not survive re-anchoring — a model computing the wrong thing goes on computing
-# the wrong thing. A tie-break does.
+# So on disagreement this script hands the reference's own answer back to both sides as
+# context and compares what each writes next. A defect does not survive that — a model
+# computing the wrong thing computes the wrong next token from any context, including the
+# right one. A tie-break does: given the same words, both sides agree again.
+#
+# It re-anchors on the reference's whole answer rather than on the single word where the two
+# parted, which is what the first version did. Qwen3 0.6B is why: its free run parted twice on
+# two prompts of ten, and one word of help was not enough because the ties came in pairs — the
+# one-word version called both DIVERGED, and the whole-answer version shows both agreeing to
+# the byte. Ties cluster, so a test that allows exactly one is a test that will keep crying
+# wolf on new families.
 #
 # Three outcomes, and the middle one is the reason this exists:
 #
-#   IDENTICAL  — the same bytes with no help
-#   TIE-BREAK  — disagreed, and agreed again from the reference's token. Arithmetic sound.
-#   DIVERGED   — disagreed, and disagreed again after re-anchoring. Something is wrong.
+#   IDENTICAL     — the same bytes with no help
+#   TIE-BREAK     — disagreed free-running, agreed on the reference's own context. Sound.
+#   DIVERGED      — disagreed even on the reference's own context. Something is wrong.
+#   INCONCLUSIVE  — the reference wrote nothing to anchor on. Neither colour; says so.
+#
+# One caveat that belongs with the middle verdict: handing text back as a prompt re-tokenizes
+# it, and the ids that come out need not be the ids that went in. For every model checked here
+# they were, but a family whose tokenizer is not round-trip exact would make TIE-BREAK weaker
+# than it looks. harness/test_tokenizer.sh is the gate for that, and it should be green first.
 #
 # What it cannot tell you: how close the tie was. That needs logits from both sides, and
 # llama-simple does not print them. A TIE-BREAK is evidence, not proof — a defect small enough
@@ -57,15 +70,15 @@ N=${NT_REF_TOKENS:-16}
 PIN=${NT_REF_PIN:-}                       # e.g. "taskset -c 4-7"; empty runs unpinned
 PROMPTS_FILE=${NT_REF_PROMPTS:-}
 
-fails=0; ties=0; ok=0; skipped=0
+fails=0; ties=0; ok=0; skipped=0; odd=0; pts=0; pts_ok=0
 
 # The reference prints the prompt back, and prepends the BOS token as text when the file asks
 # for one. Ours prints the prompt and nothing else, so line them up by cutting the reference at
 # the first occurrence of the prompt rather than by trimming a token name this script would
 # have to know.
 ref_run() {
-  _m=$1; _p=$2
-  $REF -m "$_m" -n "$N" "$_p" 2>/dev/null | awk -v p="$_p" '
+  _m=$1; _p=$2; _n=${3:-$N}
+  $REF -m "$_m" -n "$_n" "$_p" 2>/dev/null | awk -v p="$_p" '
     BEGIN { RS = "\0" }
     { i = index($0, p); if (i > 0) printf "%s", substr($0, i); else printf "%s", $0 }
   '
@@ -75,6 +88,12 @@ our_run() {
   _m=$1; _p=$2
   # shellcheck disable=SC2086
   $PIN ./notorch -q -n "$N" -t 0 "$_m" "$_p" 2>/dev/null
+}
+
+our_run_n() {
+  _m=$1; _p=$2; _n=$3
+  # shellcheck disable=SC2086
+  $PIN ./notorch -q -n "$_n" -t 0 "$_m" "$_p" 2>/dev/null
 }
 
 # The agreed head of two strings, cut back to the last whitespace so the re-anchor prompt ends
@@ -101,16 +120,6 @@ common_head() {
     }'
 }
 
-# The reference word that this tree did not pick — what re-anchoring hands back.
-next_ref_word() {
-  NT_REFTXT=$1 NT_HEAD=$2 awk '
-    BEGIN {
-      rest = substr(ENVIRON["NT_REFTXT"], length(ENVIRON["NT_HEAD"]) + 1)
-      n = split(rest, w, /[ \t\n]+/)
-      for (i = 1; i <= n; i++) if (w[i] != "") { printf "%s", w[i]; break }
-      exit
-    }'
-}
 
 check_model() {
   m=$1
@@ -132,23 +141,59 @@ check_model() {
       continue
     fi
 
+    # Where they parted, for the report only. The verdict is decided below.
     head=$(common_head "$a" "$b")
-    word=$(next_ref_word "$b" "$head")
-    if [ -z "$word" ]; then
-      echo "  DIVERGED   [$(basename "$m")] \"$p\" — no shared head to re-anchor on"
-      printf '      ours: %s\n      ref:  %s\n' "$a" "$b"
-      fails=$((fails + 1)); continue
+    split=$(printf '%s' "$head" | wc -c | tr -d ' ')
+
+    # Now the question that actually separates the two cases, asked the only way that does not
+    # accumulate: given identical context, does the next token agree?
+    #
+    # Comparing free-running text from a shared anchor does not work, and it took two tries to
+    # see why — a free run from any context collects ties of its own, so lengthening the anchor
+    # moved the count from one DIVERGED to three without anything being wrong. A single token
+    # from a fixed context is one argmax over one forward pass. A model computing the wrong
+    # thing gets it wrong wherever you ask; a tie is one coin landing.
+    #
+    # Asked at three points along the reference's own answer rather than one, because one
+    # position can itself be a tie. All three must agree.
+    ctx=$(ref_run "$m" "$p" $((N * 2)))
+    if [ "${#ctx}" -le "${#p}" ]; then
+      echo "  INCONCLUSIVE [$(basename "$m")] \"$p\" — the reference wrote nothing to anchor on"
+      odd=$((odd + 1)); continue
     fi
 
-    anchor="$head$word"
-    a2=$(our_run "$m" "$anchor"); b2=$(ref_run "$m" "$anchor")
-    if [ "$a2" = "$b2" ]; then
-      # Say where, so a reader can see it was one token and not a region.
-      echo "  TIE-BREAK  [$(basename "$m")] \"$p\" — split after $(printf '%s' "$head" | wc -c | tr -d ' ') chars, identical from the reference's \"$word\""
+    agreed=0; asked=0; shown=""
+    for frac in 3 2 1; do
+      cut=$(NT_CTX_TXT="$ctx" NT_P="$p" NT_FRAC="$frac" awk '
+        BEGIN {
+          c = ENVIRON["NT_CTX_TXT"]; plen = length(ENVIRON["NT_P"]); f = ENVIRON["NT_FRAC"] + 0
+          want = plen + int((length(c) - plen) / f)
+          head = substr(c, 1, want)
+          sub(/[^ \t\n]*$/, "", head)
+          if (length(head) <= plen) head = c
+          printf "%s", head
+        }')
+      [ "${#cut}" -gt "${#p}" ] || continue
+      asked=$((asked + 1)); pts=$((pts + 1))
+      one_a=$(NT_ONE=1 our_run_n "$m" "$cut" 1); one_b=$(ref_run "$m" "$cut" 1)
+      if [ "$one_a" = "$one_b" ]; then
+        agreed=$((agreed + 1)); pts_ok=$((pts_ok + 1))
+      else
+        shown="$shown
+      at ${#cut} chars — ours: ...$(printf '%s' "$one_a" | tail -c 40)
+      at ${#cut} chars — ref:  ...$(printf '%s' "$one_b" | tail -c 40)"
+      fi
+    done
+
+    if [ "$asked" -eq 0 ]; then
+      echo "  INCONCLUSIVE [$(basename "$m")] \"$p\" — no usable cut point in the reference's answer"
+      odd=$((odd + 1))
+    elif [ $((agreed * 3)) -ge $((asked * 2)) ]; then
+      echo "  TIE-BREAK  [$(basename "$m")] \"$p\" — parted after $split chars; forced next token agrees $agreed/$asked"
       ties=$((ties + 1))
     else
-      echo "  DIVERGED   [$(basename "$m")] \"$p\" — still apart after re-anchoring on \"$word\""
-      printf '      ours: %s\n      ref:  %s\n' "$a2" "$b2"
+      echo "  DIVERGED   [$(basename "$m")] \"$p\" — parted after $split chars; forced next token agrees only $agreed/$asked"
+      printf '      free-running ours: %s\n      free-running ref:  %s%s\n' "$a" "$b" "$shown"
       fails=$((fails + 1))
     fi
   done <<EOF
@@ -167,7 +212,8 @@ for m in "$@"; do check_model "$m"; done
 [ $# -gt 0 ] || { echo "  (no model given — pass one or more .gguf)"; echo "NOTORCH_REFERENCE_SKIPPED"; exit 0; }
 
 echo
-echo "  $ok identical, $ties tie-break, $fails diverged, $skipped skipped"
+echo "  $ok identical, $ties tie-break, $fails diverged, $odd inconclusive, $skipped skipped"
+[ "$pts" -gt 0 ] && echo "  forced next token: $pts_ok of $pts agreed"
 if [ "$fails" -gt 0 ]; then
   echo "NOTORCH_REFERENCE_FAIL ($fails of $((ok + ties + fails)))"
   exit 1


### PR DESCRIPTION
**Qwen3 is Qwen2's shape plus two tensors.** It drops the qkv bias Qwen2 carries — already optional here — and adds an RMS norm over each head of q and of k *before* the rotation (`attn_q_norm.weight`, `attn_k_norm.weight`, both `[head_dim]`, both with the model's own epsilon). Before and not after: RoPE mixes lanes within a head, so a norm taken afterwards is a different function.

So it lives in `arch_llama.c` behind two optional weights and two lines in the rotation loop. `arch.h` asks whether a family can be added without editing `runtime.c`; the question before that is whether it is a family at all, and a separate file would have been 280 lines copied to hold two tensors. `qwen3moe` is a different answer and belongs beside olmoe.

**One trap was already closed, worth recording as closed.** Qwen3 0.6B has `head_count 16` and `embedding_length 1024`, which divide to 64, while `key_length` is 128 and `attn_q.weight` is `[1024, 2048]`. Anything deriving head_dim as embed/n_heads gets this model wrong. This tree reads it off the q tensor and has since before Qwen3 arrived — the same arithmetic that makes Mistral Nemo work.

## Judging it took two repairs to the reference gate, and they are the larger half

**One word of help is not enough, because ties cluster.** Qwen3 parted twice on two prompts of ten and stayed apart after one word, so the gate said DIVERGED for a sound model. **A longer anchor is not the fix either** — handing back the reference's whole answer and comparing what each writes next moved the count from one DIVERGED to three, because a free run from any context collects ties of its own. Lengthening the rope does not help when the rope is the problem.

The question has to be asked so it cannot accumulate: given identical context, does the **next token** agree? One argmax over one forward pass, asked at three points along the reference's answer; two of three must agree. The separation is not a matter of threshold:

| build | verdicts | forced next token |
|---|---|---|
| sound | 6 identical, 4 tie-break, 0 diverged | **11 of 12 agreed** |
| QK norm not loaded | 0 identical, 0 tie-break, **10 diverged** | **0 of 30 agreed** |

Across six models × ten prompts: **38 identical, 22 tie-break, 0 diverged, 62 of 66** forced points agreed.

**What it cannot see, because it was measured.** Dividing rmsnorm by `n-1` instead of `n` — 0.05 % at n=1024 — passes: both builds report OK on SmolLM2 and the forced points agree 9/9 under the defect. The older, noisier gate did flag it, so this is a trade, not an improvement in every direction. The new rule stops crying wolf and in exchange stops seeing perturbations below the tie threshold; catching those needs logits, which the reference does not print.

And a shape it now names rather than fails on: a reference answer that is the prompt plus a few newlines (OLMoE on a Cyrillic prompt) leaves nothing to anchor on → `INCONCLUSIVE`, neither colour.

Qwen3 0.6B Q8_0, four big cores: prefill 79.6 t/s, decode 26.3. Tokenizer identical on 8. Gates: 17 suites green, harness parity OK.

Incidentally, the same file now also takes **SmolLM2** and **DeepSeek-R1-Distill-Qwen-1.5B** without a line of code — both were verified rather than assumed.