### PR TITLE
q4_k: the min term is a vector, and the 30B pays for it

### DIFF
--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,97 @@ Newest entries on top.
 
 ---
 
+## 2026-09-13 — the Q4_K min term is a vector now: a fifth of every instruction gone, and one body that got slower for it
+
+The two AVX2 Q4_K arms computed the min term as eight scalar multiplies, eight
+adds and one `fmaf` per (block, column), to produce one float. At nb=56 and a
+tile of 32 that is thirty thousand scalar operations per row against sixty-six
+thousand vector ones — a third of the kernel's instructions for a scalar. ggml
+has done it in four SSE operations for years, and the shape is available to us
+for the same reason the main term's was: the mins are 6-bit and the per-32
+activation sums fit int16 by construction, 32 values of at most 127 being 4064.
+One `madd_epi16`, and the float accumulator stays a vector to the end of the row
+the way `accv` already does.
+
+Both arms changed together, because `tests/test_qmatmul` memcmps them: 46 of 46.
+
+    kernel, one pinned core, i5-8500T
+      m=4096 k=14336 n=8      22.0 -> 27.2 GMAC/s
+      m=4096 k=14336 n=32     20.1 -> 25.6
+      m=768  k=2048  n=8      24.0 -> 29.6      (a 30B expert's gate/up)
+      m=2048 k=768   n=16     24.9 -> 32.0      (its down)
+      m=2048 k=2048  n=16     26.0 -> 34.9
+
+Faster at every shape measured, and at n=8 on one core the kernel is now ahead of
+llama.cpp's on the same machine and the same shape: 27.2 against their 24.9
+(`test-backend-ops perf -o MUL_MAT`, `taskset -c 0`).
+
+### What it does to the bodies, including the one it hurts
+
+61-token prompt, six threads, two runs each, alternating binaries:
+
+    Qwen3-4B Q4_K_M        prefill 21.9 -> 23.9   decode 8.4 -> 8.4
+    Ministral-3B Q4_K_M    prefill 27.3 -> 28.7   decode 10.2 -> 10.2
+    Qwen3-30B-A3B Q4_K_M   prefill 13.4 -> 12.7   decode 6.95 -> 7.1
+
+The MoE loses 5% of prefill and it is not noise: eight alternating runs in both
+orders, 13.3-13.6 against 12.6-12.7, no overlap. Splitting the change in half
+put it on the batched arm — a build with the new per-token arm and the old
+batched one runs exactly at the old number.
+
+What the counters say about the whole MoE run, old against new:
+
+    instructions   137.4 -> 109.8 G    -20%
+    uops executed  159.1 -> 134.7 G    -15%
+    loads           39.7 ->  32.6 G    -18%
+    cycles           66.4 ->  61.8 G    -7%
+    resource_stalls.any  16.0% -> 19.7% of cycles
+
+Everything the kernel is charged for went down. The one thing that went up is
+backend occupancy, and it is not the store buffer (1.57 -> 1.38 G) and not
+memory (`cycle_activity.stalls_mem_any` flat). The reading that fits: the new
+inner loop carries two dependent accumulator chains where the old one carried a
+vector chain beside scalar work on idle ports, and the 30B's down-projection has
+k=768 — three blocks per row, nothing to hide the latency behind. The dense
+bodies have k=9728 and k=14336 and do not care.
+
+Four fixes tried and rejected, measured on the polygon:
+
+1. **Thread count.** 1, 2, 4 and 6 threads all give 13.3 old / 12.7 new. Not the
+    pool.
+2. **Spin budget.** `NT_QMV_SPIN` at 500000 and 4000000: unchanged.
+3. **Chunk granularity.** `NT_QMV_CHUNKS` at 4, 16, 32: 12.7, 12.7, 12.6.
+4. **Register pressure.** Dropping `sv[8]` from the batched arm, so eight
+    architectural registers stop being held across the column loop and the scale
+    broadcast is rebuilt inline the way the per-token arm does it: MoE 12.6-12.7,
+    dense 23.7-23.8. Exactly nothing.
+
+The fix that would settle it — holding the row's mins in registers instead of a
+stack array indexed by column — needs an array sized by `nb` in the hot kernel,
+and that is a bigger restructuring than this change is. Left open and named.
+
+### What it costs in bits
+
+`harness/test_reference.sh` against llama.cpp on the polygon, both binaries, same
+machine, same reference build:
+
+    Qwen3-4B Q4_K_M       2 identical, 1 tie-break  ->  1 identical, 2 tie-break
+    Ministral-3B Q4_K_M   1 identical, 2 tie-break  ->  2 identical, 1 tie-break
+    Qwen3-30B-A3B Q4_K_M  3 identical, 0 tie-break  ->  3 identical, 0 tie-break
+
+Zero diverged in all six. The min term's summation order moved by one ULP, one
+greedy path per model crossed a tie, and it crossed in both directions.
+
+Gates: notorch_test 49/49 and 73/73, test_qmatmul 46/46 on both machines,
+`NOTORCH_REFERENCE_OK` on all three bodies, `NOTORCH_REPEAT_OK`, `JANUS_OK`,
+`RESONANCE_OK`, `NOTORCH_PARITY_OK (6 checks)`, `NOTORCH_CONSUMER_OK (3 checks)`.
+
+Still owed, unchanged: the NEON arms keep the per-32 shape and take none of this.
+Noted in passing and not touched: `nsub` has been unused in the per-token AVX2
+Q4_K arm since before this change.
+
+---
+
 ## 2026-09-13 — attention was the one part of a layer not using the machine
 
 Re-profiling after the three kernel changes moved the target. The FFN's share of

--- a/notorch.c
+++ b/notorch.c
@@ -7028,7 +7028,7 @@ static void nt_q4_k_rows_i8(float *out, const uint8_t *W, const int8_t *qa,
     for (int row = r0; row < r1; row++) {
         const uint8_t *rb = W + (long)row * nb * 144;
         __m256 accv = _mm256_setzero_ps();
-        float accm = 0.0f;
+        __m128 accmv = _mm_setzero_ps();
         for (int blk = 0; blk < nb; blk++) {
             const uint8_t *b = rb + (long)blk * 144;
             float d    = nt_f16_to_f32((uint16_t)(b[0] | (b[1] << 8)));
@@ -7065,6 +7065,7 @@ static void nt_q4_k_rows_i8(float *out, const uint8_t *W, const int8_t *qa,
              * subtractions. */
             uint8_t ls[8], lm[8];
             for (int j = 0; j < 8; j++) nt_get_scale_min_k4(j, sc, &ls[j], &lm[j]);
+            const __m128i mins16 = _mm_cvtepu8_epi16(_mm_loadl_epi64((const __m128i *)lm));
             const __m256i q0 = _mm256_loadu_si256((const __m256i *)(qs));
             const __m256i q1 = _mm256_loadu_si256((const __m256i *)(qs + 32));
             const __m256i q2 = _mm256_loadu_si256((const __m256i *)(qs + 64));
@@ -7086,18 +7087,24 @@ static void nt_q4_k_rows_i8(float *out, const uint8_t *W, const int8_t *qa,
             #undef NT_Q4K_HI
             float dsb = da[blk * 8];          /* one scale for the whole superblock now */
             accv = _mm256_fmadd_ps(_mm256_set1_ps(d * dsb), _mm256_cvtepi32_ps(sumi), accv);
-            int32_t mt = 0;
-            for (int j = 0; j < 8; j++) mt += (int32_t)lm[j] * asum[blk * 8 + j];
-            /* Spelled out, not left to the compiler: it contracts a += b*c into an FMA at
-             * one call site and not at another, and tests/test_qmatmul compares bits. The
-             * comment above nt_q4k_acc has said so for months; writing these two sites
-             * without it turned 72 of 3968 outputs red, identical to six printed digits. */
-            accm = __builtin_fmaf(dmin * dsb, (float)mt, accm);
+            /* The min term in the same domain as the rest. The eight mins are 6-bit and the
+             * eight per-32 activation sums fit int16 by construction (32 values of at most
+             * 127 is 4064), so one madd_epi16 does what eight scalar multiplies and eight
+             * adds did, and the float accumulator stays a vector to the end of the row the
+             * way accv does. No __builtin_fmaf needed here any more: _mm_fmadd_ps IS the
+             * instruction, so the contraction the compiler used to apply at one site and
+             * not the other has nothing left to decide. */
+            __m128i as16 = _mm_packs_epi32(
+                _mm_loadu_si128((const __m128i *)(asum + blk * 8)),
+                _mm_loadu_si128((const __m128i *)(asum + blk * 8 + 4)));
+            accmv = _mm_fmadd_ps(_mm_set1_ps(dmin * dsb),
+                                 _mm_cvtepi32_ps(_mm_madd_epi16(mins16, as16)), accmv);
         }
         {
             __m128 h = _mm_add_ps(_mm256_castps256_ps128(accv), _mm256_extractf128_ps(accv, 1));
             h = _mm_hadd_ps(h, h); h = _mm_hadd_ps(h, h);
-            out[row] = _mm_cvtss_f32(h) - accm;
+            __m128 hm = _mm_hadd_ps(accmv, accmv); hm = _mm_hadd_ps(hm, hm);
+            out[row] = _mm_cvtss_f32(h) - _mm_cvtss_f32(hm);
         }
     }
 }
@@ -7596,8 +7603,8 @@ static void nt_q4_k_rows_i8n(float *out, int m, const uint8_t *W, const int8_t *
         for (int row = r0; row < r1; row++) {
             const uint8_t *rb = W + (long)row * nb * 144;
             __m256 accv[NT_QMM_TILE];
-            float accm[NT_QMM_TILE];
-            for (int j = 0; j < jn; j++) { accv[j] = _mm256_setzero_ps(); accm[j] = 0.0f; }
+            __m128 accmv[NT_QMM_TILE];
+            for (int j = 0; j < jn; j++) { accv[j] = _mm256_setzero_ps(); accmv[j] = _mm_setzero_ps(); }
             for (int blk = 0; blk < nb; blk++) {
                 const uint8_t *b = rb + (long)blk * 144;
                 float d    = nt_f16_to_f32((uint16_t)(b[0] | (b[1] << 8)));
@@ -7621,6 +7628,10 @@ static void nt_q4_k_rows_i8n(float *out, int m, const uint8_t *W, const int8_t *
                     nt_get_scale_min_k4(s, sc, &ls[s], &lm[s]);
                     sv[s] = _mm256_set1_epi16((short)ls[s]);
                 }
+                /* Column-independent, so it is built once per block rather than once per
+                 * block per column — which is the whole reason the min term was worth
+                 * moving. See the per-token arm for what the shape is. */
+                const __m128i mins16 = _mm_cvtepu8_epi16(_mm_loadl_epi64((const __m128i *)lm));
                 /* Named, not indexed, and the loop over the four nibble vectors unrolled.
                  *
                  * As arrays these two lived on the stack: perf annotate showed the hot loop
@@ -7659,16 +7670,20 @@ static void nt_q4_k_rows_i8n(float *out, int m, const uint8_t *W, const int8_t *
                     float dsb = dac[blk * 8];
                     accv[j] = _mm256_fmadd_ps(_mm256_set1_ps(d * dsb),
                                               _mm256_cvtepi32_ps(sumi), accv[j]);
-                    int32_t mt = 0;
-                    for (int s = 0; s < 8; s++) mt += (int32_t)lm[s] * asc[blk * 8 + s];
-                    accm[j] = __builtin_fmaf(dmin * dsb, (float)mt, accm[j]);
+                    __m128i as16 = _mm_packs_epi32(
+                        _mm_loadu_si128((const __m128i *)(asc + blk * 8)),
+                        _mm_loadu_si128((const __m128i *)(asc + blk * 8 + 4)));
+                    accmv[j] = _mm_fmadd_ps(_mm_set1_ps(dmin * dsb),
+                                            _mm_cvtepi32_ps(_mm_madd_epi16(mins16, as16)),
+                                            accmv[j]);
                 }
             }
             for (int j = 0; j < jn; j++) {
                 __m128 h = _mm_add_ps(_mm256_castps256_ps128(accv[j]),
                                       _mm256_extractf128_ps(accv[j], 1));
                 h = _mm_hadd_ps(h, h); h = _mm_hadd_ps(h, h);
-                out[(long)(j0 + j) * m + row] = _mm_cvtss_f32(h) - accm[j];
+                __m128 hm = _mm_hadd_ps(accmv[j], accmv[j]); hm = _mm_hadd_ps(hm, hm);
+                out[(long)(j0 + j) * m + row] = _mm_cvtss_f32(h) - _mm_cvtss_f32(hm);
             }
         }
     }

--- a/tests/bench_qmatmul.c
+++ b/tests/bench_qmatmul.c
@@ -169,9 +169,10 @@ int main(int argc, char **argv) {
     double ghz = argc > 2 ? atof(argv[2]) : 0.0;
 
     /* A feed-forward of the size the 4B bodies carry, against a prefill chunk. */
-    const int m = 4096, dtype = 12;
+    const int dtype = 12;
     int n = argc > 3 ? atoi(argv[3]) : 32;
     int k = argc > 4 ? atoi(argv[4]) : 2048;
+    int m = argc > 5 ? atoi(argv[5]) : 4096;
     uint8_t *W = make_q4_k(m, k, 7u);
     float *X = (float *)malloc(sizeof(float) * (size_t)k * n);
     float *O = (float *)malloc(sizeof(float) * (size_t)m * n);


### PR DESCRIPTION
Both AVX2 Q4_K arms computed the min term as eight scalar multiplies, eight adds and one fmaf per (block, column) to produce one float — a third of the kernel's instructions at nb=56 and a tile of 32. One madd_epi16 replaces them: the mins are 6-bit and the per-32 activation sums fit int16 by construction, and the float accumulator now stays a vector to the end of the row the way accv does. Both arms moved together; tests/test_qmatmul memcmps them and reads 46 of 46.

Kernel on one pinned core, i5-8500T: m=4096 k=14336 n=8 22.0 -> 27.2 GMAC/s, n=32 20.1 -> 25.6; the 30B's expert shapes 24.0 -> 29.6 and 24.9 -> 32.0. Faster at every shape measured, and at n=8 ahead of llama.cpp's 24.9 on the same machine and shape.

Bodies, 61-token prompt, six threads: Qwen3-4B prefill 21.9 -> 23.9, Ministral-3B 27.3 -> 28.7, Qwen3-30B-A3B 13.4 -> 12.7. The MoE regression is real — eight alternating runs in both orders, no overlap — and isolated to the batched arm by a half-and-half build. Instructions -20%, uops -15%, loads -18%, cycles -7%; the only counter that rises is resource_stalls.any, 16.0% -> 19.7% of cycles, and it is neither the store buffer nor memory. Four fixes measured and rejected: thread count, spin budget, chunk granularity, dropping sv[8].

test_reference against llama.cpp on all three bodies: zero diverged, one tie-break crossing in each direction. notorch_test 49/49 and 73/73, NOTORCH_REFERENCE_OK, NOTORCH_REPEAT_OK, JANUS_OK, RESONANCE_OK, NOTORCH_PARITY_OK, NOTORCH_CONSUMER_OK.

tests/bench_qmatmul now takes m, which is how the expert shapes could be measured at all.

Quote: "Optimization hinders evolution." — Alan Perlis, Epigrams on Programming, 1982
Method: the Method ships the counter that fell and the body that slowed in the same commit.

By Arianna Method (Co-authored by Claude, neo) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff