### PR TITLE
the method asked whether both sides were handed the same question

### DIFF
--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,42 @@ Newest entries on top.
 
 ---
 
+## 2026-09-12 — two quantizations looked like a broken kernel and the tokenizer had done it
+
+The reference gate re-anchors on the reference's own text, and text handed back as a prompt is
+tokenized again. That caveat was written into the file when the gate was built. It came true
+the same day, and it did not look like a tokenizer problem at all: `qwen05b_q4km` reported
+DIVERGED with the forced next token agreeing at only 1 of 3 points, and a probe at nine points
+along the same answer put it at 4 of 9 — while the same organism in Q4_0 sat at 9 of 9. That is
+a clean accusation against the Q4_K path, and it was wrong. Q5_0 of the same organism measured
+3 of 9 on that prompt, which no story about K-quants explains.
+
+What the two failing runs had in common was the character in the reference's answer. Ours and
+the reference split `" \u2460"` differently — 2858,239,254 here against 220,48312,254 there —
+while the same codepoint alone splits identically in both. The space is the whole difference.
+That codepoint is Unicode category No, a number; this tree's pre-tokenizer treats everything
+above 0x80 as a symbol, and the qwen2 alternative for a run of symbols may absorb a preceding
+space where the one for numbers may not. It is the `\p{L}` and `\p{N}` gap that PR #70 wrote
+down as the blocker for the last two qwen2 divergences, now with a two-character reproducer.
+
+So the gate checks it. Before asking whether two implementations compute the same thing, it
+asks whether they were handed the same thing: the anchor goes through both tokenizers and a
+mismatch reports TOKENIZER, which is neither colour and points at the real difference instead
+of accusing the kernel. The cross-check needs `llama-tokenize`; without it the gate still runs
+and says in its output that anchors are not cross-checked, because a gate that quietly drops a
+check is worse than one that never had it.
+
+With it, the same two files read 0 diverged and 2 inconclusive. Across five models and ten
+prompts: 28 identical, 19 tie-break, 0 diverged, 3 inconclusive, 53 of 57 forced points agreed.
+Not loading Qwen3's QK norm still turns all ten DIVERGED with 0 of 30 forced points, so the new
+verdict hides nothing.
+
+A first reading blamed the Q4_K changes that arrived from the other machine the same morning.
+Building this tree's previous revision and running the same case produced byte-identical output
+to the current one, which ended that theory before it reached a commit message.
+
+---
+
 ## 2026-09-12 — correcting the 1.89x: per core it is 2.4x, and the bench was timing its own setup
 
 The entry below reports the kernel as 1.89x behind llama.cpp's and concludes

--- a/harness/test_reference.sh
+++ b/harness/test_reference.sh
@@ -32,6 +32,9 @@
 #   TIE-BREAK     — disagreed free-running, agreed on the reference's own context. Sound.
 #   DIVERGED      — disagreed even on the reference's own context. Something is wrong.
 #   INCONCLUSIVE  — the reference wrote nothing to anchor on. Neither colour; says so.
+#   TOKENIZER     — the two split the anchor into different ids, so there is nothing to
+#                   compare arithmetically. Also neither colour, and a pointer at the real
+#                   difference rather than a wrong accusation against the kernel.
 #
 # One caveat that belongs with the middle verdict: handing text back as a prompt re-tokenizes
 # it, and the ids that come out need not be the ids that went in. For every model checked here
@@ -59,6 +62,7 @@ set -eu
 cd "$(dirname "$0")/.."
 
 REF=${NT_REF:-llama-simple}
+TOK=${NT_REF_TOK:-llama-tokenize}
 command -v "$REF" >/dev/null 2>&1 || {
   echo "reference  (no $REF on this machine — set NT_REF or install llama.cpp)"
   echo "NOTORCH_REFERENCE_SKIPPED"
@@ -71,6 +75,11 @@ PIN=${NT_REF_PIN:-}                       # e.g. "taskset -c 4-7"; empty runs un
 PROMPTS_FILE=${NT_REF_PROMPTS:-}
 
 fails=0; ties=0; ok=0; skipped=0; odd=0; pts=0; pts_ok=0
+# The tokenizer cross-check is optional: without it the gate still works and can still be
+# fooled by a split, which is why it says so rather than pretending.
+TOK_OK=""
+command -v "$TOK" >/dev/null 2>&1 && TOK_OK=1
+[ -n "$TOK_OK" ] || echo "  (no $TOK — anchors are not cross-checked for tokenization)"
 
 # The reference prints the prompt back, and prepends the BOS token as text when the file asks
 # for one. Ours prints the prompt and nothing else, so line them up by cutting the reference at
@@ -172,6 +181,23 @@ check_model() {
     if [ "${#ctx}" -le "${#p}" ]; then
       echo "  INCONCLUSIVE [$(basename "$m")] \"$p\" — the reference wrote nothing to anchor on"
       odd=$((odd + 1)); continue
+    fi
+
+    # Before asking whether the two compute the same thing, check they are being asked the
+    # same thing. Handing text back as a prompt re-tokenizes it, and the two tokenizers can
+    # split it differently — which makes the forced comparison meaningless and, worse, look
+    # like an arithmetic defect. Found rather than foreseen: on this machine a space followed
+    # by "\u2460" splits as 2858,239,254 here and 220,48312,254 in the reference, because that
+    # codepoint is Unicode category No and this tree's pre-tokenizer treats anything above
+    # 0x80 as a symbol that may absorb a preceding space. Two Qwen quantizations looked like
+    # a broken Q4_K path for exactly that reason and neither was.
+    if [ -n "$TOK_OK" ]; then
+      ids_a=$($PIN ./notorch -T "$m" "$ctx" 2>/dev/null | tr -d ' ')
+      ids_b=$($TOK -m "$m" -p "$ctx" --ids 2>/dev/null | tail -1 | tr -d '[] ')
+      if [ -n "$ids_a" ] && [ -n "$ids_b" ] && [ "$ids_a" != "$ids_b" ]; then
+        echo "  TOKENIZER  [$(basename "$m")] \"$p\" — the two split the anchor differently; no arithmetic conclusion"
+        odd=$((odd + 1)); continue
+      fi
     fi
 
     agreed=0; asked=0; shown=""


### PR DESCRIPTION
The reference gate re-anchors on the reference's own text, and text handed back as a prompt is **tokenized again**. That caveat was written into the file when the gate was built. It came true the same day — and it did not look like a tokenizer problem at all.

`qwen05b_q4km` reported DIVERGED with the forced next token agreeing at only **1 of 3** points; a probe at nine points along the same answer put it at **4 of 9**, while the same organism in Q4_0 sat at **9 of 9**. That is a clean accusation against the Q4_K path, and it was wrong: **Q5_0 of the same organism measured 3 of 9** on that prompt, which no story about K-quants explains.

What the failing runs had in common was a character. Ours and the reference split a space followed by `U+2460` differently — `2858,239,254` here against `220,48312,254` there — while **the same codepoint alone splits identically in both**. The space is the whole difference. That codepoint is Unicode category **No**, a number; this tree's pre-tokenizer treats everything above 0x80 as a symbol, and the qwen2 alternative for a run of symbols may absorb a preceding space where the one for numbers may not. It is the `\p{L}` / `\p{N}` gap that PR #70 wrote down as the blocker for the last two qwen2 divergences — now with a two-character reproducer.

**So the gate checks it.** Before asking whether two implementations compute the same thing, it asks whether they were handed the same thing: the anchor goes through both tokenizers, and a mismatch reports `TOKENIZER` — neither colour, and a pointer at the real difference instead of an accusation against the kernel. The cross-check needs `llama-tokenize`; without it the gate still runs and says in its own output that anchors are not cross-checked, because a gate that quietly drops a check is worse than one that never had it.

With it, the same two files read **0 diverged, 2 inconclusive**. Across five models × ten prompts: 28 identical, 19 tie-break, **0 diverged**, 3 inconclusive, 53 of 57 forced points agreed. Not loading Qwen3's QK norm still turns all ten DIVERGED with 0 of 30 forced points, so the new verdict hides nothing.

A first reading blamed the Q4_K work that arrived from the other machine the same morning. Building this tree's previous revision and running the same case produced **byte-identical** output to the current one, which ended that theory before it reached a commit message.