### PR TITLE
harness: rope and silu use the machine; the small chunk was a bench a…

### DIFF
--- a/NOTORCHLOG.md
+++ b/NOTORCHLOG.md
@@ -13,6 +13,86 @@ Newest entries on top.
 
 ---
 
+## 2026-09-13 — rope and silu join the machine, and the chunk that looked right in the bench was wrong in the body
+
+Went and read what Gerganov actually does, which was the right instinct. Two
+things came back. `ggml/src/ggml-cpu/repack.cpp` carries `block_q4_Kx8` and
+`ggml_gemm_q4_K_8x8_q8_K`: eight rows of weights interleaved into one block so a
+single pass produces eight rows against one activation load. That is negative
+result #7 from 09-12 — "two rows through one activation load", which lost by 30%
+— done the way it has to be done. It lost because row-major weights make
+multi-row blocking a strided-load problem; they changed the layout, not the loop.
+Second thing: on this machine it does not matter. `GGML_CPU_REPACK=0` reads
+47.56 t/s against 47.07 with it on, so their prefill here is the plain
+`vec_dot_q4_K_q8_K` path, called per (row, column).
+
+Which made the real comparison possible, thread by thread, Qwen3-4B Q4_K_M,
+61-token prompt:
+
+    threads    llama.cpp    notorch
+      1           9.54        6.2
+      2          18.83       11.1
+      4          36.09       18.8
+      6          47.67       23.7
+    scaling      5.00x       3.82x
+
+Two deficits, and they multiply to 2.01x, which is exactly the measured gap.
+
+### The serial sections, closed
+
+Amdahl on 3.82x gives a serial fraction of 11.4%; the single-threaded sections of
+the profile — rope+kv 147 ms, silu 97 ms, rmsnorm 21, residual 7, of a 2540 ms
+prefill — are 10.7%. Close enough to act on. Both loops are per token and touch
+nothing shared, so both go through `nt_par_for` behind the same work gate
+attention uses.
+
+    rope+kv    147 -> 42 ms    silu    97 -> 36 ms
+
+Qwen3-4B prefill 23.6 -> 24.65, Ministral 28.5 -> 29.5, both alternating runs.
+Decode unchanged at 8.4 and 10.2 — the gate keeps n=1 on one core. The same rope
+fan-out in `arch_olmoe.c` takes Qwen3-30B-A3B from 12.7 to 12.9 and its rope from
+146 to 47 ms. Its silu is left alone deliberately: the grouped path calls it with
+`cnt * FFN` around 3072 elements, 24 us a call, 4608 calls a prefill — six
+`pthread_create`s would cost more than the work.
+
+### And the negative result that matters more than the win
+
+The bench says the column count decides the kernel's rate. Six threads,
+m=4096, three runs, medians:
+
+    k=9728    n=16  148.4    n=32  122.8      1.21x
+    k=14336   n=16  129.1    n=32  113.3      1.14x
+    k=2560    n=16  130.5    n=32  142.7
+
+So a smaller column chunk should be worth a fifth of the FFN. `NT_PREFILL_CHUNK`
+swept end to end says the opposite, monotonically:
+
+    32 -> 25.0 t/s    20 -> 24.3    16 -> 23.0    12 -> 21.5    8 -> 18.0
+
+The bench normalises by MACs and hides what the body pays: 61 tokens in chunks of
+16 is four passes over 2.3 GB of weights instead of two. The rate per MAC went up
+and the weight traffic went up faster. A per-MAC benchmark cannot answer a
+question about a whole pass, and this is the second time this week a bench number
+pointed the wrong way — the first was measuring m=4096 while believing it was
+measuring an expert.
+
+What the bench numbers do say is that the loss is cache blocking on one dimension.
+The pool splits rows only, so a worker holds 42 rows of weights (230 KB) and the
+whole activation slice (304 KB at n=32, k=9728) against 256 KB of L2 per core.
+Blocking both dimensions — a row chunk small enough that its weights stay in L2
+while the columns loop inside it — is the fix, and it is a change to the kernel's
+loop nest rather than a constant. Named, not done.
+
+Where the machine stands after this: pool scaling on a pure matmul is 4.09x of a
+5.56x ceiling (the clock drops 3.44 -> 3.19 GHz from one thread to six), against
+llama.cpp's 5.00x on the whole body.
+
+Gates: notorch_test 49/49 and 73/73, `NOTORCH_REPEAT_OK` on both machines,
+`NOTORCH_REFERENCE_OK` with 0 diverged on all three bodies, `JANUS_OK`,
+`RESONANCE_OK`, `NOTORCH_PARITY_OK (6 checks)`, `NOTORCH_CONSUMER_OK (3 checks)`.
+
+---
+
 ## 2026-09-13 — the Q4_K min term is a vector now: a fifth of every instruction gone, and one body that got slower for it
 
 The two AVX2 Q4_K arms computed the min term as eight scalar multiplies, eight

--- a/harness/arch_llama.c
+++ b/harness/arch_llama.c
@@ -190,6 +190,50 @@ typedef struct {
     float scale;
 } attn_ctx;
 
+typedef struct {
+    float *q_all, *k_new, *v_new;
+    const float *q_norm, *k_norm;
+    kv_cache *kv;
+    int pos0, H, KV, HD, KVD, Q_DIM, neox;
+    long base;
+    float rope_base, eps;
+} rope_ctx;
+
+/* One token per item. Token j writes its own slice of q_all and k_new and its own
+ * slot in the cache, so nothing here is shared. It was 147 ms of a 2540 ms prefill
+ * on one core while the matmuls beside it used six — the same shape of waste the
+ * attention loop had, and the same fix. */
+static void rope_tokens(void *vctx, int j0, int j1) {
+    const rope_ctx *r = (const rope_ctx *)vctx;
+    for (int j = j0; j < j1; j++) {
+        int pos = r->pos0 + j;
+        float *qj = r->q_all + (long)j * r->Q_DIM, *kj = r->k_new + (long)j * r->KVD;
+        for (int h = 0; h < r->H; h++) {
+            if (r->q_norm) rmsnorm(qj + h*r->HD, qj + h*r->HD, r->q_norm, r->HD, r->eps);
+            rope(qj + h*r->HD, pos, r->HD, r->rope_base, r->neox);
+        }
+        for (int h = 0; h < r->KV; h++) {
+            if (r->k_norm) rmsnorm(kj + h*r->HD, kj + h*r->HD, r->k_norm, r->HD, r->eps);
+            rope(kj + h*r->HD, pos, r->HD, r->rope_base, r->neox);
+        }
+        memcpy(r->kv->k + r->base + (long)pos * r->KVD, kj, r->KVD * sizeof(float));
+        memcpy(r->kv->v + r->base + (long)pos * r->KVD,
+               r->v_new + (long)j * r->KVD, r->KVD * sizeof(float));
+    }
+}
+
+typedef struct { float *gate; const float *up; int ffn; } silu_ctx;
+
+/* Per token, not per element: nt_par_for hands out one item at a time, so the item
+ * has to be worth an atomic. A token's row is FFN wide and carries FFN expf calls. */
+static void silu_tokens(void *vctx, int j0, int j1) {
+    const silu_ctx *c = (const silu_ctx *)vctx;
+    for (long i = (long)j0 * c->ffn; i < (long)j1 * c->ffn; i++) {
+        float g = c->gate[i];
+        c->gate[i] = (g / (1.0f + expf(-g))) * c->up[i];
+    }
+}
+
 static void attn_heads(void *vctx, int h0, int h1) {
     const attn_ctx *a = (const attn_ctx *)vctx;
     for (int h = h0; h < h1; h++) {
@@ -282,25 +326,17 @@ static int llama_forward(void *model, kv_cache *kv, const int *tokens, int n,
 
         pft = pf_mark();
         long base = (long)l * kv->max_seq * KVD;
-        for (int j = 0; j < n; j++) {
-            int pos = pos0 + j;
-            float *qj = q_all + (long)j * Q_DIM, *kj = k_new + (long)j * KVD;
+        {
             /* Qwen3 normalises each head of q and k before rotating it, with the
              * model's own epsilon. Before, not after: the rotation mixes lanes
              * within a head, so a norm taken afterwards is a different function.
              * Absent weights mean an older file and the loop is the old loop. */
-            for (int h = 0; h < H; h++) {
-                if (m->layers[l].q_norm)
-                    rmsnorm(qj + h*HD, qj + h*HD, m->layers[l].q_norm, HD, eps);
-                rope(qj + h*HD, pos, HD, m->rope_base, m->rope_neox);
-            }
-            for (int h = 0; h < KV; h++) {
-                if (m->layers[l].k_norm)
-                    rmsnorm(kj + h*HD, kj + h*HD, m->layers[l].k_norm, HD, eps);
-                rope(kj + h*HD, pos, HD, m->rope_base, m->rope_neox);
-            }
-            memcpy(kv->k + base + (long)pos * KVD, kj, KVD * sizeof(float));
-            memcpy(kv->v + base + (long)pos * KVD, v_new + (long)j * KVD, KVD * sizeof(float));
+            rope_ctx rc = { q_all, k_new, v_new,
+                            m->layers[l].q_norm, m->layers[l].k_norm, kv,
+                            pos0, H, KV, HD, KVD, Q_DIM, m->rope_neox, base,
+                            m->rope_base, eps };
+            if ((long)n * (H + KV) * HD >= 65536) nt_par_for(rope_tokens, &rc, n, 2);
+            else                                  rope_tokens(&rc, 0, n);
         }
         pf_add(PF_ROPE, pft);
 
@@ -344,9 +380,10 @@ static int llama_forward(void *model, kv_cache *kv, const int *tokens, int n,
         qmm(ffn_up, &m->layers[l].wup, xn, n);
         pf_add(PF_FFN, pft);
         pft = pf_mark();
-        for (long i = 0; i < (long)n * FFN; i++) {
-            float g = ffn_gate[i];
-            ffn_gate[i] = (g / (1.0f + expf(-g))) * ffn_up[i];
+        {
+            silu_ctx sc = { ffn_gate, ffn_up, FFN };
+            if ((long)n * FFN >= 65536) nt_par_for(silu_tokens, &sc, n, 2);
+            else                        silu_tokens(&sc, 0, n);
         }
         pf_add(PF_SILU, pft);
         pft = pf_mark();

--- a/harness/arch_olmoe.c
+++ b/harness/arch_olmoe.c
@@ -238,6 +238,30 @@ typedef struct {
     float scale;
 } attn_ctx;
 
+typedef struct {
+    float *q_all, *k_new, *v_new;
+    kv_cache *kv;
+    int pos0, H, KV, HD, KVD, Q_DIM;
+    long base;
+    float rope_base;
+} moe_rope_ctx;
+
+/* One token per item, same as arch_llama.c. Simpler here: this arch normalises q and
+ * k as whole vectors before the rotation, so the fanned-out loop is only the rotation
+ * and the two copies into the cache, each token touching its own slice. */
+static void moe_rope_tokens(void *vctx, int j0, int j1) {
+    const moe_rope_ctx *r = (const moe_rope_ctx *)vctx;
+    for (int j = j0; j < j1; j++) {
+        int pos = r->pos0 + j;
+        float *qj = r->q_all + (long)j * r->Q_DIM, *kj = r->k_new + (long)j * r->KVD;
+        for (int h = 0; h < r->H; h++)  rope(qj + h*r->HD, pos, r->HD, r->rope_base, 1);
+        for (int h = 0; h < r->KV; h++) rope(kj + h*r->HD, pos, r->HD, r->rope_base, 1);
+        memcpy(r->kv->k + r->base + (long)pos * r->KVD, kj, r->KVD * sizeof(float));
+        memcpy(r->kv->v + r->base + (long)pos * r->KVD,
+               r->v_new + (long)j * r->KVD, r->KVD * sizeof(float));
+    }
+}
+
 static void attn_heads(void *vctx, int h0, int h1) {
     const attn_ctx *a = (const attn_ctx *)vctx;
     for (int h = h0; h < h1; h++) {
@@ -406,13 +430,11 @@ static int olmoe_forward(void *model, kv_cache *kv, const int *tokens, int n,
 
         pft = pf_mark();
         long base = (long)l * kv->max_seq * KVD;
-        for (int j = 0; j < n; j++) {
-            int pos = pos0 + j;
-            float *qj = q_all + (long)j * Q_DIM, *kj = k_new + (long)j * KVD;
-            for (int h = 0; h < H; h++) rope(qj + h*HD, pos, HD, m->rope_base, 1);
-            for (int h = 0; h < KV; h++) rope(kj + h*HD, pos, HD, m->rope_base, 1);
-            memcpy(kv->k + base + (long)pos * KVD, kj, KVD * sizeof(float));
-            memcpy(kv->v + base + (long)pos * KVD, v_new + (long)j * KVD, KVD * sizeof(float));
+        {
+            moe_rope_ctx rc = { q_all, k_new, v_new, kv,
+                                pos0, H, KV, HD, KVD, Q_DIM, base, m->rope_base };
+            if ((long)n * (H + KV) * HD >= 65536) nt_par_for(moe_rope_tokens, &rc, n, 2);
+            else                                  moe_rope_tokens(&rc, 0, n);
         }
         pf_add(PF_ROPE, pft);
 


### PR DESCRIPTION
…rtifact

Read ggml/src/ggml-cpu/repack.cpp: block_q4_Kx8 interleaves eight weight rows so one pass serves eight rows against one activation load — which is why the 09-12 two-row attempt lost by 30%, it blocked rows in a row-major layout. On this machine it is moot: GGML_CPU_REPACK=0 reads 47.56 t/s against 47.07 with it on, so llama.cpp's prefill here is the plain per-(row,column) vec_dot.

Thread by thread on Qwen3-4B Q4_K_M, 61 tokens: llama.cpp 9.54 / 18.83 / 36.09 / 47.67, notorch 6.2 / 11.1 / 18.8 / 23.7. Scaling 5.00x against 3.82x. Amdahl puts our serial fraction at 11.4%; the single-threaded profile sections are 10.7%.

rope+kv and silu are per token and share nothing, so both go through nt_par_for behind attention's work gate. rope+kv 147 -> 42 ms, silu 97 -> 36 ms. Qwen3-4B prefill 23.6 -> 24.65, Ministral 28.5 -> 29.5, alternating runs; decode unchanged at 8.4 and 10.2 because the gate keeps n=1 on one core. The same rope fan-out in arch_olmoe.c: Qwen3-30B-A3B 12.7 -> 12.9, its rope 146 -> 47 ms. Its silu is left serial on purpose — 3072 elements and 24 us a call, 4608 calls a prefill.

Negative result, and the more useful half: the bench says n=16 beats n=32 by 1.21x at k=9728, so a smaller prefill chunk should pay. Swept end to end it is monotonically worse — 32 -> 25.0 t/s, 20 -> 24.3, 16 -> 23.0, 12 -> 21.5, 8 -> 18.0. A per-MAC rate hides the weight traffic: 61 tokens in chunks of 16 is four passes over 2.3 GB instead of two. What the shape does say is that the pool blocks one dimension only — 42 rows of weights plus a 304 KB activation slice against 256 KB of L2 — and blocking both is a loop-nest change, named not done.

notorch_test 49/49 and 73/73, NOTORCH_REPEAT_OK both machines, NOTORCH_REFERENCE_OK 0 diverged on all three bodies, JANUS_OK, RESONANCE_OK, NOTORCH_PARITY_OK, NOTORCH_CONSUMER_OK.

Quote: "What I cannot create, I do not understand." — Richard Feynman, blackboard at his death, 1988
Method: the Method reads the other implementation before claiming its number is out of reach.

By Arianna Method (Co-authored by Claude, neo) <theariannamethod@gmail.com>, Coordinated with maintainer @iamolegataeff